### PR TITLE
Fix changeTempo() calculation

### DIFF
--- a/libs/microbit/music.ts
+++ b/libs/microbit/music.ts
@@ -162,6 +162,7 @@ namespace music {
     //% help=music/change-tempo weight=39
     //% blockId=device_change_tempo block="change tempo by (bpm)|%value" blockGap=8
     export function changeTempoBy(bpm: number): void {
+	init();
         setTempo(beatsPerMinute + bpm);
     }
 

--- a/libs/microbit/music.ts
+++ b/libs/microbit/music.ts
@@ -162,7 +162,7 @@ namespace music {
     //% help=music/change-tempo weight=39
     //% blockId=device_change_tempo block="change tempo by (bpm)|%value" blockGap=8
     export function changeTempoBy(bpm: number): void {
-        setTempo(beat(BeatFraction.Whole) + bpm);
+        setTempo(beatsPerMinute + bpm);
     }
 
     /**


### PR DESCRIPTION
Since I am very new to this project, I am afraid that I understand your intention wrongly.

`beat(BeatFraction.Whole)` is a duration of a beat in milliseconds. It seems to be wrong calculation to add the duration with bpm and then pass it to `setTempo()` which takes bpm as an argument.