### PR TITLE
Deprecating old radio APIs and fixing docs

### DIFF
--- a/docs/lessons/charting.md
+++ b/docs/lessons/charting.md
@@ -7,9 +7,9 @@ Create a charting app for simulating and measuring the acceleration applied to t
 Acceleration
 
 ## Quick Links
-* [activity](/lessons/charting/activity) 
-* [challenge](/lessons/charting/challenge) 
-* [quiz](/lessons/charting/quiz) 
+* [activity](/lessons/charting/activity)
+* [challenge](/lessons/charting/challenge)
+* [quiz](/lessons/charting/quiz)
 * [answers](/lessons/charting/quiz-answers)
 
 ## Prior learning/place of lesson in scheme of work
@@ -22,9 +22,8 @@ Learn the functions of **on data received**, **send number** and **receive numbe
 input.acceleration(Dimension.X)
 led.plotBarGraph(0, 1023)
 basic.showNumber(0)
-radio.onDataReceived(() => {})
+radio.onDataPacketReceived(() => {})
 radio.sendNumber(0)
-radio.receiveNumber()
 ```
 
 ## Objectives

--- a/docs/lessons/charting/challenge.md
+++ b/docs/lessons/charting/challenge.md
@@ -1,8 +1,8 @@
-# Challenge 
+# Challenge
 
-### ~avatar avatar 
+### ~avatar avatar
 
-Welcome! The activity will teach you how to use the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit. 
+Welcome! The activity will teach you how to use the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit.
 Let's get started!
 
 ### ~
@@ -28,8 +28,8 @@ We want to register code to run when a packet is received over radio. We can imp
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X))
 })
-radio.onDataReceived(() => {
-    
+radio.onDataPacketReceived(() => {
+
 })
 ```
 ### ~
@@ -39,26 +39,26 @@ Finally, we want to chart the acceleration. So we must first implement `plot bar
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X))
 })
-radio.onDataReceived(() => {
-    led.plotBarGraph(radio.receiveNumber(), 1023)
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    led.plotBarGraph(receivedNumber, 1023)
 })
 
 ```
 ### ~
-Notice that moving the micro:bit the farthest direction in the x direction will be -1023 on the charting beneath the simulator. The second observation will be that the LEDs will be full brightness on the 2nd micro:bit. There is a single LED turned on with the 1st micro:bit. Additionally, the graphs will reflect 0 acceleation for the 1st micro:bit. In this scenario, if you are adjusting the acceleration in the simualator, you are also changing your chart that will be produced.  
+Notice that moving the micro:bit the farthest direction in the x direction will be -1023 on the charting beneath the simulator. The second observation will be that the LEDs will be full brightness on the 2nd micro:bit. There is a single LED turned on with the 1st micro:bit. Additionally, the graphs will reflect 0 acceleation for the 1st micro:bit. In this scenario, if you are adjusting the acceleration in the simualator, you are also changing your chart that will be produced.
 
 ![](/static/mb/acc.png)
 
 ### ~
 NOTE: The colors of the charts reflect the color of the micro:bit simulator. In this instance, the micro:bits are blue and green. So the colors of the line graphs reflect the colors of the micro:bit
- 
+
  ### ~
-After running this simulation several seconds by moving the micro:bit side to side in the x direction, you are ready to graph or chart the accceleration of the micro:bit.  We want a printout of our acceleration on Excel. We will graph the fluctuating acceleration of the simulation experiment. 
+After running this simulation several seconds by moving the micro:bit side to side in the x direction, you are ready to graph or chart the accceleration of the micro:bit.  We want a printout of our acceleration on Excel. We will graph the fluctuating acceleration of the simulation experiment.
 
 ![](/static/mb/acc2.png)
 
 ### ~
-Finally, you must open the Excel CSV file by clicking on the data.xls file that was downloaded to Downloads Folder. 
+Finally, you must open the Excel CSV file by clicking on the data.xls file that was downloaded to Downloads Folder.
 
 ![](/static/mb/data3.png)
 
@@ -85,7 +85,7 @@ Have fun reviewing your simulation and analyze the acceleration by chart the Exc
 * Connect the second micro:bit to your computer using your USB cable and run the charting script on it.
 * The first person and second person take turns tilting the micro:bit in the "x" direction while the other player charts the data on the micro:bit!
 * Review and analyze the actual micro:bit device acceleration data on Excel
