### PR TITLE
fix showAnimation and scrollImage

### DIFF
--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -87,7 +87,7 @@ namespace basic {
     //% help=basic/show-animation imageLiteral=1 async
     //% parts="ledmatrix"
     void showAnimation(ImageLiteral leds, int interval = 400) {
-      uBit.display.animate(MicroBitImage(imageBytes(leds)), interval, 5, 0);
+      uBit.display.animate(MicroBitImage(imageBytes(leds)), interval, 5, 0, 0);
     }
 
     /**

--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -69,7 +69,7 @@ namespace ImageMethods {
     //% parts="ledmatrix"
     void scrollImage(Image id, int frameOffset, int interval) {
       MicroBitImage i(id);
-      uBit.display.animate(i, interval, frameOffset, MICROBIT_DISPLAY_WIDTH - 1);
+      uBit.display.animate(i, interval, frameOffset, MICROBIT_DISPLAY_ANIMATE_DEFAULT_POS, 0);
     }
 
 


### PR DESCRIPTION
We were calling the DAL with default value (true) for "autoclear", so that "autoclear" took place after the animation/scroll, clearing the display, which is not the desired behavior (or the behavior of the simulator). Fixes:

https://github.com/Microsoft/pxt/issues/2131

Tested on micro:bit - now has same behavior as simulator
