### PR TITLE
Update bluetooth.cpp

### DIFF
--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -132,7 +132,7 @@ namespace bluetooth {
     //% help=bluetooth/advertise-url
     void advertiseUrl(StringData* url, int power) {
         int8_t level = CALIBRATED_POWERS[min(7, max(0, power))];
-        uBit.bleManager.advertiseEddystoneUrl(ManagedString(url), level);
+        uBit.bleManager.advertiseEddystoneUrl(ManagedString(url), level, true);
     }
 
     /**


### PR DESCRIPTION
uBit.bleManager.advertiseEddystoneUrl(ManagedString(url), level, true); 
Ensure that the default of true is visible in pxt-microbit code such that at a latter date, a user choice for allowing connections to other services is under user, block, control. false: other services connections not allowed