### PR TITLE
Default values for array

### DIFF
--- a/libs/core/pxt.cpp
+++ b/libs/core/pxt.cpp
@@ -152,7 +152,6 @@ namespace pxt {
       {
           return data[i];          
       }
-      error(ERR_OUT_OF_BOUNDS);
       return Segment::DefaultValue;
     }
 
@@ -275,7 +274,6 @@ namespace pxt {
         --length;
         return value;
       }
-      error(ERR_OUT_OF_BOUNDS);      
       return Segment::DefaultValue;
     }
 
@@ -304,7 +302,6 @@ namespace pxt {
 #endif  
         return ret;
       }
-      error(ERR_OUT_OF_BOUNDS);
       return Segment::DefaultValue;
     }
 
@@ -387,29 +384,16 @@ namespace pxt {
 
     uint32_t RefCollection::getAt(int i) 
     {
-      if (head.isValidIndex(i)) 
+      uint32_t tmp = head.get(i);
+      if (isRef())
       {
-        uint32_t tmp = head.get(i);
-        if (isRef())
-        {
-          incr(tmp);
-        }
-        return tmp;
+        incr(tmp);
       }
-      else 
-      {
-        error(ERR_OUT_OF_BOUNDS);
-        return 0;
-      }
+      return tmp;
     }
 
     uint32_t RefCollection::removeAt(int i) 
     {
-      if (!head.isValidIndex((uint32_t)i))
-      {
-        error(ERR_OUT_OF_BOUNDS);
-        return 0;
-      }
       if (isRef())
       {
         decr(head.get(i));
@@ -419,18 +403,11 @@ namespace pxt {
 
     void RefCollection::insertAt(int i, uint32_t value) 
     {
-      if (((uint32_t)i) < length())
+      head.insert(i, value);
+      if (isRef())
       {
-        head.insert(i, value);
-        if (isRef())
-        {
-          incr(value);
-        } 
-      }
-      else
-      {
-        error(ERR_OUT_OF_BOUNDS);
-      }
+        incr(value);
+      } 
     }
 
     void RefCollection::setAt(int i, uint32_t value) 

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -38,7 +38,6 @@ namespace pxt {
     ERR_OUT_OF_BOUNDS = 8,
     ERR_REF_DELETED = 7,
     ERR_SIZE = 9,
-    ERR_MISSING_VALUE = 10,
   } ERROR;
 
   extern const uint32_t functionsAndBytecode[];
@@ -175,7 +174,7 @@ namespace pxt {
       uint16_t size;
 
       static const uint16_t MaxSize = 0xFFFF;
-      static const uint32_t MissingValue = 0x80000000;
+      static const uint32_t DefaultValue = 0x0;
 
       static uint16_t growthFactor(uint16_t size);      
       void growByMin(uint16_t minSize);
@@ -197,10 +196,6 @@ namespace pxt {
       uint32_t remove(uint32_t i);
       void insert(uint32_t i, uint32_t value);
 
-      //Returns true if there is a valid index greater than or equal to 'i', returns false otherwise
-      //If 'i' is valid returns it in 'result', if not tries to find the next valid
-      //index < length which is valid.
-      bool getNextValidIndex(uint32_t i, uint32_t *result);
       bool isValidIndex(uint32_t i);
 
       void destroy();


### PR DESCRIPTION
This adds default values for
- Missing values are no more error instead default value is returned.
- Out of bound access for array are no more error, default value is returned.

Default values are
- number[]->0
- string[]->null
- boolean[]->false
- object[]->null

Related change in pxt: https://github.com/Microsoft/pxt/pull/1055
