### PR TITLE
Simulator was not rendering correctly at loading on Firefox

### DIFF
--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -3,6 +3,7 @@ namespace pxsim.input {
         let pin = getPin(pinId);
         if (!pin) return;
         pin.isTouched();
+        runtime.queueDisplayUpdate(); 
         pxtcore.registerWithDal(pin.id, DAL.MICROBIT_BUTTON_EVT_CLICK, handler);
     }
 
@@ -10,6 +11,7 @@ namespace pxsim.input {
         let pin = getPin(pinId);
         if (!pin) return;
         pin.isTouched();
+        runtime.queueDisplayUpdate(); 
         pxtcore.registerWithDal(pin.id, DAL.MICROBIT_BUTTON_EVT_UP, handler);
     }
 


### PR DESCRIPTION
Fixed an issue where the simulator's UI was not rendering correctly on FireFox at loading. This fix is here to prepare the support of accessibility in the simulator.