-* Display acceleration with y or z using plot bar graph by changing acceleration from "x" to "y" or "z" 
+* Display acceleration with y or z using plot bar graph by changing acceleration from "x" to "y" or "z"
 
 ```package
 radio

--- a/docs/lessons/pogo.md
+++ b/docs/lessons/pogo.md
@@ -19,7 +19,6 @@ Learn how to use running time. We will be learning how to create a pogo game usi
 let jumps = 0
 let acc = input.acceleration(Dimension.Y)
 basic.showNumber(0)
-radio.receiveNumber()
 led.stopAnimation()
 radio.sendNumber(0)
 basic.forever(() => { })
@@ -32,7 +31,7 @@ basic.showLeds(`
     `)
 basic.clearScreen()
 if (true) {}
-radio.onDataReceived(() => { })
+radio.onDataPacketReceived(() => { })
 ```
 ## Objectives
 

--- a/docs/lessons/pogo/activity.md
+++ b/docs/lessons/pogo/activity.md
@@ -1,6 +1,6 @@
 # pogo activity
 
-Construct a counter that uses acceleration. 
+Construct a counter that uses acceleration.
 
 Welcome! This activity will teach how to construct a pendulum that glows using acceleration. Let's get started!
 
@@ -120,8 +120,8 @@ input.onButtonPressed(Button.AB, () => {
     let jumps = 0
     basic.showNumber(jumps)
 })
-radio.onDataReceived(() => {
-    basic.showNumber(radio.receiveNumber())
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    basic.showNumber(receivedNumber)
 })
 
 ```
@@ -151,8 +151,8 @@ input.onButtonPressed(Button.AB, () => {
     let jumps = 0
     basic.showNumber(jumps)
 })
-radio.onDataReceived(() => {
-    basic.showNumber(radio.receiveNumber())
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    basic.showNumber(receivedNumber)
     led.stopAnimation()
 })
 

--- a/docs/lessons/seismograph.md
+++ b/docs/lessons/seismograph.md
@@ -1,8 +1,8 @@
-# Seismograph Lesson 
+# Seismograph Lesson
 
 Build a seismograph with household materials
 
-## Topic 
+## Topic
 
 Acceleration & Analog Read Pin
 
@@ -11,7 +11,7 @@ Acceleration & Analog Read Pin
 * [activity](/lessons/seismograph/activity)
 * [challenge](/lessons/seismograph/challenge)
 
-## Prior learning/place of lesson in scheme of work 
+## Prior learning/place of lesson in scheme of work
 
 Learn how to **show LEDs** to turn on a LED light pattern on the LED screen. We will be learning basic comments such as show LEDs and pause.
 
@@ -21,17 +21,16 @@ Learn how to **show LEDs** to turn on a LED light pattern on the LED screen. We 
 basic.forever(() => {});
 radio.sendNumber(0);
 input.acceleration(Dimension.Strength)
-radio.onDataReceived(() => {});
+radio.onDataPacketReceived(() => {});
 led.plotBarGraph(0, 0);
-radio.receiveNumber();
 ```
 
 ## Objectives
 
 * learn how to repeat code forever in the background
-* learn how to display a vertical bar graph based on the value. 
+* learn how to display a vertical bar graph based on the value.
 * learn how to return the sum of the two numbers
-* learn how to get acceleration value in milli-gravitys 
+* learn how to get acceleration value in milli-gravitys
 * learn how to read the connector value as analog as a value comprised between 0 and 1023
 
 ```package

--- a/docs/lessons/seismograph/challenge.md
+++ b/docs/lessons/seismograph/challenge.md
@@ -1,20 +1,20 @@
-# Seismograph Challenge 
+# Seismograph Challenge
 
-Coding challenges for the seismograph. 
+Coding challenges for the seismograph.
 
 
 ### ~avatar avatar
 
-Engineering: In this project, you will build a remote control based on the seismograph micro:bit activity using a second micro:bit and micro USB cable. 
+Engineering: In this project, you will build a remote control based on the seismograph micro:bit activity using a second micro:bit and micro USB cable.
 
 ### ~
 
-## What you'll need: 
+## What you'll need:
 
 * BBC micro:bits (2)
-* micro USB cables (2) 
-* Plate 
-* Tape 
+* micro USB cables (2)
+* Plate
+* Tape
 * Scissors
 
 ![](/static/mb/lessons/seis_challenge01.png)
@@ -30,14 +30,14 @@ basic.forever(() => {
 
 ```
 
-### ~avatar avatar 
+### ~avatar avatar
 Computer Science: Welcome! The activity will teach you how to code the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit. Let's get started!
 ### ~
 
 # Computer Science Steps
 
 ## 1.
-We want to simply detach the blocks from the recent activity. We will use blocks from the activity to create a brand new program to show the way micro:bit devices communicate through the BLE (Bluetooth low energy) radio. 
+We want to simply detach the blocks from the recent activity. We will use blocks from the activity to create a brand new program to show the way micro:bit devices communicate through the BLE (Bluetooth low energy) radio.
 
 ```shuffle
 basic.forever(() => {
@@ -46,10 +46,10 @@ basic.forever(() => {
 
 ```
 
