### PR TITLE
Add firmware update note and page.

### DIFF
--- a/docs/device/firmware.md
+++ b/docs/device/firmware.md
@@ -1,0 +1,11 @@
+# Firmware
+
+Occasionally, changes and improvements to the system software (firmware) on the @boardname@ are needed. Updates to the firmware are made by the [micro:bit Education Foundation](http://microbit.org/about).
+
+## Do I need an update?
+
+Changes to the firmware don't happen very often. You probably don't need to update it for your @boardname@ if everything is working alright. Sometimes there's a problem with a certain part of the board not working right or it has trouble connecting to your computer or other device. In those cases, a firmware update may include a fix for the problem.
+
+## Getting a firmware update
+
+Instructions for updating the firmware are shown on the **[firmware upgrade](https://support.microbit.org/support/solutions/articles/19000019131-how-to-upgrade-the-firmware-on-the-micro-bit)** support page at microbit.org.

--- a/docs/device/serial.md
+++ b/docs/device/serial.md
@@ -34,6 +34,7 @@ If you are running a Windows version earlier than 10, you must install a device 
 * Follow the instructions at https://docs.mbed.com/docs/mbed-os-handbook/en/latest/getting_started/what_need/ to install the device driver.
 
 ## ~
+Also, if you don't see the serial port as one of your computer's devices, you might need to [update the firmware](/device/firmware) on the @boardname@. Find the device name for the attached serial port in the following instructions for your operating system.
 
 ### Chrome Extension
 


### PR DESCRIPTION
Addresses https://github.com/Microsoft/pxt/issues/2896.

- [x] Small note in _/device/serial.md_ mentioning that a firmware upgrade might be needed to get the serial port to show up.
- [x] Added _/device/firmware.md_ as a direct to the microbit.org support page for the update.

I can add more specific firmware update instructions to the new **firmware** page if necessary. The microbit.org page explains this fairly well though.


