### PR TITLE
better support for BLE UART and alignment with serial blocks.

### DIFF
--- a/docs/reference/bluetooth.md
+++ b/docs/reference/bluetooth.md
@@ -2,6 +2,14 @@
 
 Support for additional Bluetooth services.
 
+### ~hint
+![](/static/bluetooth/Bluetooth_SIG.png)
+
+For another device like a smartphone to use any of the Bluetooth "services" which the micro:bit has, it must first be [paired with the micro:bit](/reference/bluetooth/bluetooth-pairing). Once paired, the other device may connect to the micro:bit and exchange data relating to many of the micro:bit's features.
+
+### ~
+
+
 ```cards
 bluetooth.startAccelerometerService();
 bluetooth.startButtonService();
@@ -9,20 +17,34 @@ bluetooth.startIOPinService();
 bluetooth.startLEDService();
 bluetooth.startMagnetometerService();
 bluetooth.startTemperatureService();
+bluetooth.onBluetoothConnected(() => {});
+bluetooth.onBluetoothDisconnected(() => {});
+```
+
+## UART 
+
+```cards
+bluetooth.startUartService();
 bluetooth.uartRead("");
-bluetooth.uartWrite("");
-bluetooth.onBluetoothConnected(() => {
-    
-});
-bluetooth.onBluetoothDisconnected(() => {
-    
-});
+bluetooth.uartWriteString("");
+bluetooth.uartWriteNumber(0);
+bluetooth.uartWriteValue("", 0);
 ```
 
 ```package
 microbit-bluetooth
 ```
 
