### PR TITLE
Change WINS/LOSSES to SCORE

### DIFF
--- a/docs/projects/rock-paper-scissors.md
+++ b/docs/projects/rock-paper-scissors.md
@@ -180,7 +180,8 @@ input.onButtonPressed(Button.A, () => {
 
 Success! Your @boardname@ can track wins!
 But what about losses? 
-Use the ``Game`` drawer to subtract `1` from your score when you press button `B`. 
+Use the ``Game`` drawer to subtract `1` from your score when you press button `B`.
+Change `WINS` to `SCORE` in step 6.
 
 Here are all the blocks you will need:
 
@@ -188,7 +189,7 @@ Here are all the blocks you will need:
 input.onButtonPressed(Button.B, () => {
     game.addScore(-1)
     basic.pause(1)
-    basic.showString("LOSSES:")
+    basic.showString("SCORE:")
     basic.showNumber(game.score())
 })
 ```


### PR DESCRIPTION
Once step 7 is introduced WINS/LOSSES is not the correct terminology. SCORE should be used instead. For example, if initially there are 5 wins, followed by a loss, it would show: LOSSES:4
However, 4 is the current score, (5 WINS - 1 LOSS).