### PR TITLE
Fixed an issue where the Game of Life menu item was not appearing

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -35,7 +35,7 @@
     * [Plot light level](/examples/plot-light-level)
     * [Plot analog pin](/examples/plot-analog-pin)
     * [Servo Calibrator](/examples/servo-calibrator)
-    * [Game of Life](/examples/gameofLife)        
+    * [Game of Life](/examples/gameofLife)
 
 ## Examples #examples
 


### PR DESCRIPTION
Fixed an issue where the Game of Life menu item was not appearing in the documentation side bar.

The fix itself consisted to remove the white spaces in the MD file.

![capture](https://user-images.githubusercontent.com/3747805/29044085-aae297e0-7b72-11e7-8202-8b20f6d537c2.PNG)

Fixed issue : [https://github.com/Microsoft/pxt/issues/2649](https://github.com/Microsoft/pxt/issues/2649)