### PR TITLE
[Accessibility] Fixed an issue where the accessibility of the Pin was broken and was breaking the simulator.

### DIFF
--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -3,6 +3,7 @@ namespace pxsim.input {
         let pin = getPin(pinId);
         if (!pin) return;
         pin.isTouched();
+        runtime.queueDisplayUpdate();
         pxtcore.registerWithDal(pin.id, DAL.MICROBIT_BUTTON_EVT_CLICK, handler);
     }
 
@@ -10,6 +11,7 @@ namespace pxsim.input {
         let pin = getPin(pinId);
         if (!pin) return;
         pin.isTouched();
+        runtime.queueDisplayUpdate();
         pxtcore.registerWithDal(pin.id, DAL.MICROBIT_BUTTON_EVT_UP, handler);
     }
 

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1,7 +1,10 @@
 namespace pxsim.visuals {
     const MB_STYLE = `
         svg.sim {
-            margin-bottom:1em;
+            box-sizing: border-box;
+            width: 100%;
+            height: 100%;
+            display: block;
         }
         svg.sim.grayscale {
             -moz-filter: grayscale(1);


### PR DESCRIPTION
Fixed an issue where while using only the A, B button and Pin (but no thermometer or light level) in the microbit simulator, a space/padding was moving the simulator.
After fixing this issue, the tag used as an aria-live was visible, so I hidden it too.
Finally, I fixed an issue where the simulator's UI was not correctly displayed at loading on FireFox while using only the A, B button and Pin (but no thermometer or light level). It had an impact on tabbing into the Pin.

This fix is linked to pxt-core [https://github.com/Microsoft/pxt/pull/2591](https://github.com/Microsoft/pxt/pull/2591)