### PR TITLE
Fixing singal strength docs and adding an example

### DIFF
--- a/docs/reference/radio/on-data-packet-received.md
+++ b/docs/reference/radio/on-data-packet-received.md
@@ -21,7 +21,7 @@ To add or remove the parts of the packet from the block, try clicking the blue g
   * `receivedString` - The [string](/reference/types/string) that was sent in this packet or the empty string if this packet did not contain a string. See [send string](/reference/radio/send-string) and [send value](/reference/radio/send-value)
   * `time` - The system time of the @boardname@ that sent this packet at the time the packet was sent.
   * `serial` - The serial number of the @boardname@ that sent this packet or `0` if the @boardname@ did not include its serial number.
-  * `signal` - How strong the radio signal is from `255` (weak) to `0` (strong).
+  * `signal` - How strong the radio signal is from `-128` (weak) to `-42` (strong).
 
 ### Example
 
@@ -36,6 +36,23 @@ basic.forever(() => {
 })
 radio.onDataPacketReceived(({ receivedNumber }) => {
     led.plotBarGraph(receivedNumber, 1023);
+})
+```
+
+### Example
+
+This program uses the signal strength from received packets to graph the
+approximate distance between two @boardname@s.
+
+```blocks
+basic.forever(() => {
+    radio.sendNumber(0)
+})
+radio.onDataPacketReceived(({ signal, receivedNumber }) => {
+    led.plotBarGraph(
+        Math.abs(signal + 42),
+        128 - 42
+    )
 })
 ```
 

--- a/docs/reference/radio/received-signal-strength.md
+++ b/docs/reference/radio/received-signal-strength.md
@@ -2,8 +2,8 @@
 
 > Note: This API has been deprecated! Use [on data packet received](/reference/radio/on-data-packet-received) instead.
 
-Find how strong the ``radio`` signal is, from `255` to `0`.
-(`255` means a weak signal and `0` means a strong one.)
+Find how strong the ``radio`` signal is, from `-128` to `-42`.
+(`-128` means a weak signal and `-42` means a strong one.)
 
 The @boardname@ finds the signal strength by checking how strong it was
 the last time it ran the
@@ -16,7 +16,7 @@ radio.receivedSignalStrength();
 
 ### Returns
 
-* a [number](/reference/types/number) between `255` and `0` that means
+* a [number](/reference/types/number) between `-128` and `-42` that means
 how strong the signal is.
 
 ### Simulator


### PR DESCRIPTION
The correct range (according to the DAL) is -42 to -128. Fixes https://github.com/Microsoft/pxt/issues/1167

Also adds an example using the rssi to show the distance between two micro:bits since that's fun.