-## 2. 
+## 2.
 Let's measure `acceleration (mg)` and then `send number`. `Acceleration` is measured in **milli-gravities**, so a value of -1000 is equivalent to -1g or -9.81m/s^2. We will be able to get the acceleration value (g-force), in the specified "x" dimension. `Send number` will broadcast a number data packet to other micro:bits connected via radio.
 
-We need add send number block found in the Radio drawer. We will attach send number to acceleration and subtract the gravity from acceleration strength.  
+We need add send number block found in the Radio drawer. We will attach send number to acceleration and subtract the gravity from acceleration strength.
 
 Your finished code will look like this:
 
@@ -57,8 +57,8 @@ Your finished code will look like this:
 radio.sendNumber(input.acceleration(Dimension.Strength) - 1023);
 ```
 
-## 3. 
-We want to display the acceleration forever. In order to do so, we need a `forever` loop. A forever loop will repeat code in the background forever. We need attach forever loop to send number. 
+## 3.
+We want to display the acceleration forever. In order to do so, we need a `forever` loop. A forever loop will repeat code in the background forever. We need attach forever loop to send number.
 
 Your finished code will look like this:
 
@@ -69,7 +69,7 @@ basic.forever(() => {
 
 ```
 
-## 4. 
+## 4.
 We want to register code to run when a packet is received over radio. We can implement this code by adding `on data received`block found in the radio drawer.
 
 Your finished code will look like this:
@@ -78,12 +78,12 @@ Your finished code will look like this:
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.Strength) - 1023);
 });
