### PR TITLE
Rename the parameters for the sendValue block

### DIFF
--- a/docs/reference/radio.md
+++ b/docs/reference/radio.md
@@ -4,7 +4,7 @@ Communicate data using radio packets
 
 ```cards
 radio.sendNumber(0);
-radio.sendValue("data", 0);
+radio.sendValue("name", 0);
 radio.sendString("");
 radio.onDataPacketReceived(() => {
 

--- a/docs/reference/radio/send-value.md
+++ b/docs/reference/radio/send-value.md
@@ -4,7 +4,7 @@ Send a [string]() and [number]() together by ``radio`` to other micro:bits.
 The maximum [string]() length is 12 characters.
 
 ```sig
-radio.sendValue("data", 0);
+radio.sendValue("name", 0);
 ```
 
 ### Parameters

--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -188,7 +188,7 @@ namespace radio {
     /**
     * Broadcasts a name / value pair along with the device serial number
     * and running time to any connected micro:bit in the group.
-    * @param name the field name (max 12 characters), eg: "data"
+    * @param name the field name (max 12 characters), eg: "name"
     * @param value the numberic value
     */
     //% help=radio/send-value

--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -35,7 +35,7 @@ namespace radio {
     //% help=radio/on-data-packet-received
     //% mutate=true
     //% mutateText=Packet
-    //% mutateDefaults="receivedNumber;receivedString,receivedNumber;receivedString"
+    //% mutateDefaults="receivedNumber;receivedString:name,receivedNumber:value;receivedString"
     //% blockId=radio_on_packet block="on radio received" blockGap=8
     export function onDataPacketReceived(cb: (packet: Packet) => void) {
         onDataReceived(() => {

--- a/libs/radio/shims.d.ts
+++ b/libs/radio/shims.d.ts
@@ -16,7 +16,7 @@ declare namespace radio {
     /**
      * Broadcasts a name / value pair along with the device serial number
      * and running time to any connected micro:bit in the group.
-     * @param name the field name (max 12 characters), eg: "data"
+     * @param name the field name (max 12 characters), eg: "name"
      * @param value the numberic value
      */
     //% help=radio/send-value


### PR DESCRIPTION
Part of https://github.com/Microsoft/pxt/issues/595

By the way, it's sort of weird how we specify string values. Took me a while to realize I had to change the "e.g." example in the jsdoc for the function.