### PR TITLE
updated setPull help annotation

### DIFF
--- a/libs/microbit/pins.cpp
+++ b/libs/microbit/pins.cpp
@@ -229,7 +229,7 @@ namespace pins {
     * @param name pin to set the pull mode on
     * @param pull one of the mbed pull configurations: PullUp, PullDown, PullNone 
     */
-    //% help=pins/digital-set-pull weight=3
+    //% help=pins/set-pull weight=3
     //% blockId=device_set_pull block="set pull|pin %pin|to %pull"
     void setPull(DigitalPin name, PinPullMode pull) {
         PinMode m = pull == PinPullMode::PullDown 


### PR DESCRIPTION
At some point I'm guessing the help file url has been renamed and its current url is https://codethemicrobit.com/reference/pins/set-pull. This change to the annotation of setPull removes the word "digital" so that the link should work again