### PR TITLE
Correction for max. length of advertised url to 17

### DIFF
--- a/docs/reference/bluetooth/advertise-url.md
+++ b/docs/reference/bluetooth/advertise-url.md
@@ -23,7 +23,7 @@ bluetooth.advertiseUrl("https://pxt.microbit.org/", 7);
 
 ### Parameters
 
-* ``url`` - a [string](/reference/types/string) containing the URL to broadcast, at most 17 characters long
+* ``url`` - a [string](/reference/types/string) containing the URL to broadcast, at most 17 characters long, excluding the protocol (eg: ``https://``) which gets encoded as 1 byte.
 * ``power`` - a [number](/reference/types/number) representing the power level between 0 (short) and 7 (maximum range).
 
 ### Example: Broadcast a secret code

--- a/docs/reference/bluetooth/advertise-url.md
+++ b/docs/reference/bluetooth/advertise-url.md
@@ -23,7 +23,7 @@ bluetooth.advertiseUrl("https://pxt.microbit.org/", 7);
 
 ### Parameters
 
-* ``url`` - a [string](/reference/types/string) containing the URL to broadcast, at most 18 characters long
+* ``url`` - a [string](/reference/types/string) containing the URL to broadcast, at most 17 characters long
 * ``power`` - a [number](/reference/types/number) representing the power level between 0 (short) and 7 (maximum range).
 
 ### Example: Broadcast a secret code


### PR DESCRIPTION
https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification states 1-17

When one makes a general google for the max length, some have written 18 and some 17 :(

The difference could lie in the https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix which adds an extra byte but it's use is to reduce the number of bytes needed for an url in the 1-17.

The implementation in the micro:bit Lancaster is unknown as to how the url-scheme-prefix is or is not used: there does not seem to be a scheme for "Just take the 1-17" for the url.

At the moment, "play it safe" and write 17 ?

---

Edit

One correct answer is 17: but the full truth would take longer to write in 
The Lancaster implementation of the transmission of the the url presented to the advertiseEddystoneUrl increases the available url length to over 17
https://github.com/lancaster-university/microbit-dal/blob/12bf127ae28c93498a5d3cf50894866496d9d335/source/bluetooth/MicroBitEddystone.cpp#L52-L56