### PR TITLE
Include the bitbot package in the whitelist

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -7,7 +7,8 @@
         "approvedRepos": [
             "CoderDojoOlney/pxt-olney",
             "PaulDFoster/pxt-microbit-GY521",
-            "chevyng/pxt-ucl-junkrobot"
+            "chevyng/pxt-ucl-junkrobot",
+            "srs/pxt-bitbot"
         ]
     }
 }


### PR DESCRIPTION
The BitBot package owners have asked to be whitelisted and the package meets the requirements:

* Appropriately named repo
* Substantive tests
* Clear README
* Approval from the BitBot manufacturer for this third party library to be whitelisted