### PR TITLE
Fix beginMelody 

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -181,6 +181,7 @@
   "music": "Generation of music tones.",
   "music.beat": "Returns the duration of a beat in milli-seconds",
   "music.beginMelody": "Starts playing a melody.\nNotes are expressed as a string of characters with this format: NOTE[octave][:duration]",
+  "music.beginMelody|param|melodyArray": "the melody array to play, eg: ['g5:1']",
   "music.beginMelody|param|options": "melody options, once / forever, in the foreground / background",
   "music.builtInMelody": "Gets the melody array of a built-in melody.",
   "music.changeTempoBy": "Change the tempo by the specified amount",

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -307,13 +307,13 @@ namespace music {
     /**
      * Starts playing a melody.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param melody the melody array to play, eg: ['g5:1']
+     * @param melodyArray the melody array to play, eg: ['g5:1']
      * @param options melody options, once / forever, in the foreground / background
      */
     //% help=music/begin-melody weight=60 blockGap=8
     //% blockId=device_start_melody block="start melody %melody=device_builtin_melody| repeating %options"
     //% parts="headphone"
-    export function beginMelody(melodyArray: string[], options: MelodyOptions = MelodyOptions.Once) {
+    export function beginMelody(melodyArray: string[], options: MelodyOptions = 1) {
         init();
         if (currentMelody != undefined) {
             if (((options & MelodyOptions.OnceInBackground) == 0)


### PR DESCRIPTION
Fixed begin melody API so it doesn't complain about a compiler error, and uses the default value.

```
music.beginMelody([])
```
was complaining with this error: 
![screen shot 2017-08-22 at 5 59 05 pm](https://user-images.githubusercontent.com/16690124/29594117-99f52482-8763-11e7-8150-8b52a61d00f1.png)

This is because we don't support ENUM defaults yet..