### PR TITLE
Support for offline hex cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ clients/win10/*.opendb
 clients/**/bin/**
 clients/**/obj/**
 clients/electron/projects
+hexcache
 
 *.user
 *.sw?

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "sim/public",
     "docs/*.md",
     "docs/*/*.md",
-    "docs/*/*/*.md"
+    "docs/*/*/*.md",
+    "hexcache/*.hex"
   ],
   "devDependencies": {
     "typescript": "^1.8.7"


### PR DESCRIPTION
`pxt-microbit` NPM package now bundles the offline hex cache