### PR TITLE
Update pxt.json

### DIFF
--- a/libs/bluetooth/pxt.json
+++ b/libs/bluetooth/pxt.json
@@ -24,7 +24,7 @@
             "microbit-dal": {
                 "bluetooth": {
                     "private_addressing": 0,
-                    "whitelist": 1,
+                    "whitelist": 0,
                     "advertising_timeout": 0,
                     "tx_power": 6,
                     "dfu_service": 1,
@@ -32,8 +32,8 @@
                     "device_info_service": 1,
                     "eddystone_url": 1,
                     "eddystone_uid": 0,
-                    "pairing_mode": 1,
-                    "open": 0,
+                    "pairing_mode": 0,
+                    "open": 1,
                     "security_level": "SECURITY_MODE_ENCRYPTION_NO_MITM"
                 }
             },


### PR DESCRIPTION
ensure that conflict between Pairing Modes, where pairing is required does not affect user choice of Eddystone.
Note: user confusion in connection with the choice of pairing and that default JustWorks is overridden.

Lancaster, mdw input
https://github.com/lancaster-university/microbit-dal/issues/251