-radio.onDataReceived(() => {
+radio.onDataPacketReceived(() => {
 });
 
 ```
 
-## 5. 
+## 5.
 Finally, we want to chart the acceleration. So we must first implement `plot bar graph`. `Plot Bar Graph` will display a vertical bar graph based on the value and high value. In order to transfer the receive the number from the 1st micro:bit, we must implement `receive number` to constantly display a vertical bar graph based on the value. Remember, the value will equal to the micro:bit's acceleration in the "x" direction.
 
 Your finished code will look like this:
@@ -92,25 +92,25 @@ Your finished code will look like this:
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.Strength) - 1023);
 });
-radio.onDataReceived(() => {
-    led.plotBarGraph(radio.receiveNumber(), 0);
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    led.plotBarGraph(receivedNumber, 0);
 });
 ```
 
-### ~avatar avatar 
+### ~avatar avatar
 Science: Welcome! The activity will teach you how to chart the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit. Let's get started!
 ### ~
 
 # Science Steps
 
-## 6. 
+## 6.
 First, notice that moving the 1st micro:bit in the simulator in any direction, you will change the acceleration value of the 2nd micro:bit. Also, notice that by moving the micro:bit simulator, there is a changing acceleration value of the second micro:bit. Second, the flat colored horizontal line will start a waving line on the 2nd micro:bit to display the value of the strength as measured in milli-gravities. Finally, notice that the LED display will fluctate based on the movement of the 2nd micro:bit simulator.
 
 ![](/static/mb/lessons/seis_challenge02.png)
 
-## 7. 
- 
-Connect the 2nd micro:bit to your computer using your USB cable. We should have two micro:bit devices attached to the computer. 
+## 7.
+
+Connect the 2nd micro:bit to your computer using your USB cable. We should have two micro:bit devices attached to the computer.
 
 ![](/static/mb/lessons/seismograph33.png)
 
@@ -118,7 +118,7 @@ Connect the 2nd micro:bit to your computer using your USB cable. We should have 
 
 Click or tap the **Download** button for the seismograph program to run the program on the 1st micro:bit and 2nd micro:bit.
 
-## 9. 
+## 9.
 
 The black lines should appear directly beneath the colored lines. The black lines measure the micro:bit acceleration. And the colored lines measures micro:bit simulator acceleration.
 
@@ -134,34 +134,34 @@ Every time the micro:bit moves in any direction, you generate data points that c
 
 Now we are ready to graph or chart the accceleration of the micro:bit. We want a printout of the micro:bit acceleration graphed in Excel.
 
-## 10. 
+## 10.
 
 In order to receive the the data plotted by Excel, click or tap anywhere in the on the chart data.
 
 ![](/static/mb/lessons/seis_challenge07.png)
 
-## 11. 
+## 11.
 
-You have two options to Analyze Data: 
+You have two options to Analyze Data:
 
-* Local File: Save the data to your local Downloads folder and open it in Excel. 
-* Stream to Cloud: Upload your data to Microsoft Azure to analyze it. 
+* Local File: Save the data to your local Downloads folder and open it in Excel.
+* Stream to Cloud: Upload your data to Microsoft Azure to analyze it.
 
 Click or tap Download data
 
 ![](/static/mb/lessons/seismograph9.png)
 
-## 12. 
+## 12.
 
-A CSV file will be generated to display the data points collected by the micro:bit. Click or tap on the data Excel file that was downloaded to your local Downloads Folder. 
+A CSV file will be generated to display the data points collected by the micro:bit. Click or tap on the data Excel file that was downloaded to your local Downloads Folder.
 
 ![](/static/mb/lessons/analyze9.png)
 
 ## 13.
 
-Select the data that you want to include in your chart. The chart should include the first two columns: time and acceleration. 
+Select the data that you want to include in your chart. The chart should include the first two columns: time and acceleration.
 
-Click or tap on the first two columns (A, B) to include time and acceleration data from the micro:bit. We only need the first two columns (A, B) because the 2nd micro:bit changes have been communicated by the 1st micro:bit. So the data points of the seismograph are being recorded on the 1st micro:bit. 
+Click or tap on the first two columns (A, B) to include time and acceleration data from the micro:bit. We only need the first two columns (A, B) because the 2nd micro:bit changes have been communicated by the 1st micro:bit. So the data points of the seismograph are being recorded on the 1st micro:bit.
 
 ## 14.
 
@@ -169,23 +169,23 @@ Click or tap on Insert then select Recommended Charts. We can select a chart tha
 
 ![](/static/mb/analyze3.png)
 
-On the Recommended Charts tab, scroll through the list of chart types that Excel recommends for your data. 
+On the Recommended Charts tab, scroll through the list of chart types that Excel recommends for your data.
 
-We want to select the chart called Line. A line chart is used to display trends over time. We will use the line chart because there are many data points over time. 
+We want to select the chart called Line. A line chart is used to display trends over time. We will use the line chart because there are many data points over time.
 
-Click on the chart type to see how your data will look in that format. When you find the chart type that you want, click it, and then click OK. 
+Click on the chart type to see how your data will look in that format. When you find the chart type that you want, click it, and then click OK.
 
 ![](/static/mb/lessons/analyze16.png)
 
 Tip: If you don’t see the line chart, click the All Charts tab to see the line chart.
 
-## 15. 
+## 15.
 
 Use the Chart Elements, Chart Styles, and Chart Filters buttons next to the upper-right corner of the chart to add chart elements like axis titles or data labels, to customize the look of your chart
 
-Alternatively, click or tap on the Design Ribbon. 
+Alternatively, click or tap on the Design Ribbon.
 
-Let's select Style 10 as an example. 
+Let's select Style 10 as an example.
 
 ![](/static/mb/lessons/analyze19.png)
 

--- a/docs/projects/messenger.md
+++ b/docs/projects/messenger.md
@@ -16,13 +16,13 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 2
 
-Use [radio on data received](/reference/radio/on-data-received) display "YO" when the number ``0`` is received
+Use [radio on data packet received](/reference/radio/on-data-packet-received) display "YO" when the number ``0`` is received
 by radio.
 
 ```blocks
 let message = 0;
-radio.onDataReceived(() => {
-    message = radio.receiveNumber();
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    message = receivedNumber;
     if (message == 0) {
         basic.showString("YO")
     }
@@ -43,13 +43,13 @@ input.onButtonPressed(Button.B, () => {
 
 ## Step 4
 
-Add blocks in [radio on data received](/reference/radio/on-data-received) to display "BYE" when the number ``1`` is received
+Add blocks in [radio on data packet received](/reference/radio/on-data-packet-received) to display "BYE" when the number ``1`` is received
 by radio.
 
 ```blocks
 let message = 0;
-radio.onDataReceived(() => {
-    message = radio.receiveNumber();
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    message = receivedNumber;
     if (message == 0) {
         basic.showString("YO")
     }

--- a/docs/projects/radio-challenges.md
+++ b/docs/projects/radio-challenges.md
@@ -1,8 +1,8 @@
-# Challenge 
+# Challenge
 
-### ~avatar avatar 
+### ~avatar avatar
 
-Welcome! The activity will teach you how to use the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit. 
+Welcome! The activity will teach you how to use the acceleration of the 1st micro:bit and to visualize the acceleration on the 2nd micro:bit.
 Let's get started!
 
 ### ~
@@ -28,8 +28,8 @@ We want to register code to run when a packet is received over radio. We can imp
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X))
 })
-radio.onDataReceived(() => {
-    
+radio.onDataPacketReceived(() => {
+
 })
 ```
 ### ~
@@ -39,28 +39,28 @@ Finally, we want to chart the acceleration. So we must first implement `plot bar
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X))
 })
