### PR TITLE
add false for advertiseEddystoneUrl

### DIFF
--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -132,7 +132,7 @@ namespace bluetooth {
     //% help=bluetooth/advertise-url
     void advertiseUrl(StringData* url, int power) {
         int8_t level = CALIBRATED_POWERS[min(7, max(0, power))];
-        uBit.bleManager.advertiseEddystoneUrl(ManagedString(url), level);
+        uBit.bleManager.advertiseEddystoneUrl(ManagedString(url), level, false);
     }
 
     /**


### PR DESCRIPTION
I used https://bluetooth-mdw.blogspot.dk/2016/11/microbit-proximity-beacons.html for reference, there is cpp code therin

Currently investigating why the advertised url. http://pxt.io is corruptted on the Windows App Bluetooth Beacon Interactor that I use as a baseline.

Note that https://show.io/ micro:bit hex code does not have a problem with the url with the refereance app.

https://www.microsoft.com/da-dk/store/p/bluetooth-beacon-interactor/9nblggh1z24k