### PR TITLE
Fix misspells in documentation macros 

### DIFF
--- a/docs/projects/hot-or-cold.md
+++ b/docs/projects/hot-or-cold.md
@@ -4,7 +4,7 @@
 
 ### ~avatar avatar
 
-Find the hidden @boarname@ before the other players!
+Find the hidden @boardname@ before the other players!
 
 ### ~
 

--- a/docs/projects/wallet/make.md
+++ b/docs/projects/wallet/make.md
@@ -167,7 +167,7 @@ That's it! You have an @boardname@ wallet!
 
 ## Protecting those buttons!
 
-The buttons of the @boarname@ are left vulnerable to being ripped out.
+The buttons of the @boardname@ are left vulnerable to being ripped out.
 
 ![](/static/mb/projects/wallet/rug1.jpg)
 


### PR DESCRIPTION
Just a couple of small misspells that caused the documentation html output to have "unknown macro" written.