-radio.onDataReceived(() => {
-    led.plotBarGraph(radio.receiveNumber(), 1023)
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    led.plotBarGraph(receivedNumber, 1023)
 })
 
 ```
 ### ~
-Notice that moving the micro:bit the farthest direction in the x direction will be -1023 on the charting beneath the simulator. The second observation will be that the LEDs will be full brightness on the 2nd micro:bit. There is a single LED turned on with the 1st micro:bit. Additionally, the graphs will reflect 0 acceleation for the 1st micro:bit. In this scenario, if you are adjusting the acceleration in the simualator, you are also changing your chart that will be produced.  
+Notice that moving the micro:bit the farthest direction in the x direction will be -1023 on the charting beneath the simulator. The second observation will be that the LEDs will be full brightness on the 2nd micro:bit. There is a single LED turned on with the 1st micro:bit. Additionally, the graphs will reflect 0 acceleation for the 1st micro:bit. In this scenario, if you are adjusting the acceleration in the simualator, you are also changing your chart that will be produced.
 
 ![](/static/mb/acc.png)
 
 ### ~
 NOTE: The colors of the charts reflect the color of the micro:bit simulator. In this instance, the micro:bits are blue and green. So the colors of the line graphs reflect the colors of the micro:bit
- 
+
  ### ~
-After running this simulation several seconds by moving the micro:bit side to side in the x direction, you are ready to graph or chart the accceleration of the micro:bit.  We want a printout of our acceleration on Excel. We will graph the fluctuating acceleration of the simulation experiment. 
+After running this simulation several seconds by moving the micro:bit side to side in the x direction, you are ready to graph or chart the accceleration of the micro:bit.  We want a printout of our acceleration on Excel. We will graph the fluctuating acceleration of the simulation experiment.
 
 ![](/static/mb/acc2.png)
 
 ### ~
 
 Finally, you must open the Excel CSV file by clicking on the `data.csv` file
-that was downloaded to Downloads Folder. 
+that was downloaded to Downloads Folder.
 
 ![](/static/mb/data3.png)
 
@@ -87,7 +87,7 @@ Have fun reviewing your simulation and analyze the acceleration by chart the Exc
 * Connect the second micro:bit to your computer using your USB cable and run the charting script on it.
 * The first person and second person take turns tilting the micro:bit in the "x" direction while the other player charts the data on the micro:bit!
 * Review and analyze the actual micro:bit device acceleration data on Excel
-* Display acceleration with y or z using plot bar graph by changing acceleration from "x" to "y" or "z" 
+* Display acceleration with y or z using plot bar graph by changing acceleration from "x" to "y" or "z"
 
 ```package
 radio

--- a/docs/reference/radio.md
+++ b/docs/reference/radio.md
@@ -6,13 +6,9 @@ Communicate data using radio packets
 radio.sendNumber(0);
 radio.sendValue("data", 0);
 radio.sendString("");
-radio.onDataReceived(() => {
-    
+radio.onDataPacketReceived(() => {
+
 });
-radio.receiveNumber();
-radio.receivedNumberAt(0);
-radio.receiveString();
-radio.receivedSignalStrength();
 radio.setGroup(0);
 radio.setTransmitPower(7);
 radio.setTransmitSerialNumber(false);
@@ -25,4 +21,11 @@ radio
 
 ### See Also
 
-[sendNumber](/reference/radio/send-number), [sendValue](/reference/radio/send-value), [sendString](/reference/radio/send-string), [onDataReceived](/reference/radio/on-data-received), [receiveNumber](/reference/radio/receive-number), [receiveString](/reference/radio/receive-string), [receivedSignalStrength](/reference/radio/received-signal-strength), [setGroup](/reference/radio/set-group), [setTransmitPower](/reference/radio/set-transmit-power), [setTransmitSerialNumber](/reference/radio/set-transmit-serial-number), [writeValueToSerial](/reference/radio/write-value-to-serial)
+[sendNumber](/reference/radio/send-number),
+[sendValue](/reference/radio/send-value),
+[sendString](/reference/radio/send-string),
+[onDataPacketReceived](/reference/radio/on-data-packet-received),
+[setGroup](/reference/radio/set-group),
+[setTransmitPower](/reference/radio/set-transmit-power),
+[setTransmitSerialNumber](/reference/radio/set-transmit-serial-number),
+[writeValueToSerial](/reference/radio/write-value-to-serial)

--- a/docs/reference/radio/on-data-packet-received.md
+++ b/docs/reference/radio/on-data-packet-received.md
@@ -1,14 +1,16 @@
-# On Data Received
-
-> Note: This API has been deprecated! Use [on data packet received](/reference/radio/on-data-packet-received) instead.
+# On Data Packet Received
 
 Run part of a program when the micro:bit receives a
 [number](/reference/types/number) or [string](/reference/types/string) over ``radio``.
 
 
 ```sig
-radio.onDataReceived(() => { });
+radio.onDataPacketReceived((packet: Packet) => { });
 ```
+
+### Callback Parameters
+
+* ``packet`` - the [packet](/reference/radio/packet) that was received by the radio
 
 ### Example
 
@@ -21,15 +23,17 @@ thing from nearby micro:bits. It shows these numbers as a
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X));
 })
