### PR TITLE
Fixing scrollImage to actually scroll

### DIFF
--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -61,7 +61,7 @@ namespace ImageMethods {
 
     /**
      * Scrolls an image .
-     * @param frameOffset x offset moved on each animation step, eg: 5, 1, -1
+     * @param frameOffset x offset moved on each animation step, eg: 1, 2, 5
      * @param interval time between each animation step in milli seconds, eg: 200
      */
     //% help=images/show-image weight=79 async blockNamespace=images
@@ -69,10 +69,7 @@ namespace ImageMethods {
     //% parts="ledmatrix"
     void scrollImage(Image id, int frameOffset, int interval) {
       MicroBitImage i(id);
-      if (i.getWidth() <= 5)
-        showImage(id, 0);
-      else
-        uBit.display.animate(i, interval, frameOffset, 0);
+      uBit.display.animate(i, interval, frameOffset, MICROBIT_DISPLAY_WIDTH - 1);
     }
 
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -53,7 +53,7 @@ declare interface Image {
 
     /**
      * Scrolls an image .
-     * @param frameOffset x offset moved on each animation step, eg: 5, 1, -1
+     * @param frameOffset x offset moved on each animation step, eg: 1, 2, 5
      * @param interval time between each animation step in milli seconds, eg: 200
      */
     //% help=images/show-image weight=79 async blockNamespace=images


### PR DESCRIPTION
Left to right scrolling is not implemented in the simulator today, hence I left it as is. This fixes https://github.com/Microsoft/pxt/issues/788 for microbit. If this looks good, I will produce a patch for calliope.