### PR TITLE
[Accessibility] Fixed the color contrast of the tutorial

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -21,7 +21,6 @@
 @green: #107C10;
 
 /* Microbit.org colors */
-@orange: #ff8b27;
 @purple: #6633cc;
 
 @pageBackground: #fff;


### PR DESCRIPTION
Fixed the Orange color contrast of the tutorial by using the Microsoft color.

Related issue : [https://github.com/Microsoft/pxt/issues/2535](https://github.com/Microsoft/pxt/issues/2535)
Related PR : [https://github.com/Microsoft/pxt/pull/2931](https://github.com/Microsoft/pxt/pull/2931)

![untitled](https://user-images.githubusercontent.com/3747805/30351797-fa7e7636-97d1-11e7-950b-7bf37b77acbb.png)
