### PR TITLE
Add Kitronik (KitronikLtd) as an approved org

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,7 +13,6 @@
             "sparkfun/pxt-gamer-bit",
             "sparkfun/pxt-moto-bit",
             "sparkfun/pxt-weather-bit",
-            "KitronikLtd/pxt-kitronik-servo-lite",
             "Tinkertanker/pxt-ssd1306-microbit",
             "minodekit/pxt-minode"
         ],

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -2,7 +2,8 @@
     "packages": {
         "approvedOrgs": [
             "Microsoft",
-            "microbit-foundation"
+            "microbit-foundation",
+            "KitronikLtd"
         ],
         "approvedRepos": [
             "CoderDojoOlney/pxt-olney",


### PR DESCRIPTION
Kitronik work closely with the foundation and have a number of packages, and they understand the requirements for alpha/beta release quality so we're adding them as an approved org.