### PR TITLE
[Accessibility] Fixed the focus outline

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -140,7 +140,15 @@ namespace pxsim.visuals {
             stroke-width: 2px;
         }
         *:focus {
-            outline: 2px solid white;
+            outline: none;
+        }
+        *:focus .sim-button-outer,
+        .sim-pin:focus,
+        .sim-thermometer:focus,
+        .sim-shake:focus,
+        .sim-light-level-button:focus {
+            stroke: #4D90FE !important;
+            stroke-width: 3px !important;
         }
         .no-drag {
             user-drag: none;
@@ -402,7 +410,7 @@ namespace pxsim.visuals {
         private updateGestures() {
             let state = this.board;
             if (state.accelerometerState.useShake && !this.shakeButton) {
-                this.shakeButton = svg.child(this.g, "circle", { cx: 380, cy: 100, r: 16.5 }) as SVGCircleElement;
+                this.shakeButton = svg.child(this.g, "circle", { cx: 380, cy: 100, r: 16.5, class: "sim-shake" }) as SVGCircleElement;
                 accessibility.makeFocusable(this.shakeButton);
                 svg.fill(this.shakeButton, this.props.theme.virtualButtonUp)
                 this.shakeButton.addEventListener(pointerEvents.down, ev => {


### PR DESCRIPTION
Fixed the outline color of the simulator's component + fixed an issue where in Edge and IE there was no outline.

The basic issue was that Edge doesn't support the outline on SVG : [https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12527853/](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12527853/)

But SVG doesn't support border too. So because of that, I used a stroke.

Let me know if the fix is OK. I tried to do it quickly so it's ready for today's demo. Also I will need to apply a similar change for Adafruit because the issue probably exists too.

When all the components have the focus, it looks like this : 

![capture](https://user-images.githubusercontent.com/3747805/29680996-3859a690-88bb-11e7-97e7-b4d0b6cbe233.PNG)
