### PR TITLE
Fix plotImage and showImage behavior in the sim 

### DIFF
--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -131,15 +131,35 @@ namespace pxsim.images {
 namespace pxsim.ImageMethods {
     export function showImage(leds: Image, offset: number, interval: number) {
         pxtrt.nullCheck(leds)
-        leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
-        runtime.queueDisplayUpdate()
-        basic.pause(interval);
+        let cb = getResume();
+        let first = true;
+
+        board().ledMatrixState.animationQ.enqueue({
+            interval,
+            frame: () => {
+                if (first) {
+                    leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
+                    runtime.queueDisplayUpdate()
+                    first = false;
+                    return true;
+                }
+                return false;
+            },
+            whenDone: cb
+        })
     }
 
     export function plotImage(leds: Image, offset: number): void {
         pxtrt.nullCheck(leds)
-        leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
-        runtime.queueDisplayUpdate()
+
+        board().ledMatrixState.animationQ.enqueue({
+            interval: 0,
+            frame: () => {
+                leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
+                runtime.queueDisplayUpdate()
+                return false;
+            }
+        })
     }
 
     export function height(leds: Image): number {

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -139,7 +139,6 @@ namespace pxsim.ImageMethods {
             frame: () => {
                 if (first) {
                     leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
-                    runtime.queueDisplayUpdate()
                     first = false;
                     return true;
                 }
@@ -156,7 +155,6 @@ namespace pxsim.ImageMethods {
             interval: 0,
             frame: () => {
                 leds.copyTo(offset, 5, board().ledMatrixState.image, 0)
-                runtime.queueDisplayUpdate()
                 return false;
             }
         })


### PR DESCRIPTION
Tested on hardware. Both `plotImage()` and `showImage()` respect the animation queue. The difference is that `showImage()` is async and lets you specify a delay.