+### Advanced
+ 
+For more advanced information on the micro:bit Bluetooth UART service including information on using a smartphone, see the [Lancaster University micro:bit runtime technical documentation](http://lancaster-university.github.io/microbit-docs/ble/uart-service/)
+
 ### See Also
 
-[startAccelerometerService](/reference/bluetooth/start-accelerometer-service), [startButtonService](/reference/bluetooth/start-button-service), [startIOPinService](/reference/bluetooth/start-io-pin-service), [startLEDService](/reference/bluetooth/start-led-service), [startMagnetometerService](/reference/bluetooth/start-magnetometer-service), [startTemperatureService](/reference/bluetooth/start-temperature-service), [uartRead](/reference/bluetooth/uart-read), [uartWrite](/reference/bluetooth/uart-write), [onBluetoothConnected](/reference/bluetooth/on-bluetooth-connected), [onBluetoothDisconnected](/reference/bluetooth/on-bluetooth-disconnected)
+[startAccelerometerService](/reference/bluetooth/start-accelerometer-service), [startButtonService](/reference/bluetooth/start-button-service), [startIOPinService](/reference/bluetooth/start-io-pin-service), [startLEDService](/reference/bluetooth/start-led-service), [startMagnetometerService](/reference/bluetooth/start-magnetometer-service), [startTemperatureService](/reference/bluetooth/start-temperature-service), 
+[startUartService](/reference/bluetooth/start-uart-service),
+[uartRead](/reference/bluetooth/uart-read), 
+[uartWriteString](/reference/bluetooth/uart-write-string), 
+[uartWriteNumber](/reference/bluetooth/uart-write-number), 
+[uartWriteValue](/reference/bluetooth/uart-write-value), 
+[onBluetoothConnected](/reference/bluetooth/on-bluetooth-connected), [onBluetoothDisconnected](/reference/bluetooth/on-bluetooth-disconnected)

--- a/docs/reference/bluetooth.md
+++ b/docs/reference/bluetooth.md
@@ -25,7 +25,7 @@ bluetooth.onBluetoothDisconnected(() => {});
 
 ```cards
 bluetooth.startUartService();
-bluetooth.uartRead("");
+bluetooth.uartReadUntil("");
 bluetooth.uartWriteString("");
 bluetooth.uartWriteNumber(0);
 bluetooth.uartWriteValue("", 0);
@@ -43,7 +43,7 @@ For more advanced information on the micro:bit Bluetooth UART service including 
 
 [startAccelerometerService](/reference/bluetooth/start-accelerometer-service), [startButtonService](/reference/bluetooth/start-button-service), [startIOPinService](/reference/bluetooth/start-io-pin-service), [startLEDService](/reference/bluetooth/start-led-service), [startMagnetometerService](/reference/bluetooth/start-magnetometer-service), [startTemperatureService](/reference/bluetooth/start-temperature-service), 
 [startUartService](/reference/bluetooth/start-uart-service),
-[uartRead](/reference/bluetooth/uart-read), 
+[uartReadUntil](/reference/bluetooth/uart-read-until), 
 [uartWriteString](/reference/bluetooth/uart-write-string), 
 [uartWriteNumber](/reference/bluetooth/uart-write-number), 
 [uartWriteValue](/reference/bluetooth/uart-write-value), 

--- a/docs/reference/bluetooth/uart-read-until.md
+++ b/docs/reference/bluetooth/uart-read-until.md
@@ -12,7 +12,7 @@ The [Bluetooth UART service](start-uart-service.md) allows another device such a
 With the Bluetooth UART service running, this block allows a micro:bit to read data which has been received from a Bluetooth connected device, terminating reading and returning the value obtained as soon as a specified delimiter character is encountered. This means that connected devices can send data to the micro:bit and indicate that the complete message has been sent by appending the message with the delimiter character.
 
 ```sig
-bluetooth.uartRead("");
+bluetooth.uartReadUntil("");
 ```
 
 ### Example: Starting the Bluetooth UART service and then reading data received from another device which is terminated by ":" character and then displaying it
@@ -25,7 +25,7 @@ bluetooth.onBluetoothConnected(() => {
     basic.showString("C");
     connected = 1;
     while (connected == 1) {
-        uartData = bluetooth.uartRead(":");
+        uartData = bluetooth.uartReadUntil(":");
         basic.showString(uartData);
     }
 });

--- a/docs/reference/bluetooth/uart-write-number.md
+++ b/docs/reference/bluetooth/uart-write-number.md
@@ -1,4 +1,4 @@
-# UART Write 
+# UART Write Number
 
 ### ~hint
 ![](/static/bluetooth/Bluetooth_SIG.png)
@@ -7,36 +7,13 @@ For another device like a smartphone to use any of the Bluetooth "services" whic
 
 ### ~
 
-The [Bluetooth UART service](start-uart-service.md) allows another device such as a smartphone to exchange any data it wants to with the micro:bit, in small chunks. 
+The [Bluetooth UART service](/reference/bluetooth/start-uart-service.md) allows another device such as a smartphone to exchange any data it wants to with the micro:bit, in small chunks. 
 
 With the Bluetooth UART service running, this block allows a micro:bit to send data to a Bluetooth connected device.
 
 ```sig
-bluetooth.uartWrite("");
+bluetooth.uartWriteNumber(42);
 ```
-
-### Example: Starting the Bluetooth UART service and then sending "HELLO" whenever button A is pressed and another device has connected over Bluetooth
-
-```blocks
-let connected = 0;
-bluetooth.onBluetoothConnected(() => {
-    basic.showString("C");
-    connected = 1;
-});
-bluetooth.onBluetoothDisconnected(() => {
-    basic.showString("D");
-    connected = 0;
-});
-input.onButtonPressed(Button.A, () => {
-    if (connected == 1) {
-        bluetooth.uartWrite("HELLO");
-    }
-});
-```
-
-### Video - UART service guessing game
-
-https://www.youtube.com/watch?v=PgGeWddMAZ0
 
 ### Advanced
  

--- a/docs/reference/bluetooth/uart-write-string.md
+++ b/docs/reference/bluetooth/uart-write-string.md
@@ -1,0 +1,51 @@
+# UART Write Number
+
+### ~hint
+![](/static/bluetooth/Bluetooth_SIG.png)
+
+For another device like a smartphone to use any of the Bluetooth "services" which the micro:bit has, it must first be [paired with the micro:bit](/reference/bluetooth/bluetooth-pairing). Once paired, the other device may connect to the micro:bit and exchange data relating to many of the micro:bit's features.
+
+### ~
+
+The [Bluetooth UART service](/reference/bluetooth/start-uart-service.md) allows another device such as a smartphone to exchange any data it wants to with the micro:bit, in small chunks. 
+
+With the Bluetooth UART service running, this block allows a micro:bit to send data to a Bluetooth connected device.
+
+```sig
+bluetooth.uartWriteString("");
+```
+
+### Example: Starting the Bluetooth UART service and then sending "HELLO" whenever button A is pressed and another device has connected over Bluetooth
+
+```blocks
+let connected = 0;
+bluetooth.onBluetoothConnected(() => {
+    basic.showString("C");
+    connected = 1;
+});
+bluetooth.onBluetoothDisconnected(() => {
+    basic.showString("D");
+    connected = 0;
+});
+input.onButtonPressed(Button.A, () => {
+    if (connected == 1) {
+        bluetooth.uartWriteString("HELLO");
+    }
+});
+```
+
+### Video - UART service guessing game
+
+https://www.youtube.com/watch?v=PgGeWddMAZ0
+
+### Advanced
+ 
+For more advanced information on the micro:bit Bluetooth UART service including information on using a smartphone, see the [Lancaster University micro:bit runtime technical documentation](http://lancaster-university.github.io/microbit-docs/ble/uart-service/)
+
+### See also
+
+[About Bluetooth](/reference/bluetooth/about-bluetooth), [micro:bit Bluetooth profile overview ](http://lancaster-university.github.io/microbit-docs/ble/profile/), [micro:bit Bluetooth profile reference](http://lancaster-university.github.io/microbit-docs/resources/bluetooth/microbit-profile-V1.9-Level-2.pdf),  [Bluetooth on micro:bit resources](http://bluetooth-mdw.blogspot.co.uk/p/bbc-microbit.html), [Bluetooth SIG](https://www.bluetooth.com)
+
+```package
+microbit-bluetooth
+```

--- a/docs/reference/bluetooth/uart-write-value.md
+++ b/docs/reference/bluetooth/uart-write-value.md
@@ -1,0 +1,28 @@
+# UART Write Value
+
+### ~hint
+![](/static/bluetooth/Bluetooth_SIG.png)
+
+For another device like a smartphone to use any of the Bluetooth "services" which the micro:bit has, it must first be [paired with the micro:bit](/reference/bluetooth/bluetooth-pairing). Once paired, the other device may connect to the micro:bit and exchange data relating to many of the micro:bit's features.
+
+### ~
+
+The [Bluetooth UART service](/reference/bluetooth/start-uart-service.md) allows another device such as a smartphone to exchange any data it wants to with the micro:bit, in small chunks. 
+
+With the Bluetooth UART service running, this block allows a micro:bit to send data to a Bluetooth connected device.
+
+```sig
+bluetooth.uartWriteValue("x", 42);
+```
+
+### Advanced
+ 
+For more advanced information on the micro:bit Bluetooth UART service including information on using a smartphone, see the [Lancaster University micro:bit runtime technical documentation](http://lancaster-university.github.io/microbit-docs/ble/uart-service/)
+
+### See also
+
+[About Bluetooth](/reference/bluetooth/about-bluetooth), [micro:bit Bluetooth profile overview ](http://lancaster-university.github.io/microbit-docs/ble/profile/), [micro:bit Bluetooth profile reference](http://lancaster-university.github.io/microbit-docs/resources/bluetooth/microbit-profile-V1.9-Level-2.pdf),  [Bluetooth on micro:bit resources](http://bluetooth-mdw.blogspot.co.uk/p/bbc-microbit.html), [Bluetooth SIG](https://www.bluetooth.com)
+
+```package
+microbit-bluetooth
+```

--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -4,22 +4,6 @@
 
 using namespace pxt;
 
-enum Delimiters {
-    //% block="new line"
-    NewLine = 1,
-    //% block=","
-    Comma = 2,
-    //% block="$"
-    Dollar = 3,
-    //% block=":"
-    Colon = 4,
-    //% block="."
-    Fullstop = 5,
-    //% block="#"
-    Hash = 6,
-};
-
-
 /**
  * Support for additional Bluetooth services.
  */
@@ -27,12 +11,33 @@ enum Delimiters {
 namespace bluetooth {
     MicroBitUARTService *uart = NULL;
 
+
+    /**
+    *  Starts the Bluetooth accelerometer service
+    */
+    //% help=bluetooth/start-accelerometer-service
+    //% blockId=bluetooth_start_accelerometer_service block="bluetooth accelerometer service"
+    //% parts="bluetooth" weight=90 blockGap=8
+    void startAccelerometerService() {
+        new MicroBitAccelerometerService(*uBit.ble, uBit.accelerometer);        
+    }   
+
+    /**
+    *  Starts the Bluetooth button service
+    */
+    //% help=bluetooth/start-button-service
+    //% blockId=bluetooth_start_button_service block="bluetooth button service" blockGap=8
+    //% parts="bluetooth" weight=89
+    void startButtonService() {
+        new MicroBitButtonService(*uBit.ble);      
+    }
+
     /**
     *  Starts the Bluetooth IO pin service.
     */
     //% help=bluetooth/start-io-pin-service
     //% blockId=bluetooth_start_io_pin_service block="bluetooth io pin service" blockGap=8
-    //% parts="bluetooth"
+    //% parts="bluetooth" weight=88
     void startIOPinService() {
         new MicroBitIOPinService(*uBit.ble, uBit.io);
     }
@@ -42,7 +47,7 @@ namespace bluetooth {
     */
     //% help=bluetooth/start-led-service
     //% blockId=bluetooth_start_led_service block="bluetooth led service" blockGap=8
-    //% parts="bluetooth"
+    //% parts="bluetooth" weight=87
     void startLEDService() {
         new MicroBitLEDService(*uBit.ble, uBit.display);
     }
@@ -52,7 +57,7 @@ namespace bluetooth {
     */
     //% help=bluetooth/start-temperature-service
     //% blockId=bluetooth_start_temperature_service block="bluetooth temperature service" blockGap=8
-    //% parts="bluetooth"
+    //% parts="bluetooth" weight=86
     void startTemperatureService() {    
         new MicroBitTemperatureService(*uBit.ble, uBit.thermometer);        
     }
@@ -61,38 +66,19 @@ namespace bluetooth {
     *  Starts the Bluetooth magnetometer service
     */
     //% help=bluetooth/start-magnetometer-service
-    //% blockId=bluetooth_start_magnetometer_service block="bluetooth magnetometer service" blockGap=8
-    //% parts="bluetooth"
+    //% blockId=bluetooth_start_magnetometer_service block="bluetooth magnetometer service"
+    //% parts="bluetooth" weight=85
     void startMagnetometerService() {    
         new MicroBitMagnetometerService(*uBit.ble, uBit.compass); 
     }
 
-    /**
-    *  Starts the Bluetooth accelerometer service
-    */
-    //% help=bluetooth/start-accelerometer-service
-    //% blockId=bluetooth_start_accelerometer_service block="bluetooth accelerometer service" blockGap=8
-    //% parts="bluetooth"
-    void startAccelerometerService() {
-        new MicroBitAccelerometerService(*uBit.ble, uBit.accelerometer);        
-    }
-
-    /**
-    *  Starts the Bluetooth button service
-    */
-    //% help=bluetooth/start-button-service
-    //% blockId=bluetooth_start_button_service block="bluetooth button service" blockGap=8
-    //% parts="bluetooth"
-    void startButtonService() {
-        new MicroBitButtonService(*uBit.ble);      
-    }
 
     /**
     *  Starts the Bluetooth UART service
     */
     //% help=bluetooth/start-uart-service
-    //% blockId=bluetooth_start_uart_service block="bluetooth uart service" blockGap=8
-    //% parts="bluetooth"
+    //% blockId=bluetooth_start_uart_service block="bluetooth uart service"
+    //% parts="bluetooth" advanced=true
     void startUartService() {
         if (uart) return;
         // 61 octet buffer size is 3 x (MTU - 3) + 1
@@ -108,7 +94,7 @@ namespace bluetooth {
     }    
 
     //%
-    StringData* uartRead(StringData *del) {
+    StringData* uartReadUntil(StringData *del) {
         startUartService();
         return uart->readUntil(ManagedString(del)).leakData();
     }    

--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -102,7 +102,7 @@ namespace bluetooth {
     }
     
     //%
-    void uartWrite(StringData *data) {
+    void uartWriteString(StringData *data) {
         startUartService();
     	uart->send(ManagedString(data));
     }    
@@ -133,7 +133,5 @@ namespace bluetooth {
     //% parts="bluetooth"
     void onBluetoothDisconnected(Action body) {
         registerWithDal(MICROBIT_ID_BLE, MICROBIT_BLE_EVT_DISCONNECTED, body);
-    }    
-  
-  
+    }  
 }

--- a/libs/bluetooth/bluetooth.ts
+++ b/libs/bluetooth/bluetooth.ts
@@ -1,30 +1,14 @@
+/**
+ * Support for additional Bluetooth services.
+ */
+//% color=#0082FB weight=20
 namespace bluetooth {
-    /**
-     * Returns the delimiter corresponding string
-     */
-    //% blockId="bluetooth_uart_delimiter_conv" block="%del"
-    //% weight=1 parts="bluetooth"
-    export function delimiters(del: Delimiters): string {
-        // even though it might not look like, this is more
-        // (memory) efficient than the C++ implementation, because the
-        // strings are statically allocated and take no RAM 
-        switch (del) {
-            case Delimiters.NewLine: return "\n"
-            case Delimiters.Comma: return ","
-            case Delimiters.Dollar: return "$"
-            case Delimiters.Colon: return ":"
-            case Delimiters.Fullstop: return "."
-            case Delimiters.Hash: return "#"
-            default: return "\n"
-        }
-    }
-
     /**
     *  Writes to the Bluetooth UART service buffer. From there the data is transmitted over Bluetooth to a connected device.
     */
-    //% help=bluetooth/uart-write
-    //% blockId=bluetooth_uart_write block="bluetooth uart|write %data" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::uartWriteString
+    //% help=bluetooth/uart-write weight=80
+    //% blockId=bluetooth_uart_write block="bluetooth uart|write string %data" blockGap=8
+    //% parts="bluetooth" shim=bluetooth::uartWriteString advanced=true
     export function uartWriteString(data: string): void {
         // dummy implementation for simulator
         console.log("UART Write: " + data)
@@ -33,8 +17,8 @@ namespace bluetooth {
     /**
      * Prints a numeric value to the serial
      */
-    //% help=serial/write-number
-    //% weight=89 blockGap=8
+    //% help=serial/write-number weight=79
+    //% weight=89 blockGap=8 advanced=true
     //% blockId=bluetooth_uart_writenumber block="bluetooth uart|write number %value"
     export function uartWriteNumber(value: number): void {
         uartWriteString(value.toString());
@@ -45,8 +29,8 @@ namespace bluetooth {
      * @param name name of the value stream, eg: x
      * @param value to write
      */
-    //% weight=88 blockGap=8
-    //% help=bluetooth/uart-write-value
+    //% weight=88 weight=78
+    //% help=bluetooth/uart-write-value advanced=true
     //% blockId=bluetooth_uart_writevalue block="bluetooth uart|write value %name|= %value"
     export function uartWriteValue(name: string, value: number): void {
         uartWriteString(name + ":" + value + "\r\n");
@@ -55,10 +39,10 @@ namespace bluetooth {
     /**
      *  Reads from the Bluetooth UART service buffer, returning its contents when the specified delimiter character is encountered.
      */
-    //% help=bluetooth/uart-read
-    //% blockId=bluetooth_uart_read block="bluetooth uart read %del=bluetooth_uart_delimiter_conv" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::uartRead
-    export function uartRead(del: string): string {
+    //% help=bluetooth/uart-read-until weight=75
+    //% blockId=bluetooth_uart_read block="bluetooth uart|read until %del=serial_delimiter_conv"
+    //% parts="bluetooth" shim=bluetooth::uartReadUntil advanced=true
+    export function uartReadUntil(del: string): string {
         // dummy implementation for simulator
         return "???"
     }

--- a/libs/bluetooth/bluetooth.ts
+++ b/libs/bluetooth/bluetooth.ts
@@ -23,11 +23,33 @@ namespace bluetooth {
     *  Writes to the Bluetooth UART service buffer. From there the data is transmitted over Bluetooth to a connected device.
     */
     //% help=bluetooth/uart-write
-    //% blockId=bluetooth_uart_write block="bluetooth uart write %data" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::uartWrite
-    export function uartWrite(data: string): void {
+    //% blockId=bluetooth_uart_write block="bluetooth uart|write %data" blockGap=8
+    //% parts="bluetooth" shim=bluetooth::uartWriteString
+    export function uartWriteString(data: string): void {
         // dummy implementation for simulator
         console.log("UART Write: " + data)
+    }
+
+    /**
+     * Prints a numeric value to the serial
+     */
+    //% help=serial/write-number
+    //% weight=89 blockGap=8
+    //% blockId=bluetooth_uart_writenumber block="bluetooth uart|write number %value"
+    export function uartWriteNumber(value: number): void {
+        uartWriteString(value.toString());
+    }
+
+    /**
+     * Writes a ``name: value`` pair line to the serial.
+     * @param name name of the value stream, eg: x
+     * @param value to write
+     */
+    //% weight=88 blockGap=8
+    //% help=bluetooth/uart-write-value
+    //% blockId=bluetooth_uart_writevalue block="bluetooth uart|write value %name|= %value"
+    export function uartWriteValue(name: string, value: number): void {
+        uartWriteString(name + ":" + value + "\r\n");
     }
 
     /**

--- a/libs/bluetooth/enums.d.ts
+++ b/libs/bluetooth/enums.d.ts
@@ -1,20 +1,4 @@
 // Auto-generated. Do not edit.
-
-
-    declare enum Delimiters {
-    //% block="new line"
-    NewLine = 1,
-    //% block=","
-    Comma = 2,
-    //% block="$"
-    Dollar = 3,
-    //% block=":"
-    Colon = 4,
-    //% block="."
-    Fullstop = 5,
-    //% block="#"
-    Hash = 6,
-    }
 declare namespace bluetooth {
 }
 

--- a/libs/bluetooth/shims.d.ts
+++ b/libs/bluetooth/shims.d.ts
@@ -8,43 +8,11 @@
 declare namespace bluetooth {
 
     /**
-     *  Starts the Bluetooth IO pin service.
-     */
-    //% help=bluetooth/start-io-pin-service
-    //% blockId=bluetooth_start_io_pin_service block="bluetooth io pin service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startIOPinService
-    function startIOPinService(): void;
-
-    /**
-     *  Starts the Bluetooth LED service
-     */
-    //% help=bluetooth/start-led-service
-    //% blockId=bluetooth_start_led_service block="bluetooth led service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startLEDService
-    function startLEDService(): void;
-
-    /**
-     *  Starts the Bluetooth temperature service
-     */
-    //% help=bluetooth/start-temperature-service
-    //% blockId=bluetooth_start_temperature_service block="bluetooth temperature service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startTemperatureService
-    function startTemperatureService(): void;
-
-    /**
-     *  Starts the Bluetooth magnetometer service
-     */
-    //% help=bluetooth/start-magnetometer-service
-    //% blockId=bluetooth_start_magnetometer_service block="bluetooth magnetometer service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startMagnetometerService
-    function startMagnetometerService(): void;
-
-    /**
      *  Starts the Bluetooth accelerometer service
      */
     //% help=bluetooth/start-accelerometer-service
-    //% blockId=bluetooth_start_accelerometer_service block="bluetooth accelerometer service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startAccelerometerService
+    //% blockId=bluetooth_start_accelerometer_service block="bluetooth accelerometer service"
+    //% parts="bluetooth" weight=90 blockGap=8 shim=bluetooth::startAccelerometerService
     function startAccelerometerService(): void;
 
     /**
@@ -52,15 +20,47 @@ declare namespace bluetooth {
      */
     //% help=bluetooth/start-button-service
     //% blockId=bluetooth_start_button_service block="bluetooth button service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startButtonService
+    //% parts="bluetooth" weight=89 shim=bluetooth::startButtonService
     function startButtonService(): void;
+
+    /**
+     *  Starts the Bluetooth IO pin service.
+     */
+    //% help=bluetooth/start-io-pin-service
+    //% blockId=bluetooth_start_io_pin_service block="bluetooth io pin service" blockGap=8
+    //% parts="bluetooth" weight=88 shim=bluetooth::startIOPinService
+    function startIOPinService(): void;
+
+    /**
+     *  Starts the Bluetooth LED service
+     */
+    //% help=bluetooth/start-led-service
+    //% blockId=bluetooth_start_led_service block="bluetooth led service" blockGap=8
+    //% parts="bluetooth" weight=87 shim=bluetooth::startLEDService
+    function startLEDService(): void;
+
+    /**
+     *  Starts the Bluetooth temperature service
+     */
+    //% help=bluetooth/start-temperature-service
+    //% blockId=bluetooth_start_temperature_service block="bluetooth temperature service" blockGap=8
+    //% parts="bluetooth" weight=86 shim=bluetooth::startTemperatureService
+    function startTemperatureService(): void;
+
+    /**
+     *  Starts the Bluetooth magnetometer service
+     */
+    //% help=bluetooth/start-magnetometer-service
+    //% blockId=bluetooth_start_magnetometer_service block="bluetooth magnetometer service"
+    //% parts="bluetooth" weight=85 shim=bluetooth::startMagnetometerService
+    function startMagnetometerService(): void;
 
     /**
      *  Starts the Bluetooth UART service
      */
     //% help=bluetooth/start-uart-service
-    //% blockId=bluetooth_start_uart_service block="bluetooth uart service" blockGap=8
-    //% parts="bluetooth" shim=bluetooth::startUartService
+    //% blockId=bluetooth_start_uart_service block="bluetooth uart service"
+    //% parts="bluetooth" advanced=true shim=bluetooth::startUartService
     function startUartService(): void;
 
     /**

--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -309,6 +309,22 @@ declare namespace led {
     //% block=9600
     BaudRate9600 = 9600,
     }
+
+
+    declare enum Delimiters {
+    //% block="new line"
+    NewLine = 1,
+    //% block=","
+    Comma = 2,
+    //% block="$"
+    Dollar = 3,
+    //% block=":"
+    Colon = 4,
+    //% block="."
+    Fullstop = 5,
+    //% block="#"
+    Hash = 6,
+    }
 declare namespace serial {
 }
 

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -1,6 +1,6 @@
 #include "ksbit.h"
 
-enum class SerialPin {
+enum SerialPin {
     P0 = MICROBIT_ID_IO_P0,
     P1 = MICROBIT_ID_IO_P1,
     P2 = MICROBIT_ID_IO_P2,
@@ -12,11 +12,26 @@ enum class SerialPin {
     P16 = MICROBIT_ID_IO_P16
 };
 
-enum class BaudRate {
+enum BaudRate {
   //% block=115200
   BaudRate115200 = 115200,
   //% block=9600
   BaudRate9600 = 9600
+};
+
+enum Delimiters {
+    //% block="new line"
+    NewLine = 1,
+    //% block=","
+    Comma = 2,
+    //% block="$"
+    Dollar = 3,
+    //% block=":"
+    Colon = 4,
+    //% block="."
+    Fullstop = 5,
+    //% block="#"
+    Hash = 6,
 };
 
 //% weight=2 color=30
@@ -25,23 +40,24 @@ namespace serial {
     // note that at least one // followed by % is needed per declaration!
 
     /**
-     * Reads a line of text from the serial port.
+     * Reads a line of text from the serial port and returns the buffer when the delimiter is met.
+     * @param delimiter text delimiter that separates each text chunk
      */
-    //% help=serial/read-line
-    //% blockId=serial_read_line block="serial read line"
-    //% weight=20
-    StringData* readLine() {
-      return uBit.serial.readUntil(ManagedString("\n")).leakData();
+    //% help=serial/read-until
+    //% blockId=serial_read_until block="serial|read until %delimiter=serial_delimiter_conv"
+    //% weight=19
+    StringData* readUntil(StringData* delimiter) {
+      return uBit.serial.readUntil(ManagedString(delimiter)).leakData();
     }
 
     /**
-     * Sends a piece of text through Serial connection.
+     * Reads a line of text from the serial port.
      */
-    //% help=serial/write-string
-    //% weight=87
-    //% blockId=serial_writestring block="serial write string %text"
-    void writeString(StringData *text) {
-      uBit.serial.send(ManagedString(text));
+    //% help=serial/read-line
+    //% blockId=serial_read_line block="serial|read line"
+    //% weight=20 blockGap=8
+    StringData* readLine() {
+      return readUntil(ManagedString("\n").leakData());
     }
 
     /**
@@ -49,10 +65,20 @@ namespace serial {
     * @param delimiters the characters to match received characters against. eg:"\n"
     */
     // help=serial/on-data-received
-    // weight=19
+    // weight=18
     void onDataReceived(StringData* delimiters, Action body) {
       uBit.serial.eventOn(ManagedString(delimiters));
       registerWithDal(MICROBIT_ID_SERIAL, MICROBIT_SERIAL_EVT_DELIM_MATCH, body);
+    }
+
+    /**
+     * Sends a piece of text through Serial connection.
+     */
+    //% help=serial/write-string
+    //% weight=87
+    //% blockId=serial_writestring block="serial|write string %text"
+    void writeString(StringData *text) {
+      uBit.serial.send(ManagedString(text));
     }
 
     /**
@@ -63,7 +89,7 @@ namespace serial {
     */
     //% weight=10
     //% help=serial/redirect-to
-    //% blockId=serial_redirect block="serial redirect to|TX %tx|RX %rx|at baud rate %rate"
+    //% blockId=serial_redirect block="serial|redirect to|TX %tx|RX %rx|at baud rate %rate"
     //% blockExternalInputs=1
     void redirect(SerialPin tx, SerialPin rx, BaudRate rate) {
       uBit.serial.redirect((PinName)tx, (PinName)rx);

--- a/libs/core/serial.ts
+++ b/libs/core/serial.ts
@@ -46,4 +46,24 @@ namespace serial {
     export function onLineReceived(body: Action): void {
        // serial.onDataReceived("\n", body);
     }
+
+    /**
+     * Returns the delimiter corresponding string
+     */
+    //% blockId="serial_delimiter_conv" block="%del"
+    //% weight=1
+    export function delimiters(del: Delimiters): string {
+        // even though it might not look like, this is more
+        // (memory) efficient than the C++ implementation, because the
+        // strings are statically allocated and take no RAM 
+        switch (del) {
+            case Delimiters.NewLine: return "\n"
+            case Delimiters.Comma: return ","
+            case Delimiters.Dollar: return "$"
+            case Delimiters.Colon: return ":"
+            case Delimiters.Fullstop: return "."
+            case Delimiters.Hash: return "#"
+            default: return "\n"
+        }
+    }
 }

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -649,11 +649,20 @@ declare namespace pins {
 declare namespace serial {
 
     /**
+     * Reads a line of text from the serial port and returns the buffer when the delimiter is met.
+     * @param delimiter text delimiter that separates each text chunk
+     */
+    //% help=serial/read-until
+    //% blockId=serial_read_until block="serial|read until %delimiter=serial_delimiter_conv"
+    //% weight=19 shim=serial::readUntil
+    function readUntil(delimiter: string): string;
+
+    /**
      * Reads a line of text from the serial port.
      */
     //% help=serial/read-line
-    //% blockId=serial_read_line block="serial read line"
-    //% weight=20 shim=serial::readLine
+    //% blockId=serial_read_line block="serial|read line"
+    //% weight=20 blockGap=8 shim=serial::readLine
     function readLine(): string;
 
     /**
@@ -661,7 +670,7 @@ declare namespace serial {
      */
     //% help=serial/write-string
     //% weight=87
-    //% blockId=serial_writestring block="serial write string %text" shim=serial::writeString
+    //% blockId=serial_writestring block="serial|write string %text" shim=serial::writeString
     function writeString(text: string): void;
 
     /**
@@ -672,7 +681,7 @@ declare namespace serial {
      */
     //% weight=10
     //% help=serial/redirect-to
-    //% blockId=serial_redirect block="serial redirect to|TX %tx|RX %rx|at baud rate %rate"
+    //% blockId=serial_redirect block="serial|redirect to|TX %tx|RX %rx|at baud rate %rate"
     //% blockExternalInputs=1 shim=serial::redirect
     function redirect(tx: SerialPin, rx: SerialPin, rate: BaudRate): void;
 }

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -84,6 +84,13 @@
                     "microbit-pins": "",
                     "microbit-serial": ""
                 }
+            }, 
+            {
+                "type": "api",
+                "map": {
+                    "bluetooth\\.uartRead\\((.*?)\\)" : "bluetooth.uartReadUntil($1)",
+                    "bluetooth\\.uartWrite\\((.*?)\\)" : "bluetooth.uartWriteUntil($1)"
+                }
             }
         ]
     },

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -168,7 +168,7 @@ namespace pxsim.bluetooth {
     export function uartWrite(s : string): void {
         // TODO
     }
-    export function uartRead(): string {
+    export function uartReadUntil(del: string): string {
         // TODO
         return ""
     }


### PR DESCRIPTION
Aligning serial apis with bluetooth UART. https://github.com/Microsoft/pxt-microbit/issues/274

- [x] added serial.readUntil to allow specifying separator
- [x] serial.writeNumber => bluetooth.uartWriteNumber
- [x] serial.writeString => bluetooth.uartWriteString
- [x] serial.writeValue => bluetooth.uart.WriteValue
- [x] remove bluetooth.uartRead replaced by bluetooth.uartReadUntil, auto-upgrade project
- [x] remove bluetooth.uartWrite replace by bluetooth.uartWriteUntil, auto-update project
- [x] moving UART into advanced section
