### PR TITLE
Add eventTimestamp and eventValue to pxsim.control

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "semantic-ui-less": "^2.2.4"
   },
   "dependencies": {
-    "pxt-core": "0.12.103"
+    "pxt-core": "0.12.104"
   }
 }

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -65,6 +65,14 @@ namespace pxsim.control {
         // TODO mode?
         board().bus.queue(id, evid)
     }
+
+    export function eventTimestamp() {
+        return board().bus.getLastEventTime()
+    }
+
+    export function eventValue() {
+        return board().bus.getLastEvent()
+    }
 }
 
 namespace pxsim.pxtcore {

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -71,7 +71,7 @@ namespace pxsim.control {
     }
 
     export function eventValue() {
-        return board().bus.getLastEvent()
+        return board().bus.getLastEventValue()
     }
 }
 


### PR DESCRIPTION
In conjunction with PR https://github.com/Microsoft/pxt/pull/2615, resolves issue https://github.com/Microsoft/pxt/issues/395.