-radio.onDataReceived(() => {
-    led.plotBarGraph(radio.receiveNumber(), 1023);
+radio.onDataPacketReceived(({ receivedNumber }) => {
+    led.plotBarGraph(receivedNumber, 1023);
 })
 ```
 
 ### See also
 
-[on data packet received](/reference/radio/on-data-packet-received),
-[send number](/reference/radio/send-number), [set group](/reference/radio/set-group)
+[send number](/reference/radio/send-number),
+[send string](/reference/radio/send-string),
+[send value](/reference/radio/send-value),
+[set group](/reference/radio/set-group)
 
 ```package
 radio

--- a/docs/reference/radio/packet.md
+++ b/docs/reference/radio/packet.md
@@ -1,0 +1,19 @@
+# Packet
+
+A packet that was received by the radio.
+
+## Properties
+
+* `receivedNumber` - The number that was sent in this packet or `0` if this packet did not contain a number. See [send number](/reference/radio/send-number) and [send value](/reference/radio/send-value)
+* `text` - The string that was sent in this packet or the empty string if this packet did not contain a string. See [send string](/reference/radio/send-string) and [send value](/reference/radio/send-value)
+* `time` - The system time of the micro:bit that sent this packet at the time the packet was sent.
+* `serial` - The serial number of the micro:bit that sent this packet or `0` if the micro:bit did not include its serial number.
+* `signal` - How strong the radio signal is from `255` (weak) to `0` (strong).
+
+### See also
+
+[on data packet received](/reference/radio/on-data-packet-received),
+
+```package
+radio
+```

--- a/docs/reference/radio/receive-number.md
+++ b/docs/reference/radio/receive-number.md
@@ -1,5 +1,7 @@
 # Receive Number
 
+> Note: This API has been deprecated! Use [on data packet received](/reference/radio/on-data-packet-received) instead.
+
 Receives the next number sent by a micro:bit in the same ``radio`` group.
 
 ```sig
@@ -9,10 +11,6 @@ radio.receiveNumber();
 ### Returns
 
 * the first  [number](/reference/types/number) that the micro:bit received. If it did not receive any numbers, this function will return `0`.
-
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
 
 ### Example: Simple number receiver
 
@@ -25,7 +23,7 @@ radio.onDataReceived(() => {
 })
 ```
 
-### Example: Light level receiver 
+### Example: Light level receiver
 
 This example shows the light level from the [light level sender example](/reference/radio/send-number)
 as a number.

--- a/docs/reference/radio/receive-string.md
+++ b/docs/reference/radio/receive-string.md
@@ -1,5 +1,7 @@
 # Receive String
 
+> Note: This API has been deprecated! Use [on data packet received](/reference/radio/on-data-packet-received) instead.
+
 Find the next string sent by `radio` from another micro:bit.
 
 ```sig
@@ -10,10 +12,6 @@ radio.receiveString()
 
 * the first [string](/reference/types/string) that was sent. If no
   string was sent, then this function returns an empty (blank) string.
-
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
 
 ### Example: Simple receiver
 

--- a/docs/reference/radio/received-signal-strength.md
+++ b/docs/reference/radio/received-signal-strength.md
@@ -1,11 +1,13 @@
 # Received Signal Strength
 
+> Note: This API has been deprecated! Use [on data packet received](/reference/radio/on-data-packet-received) instead.
+
 Find how strong the ``radio`` signal is, from `255` to `0`.
 (`255` means a weak signal and `0` means a strong one.)
 
 The micro:bit finds the signal strength by checking how strong it was
 the last time it ran the
-[receive number](/reference/radio/receive-number) function. That means
+[on data packet received](/reference/radio/on-data-packet-received) function. That means
 it needs to run **receive number** first.
 
 ```sig
@@ -37,7 +39,7 @@ basic.forever(() => {
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [send number](/reference/radio/send-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received), [send number](/reference/radio/send-number), [on data received](/reference/radio/on-data-received)
 
 ```package
 radio

--- a/docs/reference/radio/send-number.md
+++ b/docs/reference/radio/send-number.md
@@ -10,9 +10,6 @@ radio.sendNumber(0);
 
 * ``value`` - a [number](/reference/types/number) to send.
 
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
 
 ### Example: Broadcasting acceleration
 
@@ -30,7 +27,7 @@ input.onButtonPressed(Button.A, () => {
 
 This example broadcasts the level of the light around it.
 You can do some interesting things with it if you use it along with the
-[Mailbot](/reference/radio/receive-number) example.
+[on data packet received](/reference/radio/on-data-packet-received) example.
 
 ```blocks
 radio.setGroup(99)
@@ -42,7 +39,7 @@ basic.forever(() => {
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received)
 
 ```package
 radio

--- a/docs/reference/radio/send-string.md
+++ b/docs/reference/radio/send-string.md
@@ -1,6 +1,7 @@
 # Send String
 
-Sends a string to other micro:bits in the area connected by radio.
+Sends a string to other micro:bits in the area connected by radio. The
+maximum string length is 19 characters.
 
 ```sig
 radio.sendString("Hello!")
@@ -10,9 +11,6 @@ radio.sendString("Hello!")
 
 * `msg` is a [string](/reference/types/string) to send by radio.
 
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
 
 ### Example: Two-way radio
 
@@ -26,8 +24,8 @@ input.onButtonPressed(Button.A, () => {
     basic.showString("SENT");
 })
 
-radio.onDataReceived(() => {
-    basic.showString(radio.receiveString());
+radio.onDataPacketReceived(({ text }) => {
+    basic.showString(text);
 });
 ```
 
@@ -39,7 +37,7 @@ A radio that can both transmit and receive is called a _transceiver_.
 
 ### See also
 
-[receive string](/reference/radio/receive-string), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received)
 
 ```package
 radio

--- a/docs/reference/radio/send-value.md
+++ b/docs/reference/radio/send-value.md
@@ -1,6 +1,7 @@
 # Send Value
 
 Send a [string]() and [number]() together by ``radio`` to other micro:bits.
+The maximum [string]() length is 12 characters.
 
 ```sig
 radio.sendValue("data", 0);
@@ -10,10 +11,6 @@ radio.sendValue("data", 0);
 
 * ``name`` is a [string](/reference/types/string) to send by radio
 * ``value`` a [number](/reference/types/number) to send by radio
-
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
 
 ### Example: Broadcasting acceleration
 
@@ -34,15 +31,15 @@ Then it shows them on the LED screen.
 
 ```blocks
 radio.setGroup(99)
-radio.onDataReceived(() => {
-	basic.showString(radio.receiveString());
-    basic.showNumber(radio.receiveNumber());
+radio.onDataPacketReceived(({ text, receivedNumber }) => {
+	basic.showString(text);
+    basic.showNumber(receivedNumber);
 });
 ```
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received)
 
 ```package
 radio

--- a/docs/reference/radio/set-group.md
+++ b/docs/reference/radio/set-group.md
@@ -32,7 +32,10 @@ radio.setGroup(128)
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [send number](/reference/radio/send-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received),
+[send number](/reference/radio/send-number),
+[send value](/reference/radio/send-value),
+[send string](/reference/radio/send-string)
 
 ```package
 radio

--- a/docs/reference/radio/set-transmit-power.md
+++ b/docs/reference/radio/set-transmit-power.md
@@ -13,7 +13,7 @@ radio.setTransmitPower(7);
 ```
 
 ### Range
-   
+
 If your micro:bit is sending with a strength of `7`, and you are in
 an open area without many other computers around, the micro:bit signal
 can reach as far as 70 meters (about 230 feet).
@@ -37,7 +37,10 @@ radio.setTransmitPower(7)
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [send number](/reference/radio/send-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received),
+[send number](/reference/radio/send-number),
+[send value](/reference/radio/send-value),
+[send string](/reference/radio/send-string)
 
 ```package
 radio

--- a/docs/reference/radio/set-transmit-serial-number.md
+++ b/docs/reference/radio/set-transmit-serial-number.md
@@ -10,10 +10,6 @@ radio.setTransmitSerialNumber(true);
 
 * ``transmit`` is a [boolean](/reference/types/boolean) that represents whether the serial number needs to be transmitted.
 
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
-
 ### Example
 
 This program makes the ``radio`` send the serial number in each packet.
@@ -24,7 +20,10 @@ radio.setTransmitSerialNumber(true);
 
 ### See also
 
-[receive number](/reference/radio/receive-number), [send number](/reference/radio/send-number), [on data received](/reference/radio/on-data-received)
+[on data packet received](/reference/radio/on-data-packet-received),
+[send number](/reference/radio/send-number),
+[send value](/reference/radio/send-value),
+[send string](/reference/radio/send-string)
 
 ```package
 radio

--- a/docs/reference/radio/write-value-to-serial.md
+++ b/docs/reference/radio/write-value-to-serial.md
@@ -6,25 +6,13 @@ Writes the data received by ``radio`` to serial in JSON format.
 radio.writeValueToSerial();
 ```
 
-### ~hint
-
-This method only works for [send number](/reference/radio/send-number)
-and [send value](/reference/radio/send-value). It does not work for
-[send string](/reference/radio/send-string), although you can send a
-string as part of [send value](/reference/radio/send-value).
-
-### ~
-
 ### Data received format
 
 The format for received data printed to serial is as follows:
 
-- [send number](/reference/radio/send-number): ```{v:ValueSent,t:MicrobitTimeAlive,s:Unused}```
-- [send value](/reference/radio/send-value): ```{v:ValueSent,t:MicrobitTimeAlive,s:Unused,n:"Name"}```
-
-### Simulator
-
-This function only works on the micro:bit, not in browsers.
+- [send number](/reference/radio/send-number): ```{v:ValueSent,t:MicrobitTimeAlive,s:SerialNumber}```
+- [send value](/reference/radio/send-value): ```{v:ValueSent,t:MicrobitTimeAlive,s:SerialNumber,n:"Name"}```
+- [send string](/reference/radio/send-string): ```{t:MicrobitTimeAlive,s:SerialNumber,n:"Text"}```
 
 ### Examples
 
@@ -50,7 +38,8 @@ Sample output to serial when ``A`` button pressed:
 
 [send number](/reference/radio/send-number),
 [send value](/reference/radio/send-value),
-[on data received](/reference/radio/on-data-received)
+[send string](/reference/radio/send-string),
+[on data packet received](/reference/radio/on-data-packet-received)
 
 ```package
 radio

--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -244,7 +244,7 @@ namespace radio {
     //% help=radio/receive-number
     //% weight=46
     //% blockId=radio_datagram_receive block="radio receive number" blockGap=8
-    //% advanced=true
+    //% deprecated=true
     int receiveNumber()
     {
         if (radioEnable() != MICROBIT_OK) return 0;
@@ -258,7 +258,7 @@ namespace radio {
     //% help=radio/on-data-received
     //% weight=50
     //% blockId=radio_datagram_received_event block="radio on data received" blockGap=8
-    //% advanced=true
+    //% deprecated=true
     void onDataReceived(Action body) {
         if (radioEnable() != MICROBIT_OK) return;
         registerWithDal(MICROBIT_ID_RADIO, MICROBIT_RADIO_EVT_DATAGRAM, body);
@@ -274,7 +274,7 @@ namespace radio {
     //% blockId=radio_datagram_receive_string block="radio receive string" blockGap=8
     //% weight=44
     //% help=radio/receive-string
-    //% advanced=true
+    //% deprecated=true
     StringData* receiveString() {
         if (radioEnable() != MICROBIT_OK) return ManagedString().leakData();
         receivePacket(false);
@@ -289,7 +289,7 @@ namespace radio {
     //% help=radio/received-signal-strength
     //% weight=40
     //% blockId=radio_datagram_rssi block="radio received signal strength"
-    //% advanced=true
+    //% deprecated=true
     int receivedSignalStrength() {
         if (radioEnable() != MICROBIT_OK) return 0;
         return packet.getRSSI();

--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -32,6 +32,7 @@ namespace radio {
      * Registers code to run when the radio receives a packet. Also takes the
      * received packet from the radio queue.
      */
+    //% help=radio/on-data-packet-received
     //% mutate=true
     //% mutateText=Packet
     //% mutateDefaults="receivedNumber;text,receivedNumber;text"

--- a/libs/radio/shims.d.ts
+++ b/libs/radio/shims.d.ts
@@ -50,7 +50,7 @@ declare namespace radio {
     //% help=radio/receive-number
     //% weight=46
     //% blockId=radio_datagram_receive block="radio receive number" blockGap=8
-    //% advanced=true shim=radio::receiveNumber
+    //% deprecated=true shim=radio::receiveNumber
     function receiveNumber(): number;
 
     /**
@@ -59,7 +59,7 @@ declare namespace radio {
     //% help=radio/on-data-received
     //% weight=50
     //% blockId=radio_datagram_received_event block="radio on data received" blockGap=8
-    //% advanced=true shim=radio::onDataReceived
+    //% deprecated=true shim=radio::onDataReceived
     function onDataReceived(body: () => void): void;
 
     /**
@@ -69,7 +69,7 @@ declare namespace radio {
     //% blockId=radio_datagram_receive_string block="radio receive string" blockGap=8
     //% weight=44
     //% help=radio/receive-string
-    //% advanced=true shim=radio::receiveString
+    //% deprecated=true shim=radio::receiveString
     function receiveString(): string;
 
     /**
@@ -80,7 +80,7 @@ declare namespace radio {
     //% help=radio/received-signal-strength
     //% weight=40
     //% blockId=radio_datagram_rssi block="radio received signal strength"
-    //% advanced=true shim=radio::receivedSignalStrength
+    //% deprecated=true shim=radio::receivedSignalStrength
     function receivedSignalStrength(): number;
 
     /**


### PR DESCRIPTION
Deprecates the old radio APIs so that they won't show up in the toolbox and documents the new APIs. I also added deprecation notices in the docs and tried to remove all of the references to the old APIs. Sorry about the whitespace changes.