### PR TITLE
Game score fix

### DIFF
--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -5,7 +5,7 @@ declare namespace basic {
 }
 
 
-    declare enum Button {
+    declare const enum Button {
     A = 1,  // MICROBIT_ID_BUTTON_A
     B = 2,  // MICROBIT_ID_BUTTON_B
     //% block="A+B"
@@ -13,7 +13,7 @@ declare namespace basic {
     }
 
 
-    declare enum Dimension {
+    declare const enum Dimension {
     //% block=x
     X = 0,
     //% block=y
@@ -25,7 +25,7 @@ declare namespace basic {
     }
 
 
-    declare enum Rotation {
+    declare const enum Rotation {
     //% block=pitch
     Pitch = 0,
     //% block=roll
@@ -33,14 +33,14 @@ declare namespace basic {
     }
 
 
-    declare enum TouchPin {
+    declare const enum TouchPin {
     P0 = 7,  // MICROBIT_ID_IO_P0
     P1 = 8,  // MICROBIT_ID_IO_P1
     P2 = 9,  // MICROBIT_ID_IO_P2
     }
 
 
-    declare enum AcceleratorRange {
+    declare const enum AcceleratorRange {
     /**
      * The accelerator measures forces up to 1 gravity
      */
@@ -64,7 +64,7 @@ declare namespace basic {
     }
 
 
-    declare enum Gesture {
+    declare const enum Gesture {
     /**
      * Raised when shaken
      */
@@ -123,7 +123,7 @@ declare namespace basic {
     }
 
 
-    declare enum MesDpadButtonInfo {
+    declare const enum MesDpadButtonInfo {
     //% block="A down"
     ADown = 1,  // MES_DPAD_BUTTON_A_DOWN
     //% block="A up"
@@ -165,7 +165,7 @@ declare namespace input {
      * How to create the event.
      */
 
-    declare enum EventCreationMode {
+    declare const enum EventCreationMode {
     /**
      * MicroBitEvent is initialised, and no further processing takes place.
      */
@@ -177,7 +177,7 @@ declare namespace input {
     }
 
 
-    declare enum EventBusSource {
+    declare const enum EventBusSource {
     //% blockIdentity="control.eventSourceId"
     MICROBIT_ID_BUTTON_A = 1,  // MICROBIT_ID_BUTTON_A
     //% blockIdentity="control.eventSourceId"
@@ -239,7 +239,7 @@ declare namespace input {
     }
 
 
-    declare enum EventBusValue {
+    declare const enum EventBusValue {
     //% blockIdentity="control.eventValueId"
     MICROBIT_EVT_ANY = 0,  // MICROBIT_EVT_ANY
     //% blockIdentity="control.eventValueId"
@@ -367,7 +367,7 @@ declare namespace control {
 }
 
 
-    declare enum DisplayMode {
+    declare const enum DisplayMode {
     //% block="black and white"
     BackAndWhite = 0,  // DISPLAY_MODE_BLACK_AND_WHITE
     //% block="greyscale"
@@ -378,7 +378,7 @@ declare namespace led {
 }
 
 
-    declare enum DigitalPin {
+    declare const enum DigitalPin {
     P0 = 7,  // MICROBIT_ID_IO_P0
     P1 = 8,  // MICROBIT_ID_IO_P1
     P2 = 9,  // MICROBIT_ID_IO_P2
@@ -401,7 +401,7 @@ declare namespace led {
     }
 
 
-    declare enum AnalogPin {
+    declare const enum AnalogPin {
     P0 = 7,  // MICROBIT_ID_IO_P0
     P1 = 8,  // MICROBIT_ID_IO_P1
     P2 = 9,  // MICROBIT_ID_IO_P2
@@ -437,7 +437,7 @@ declare namespace led {
     }
 
 
-    declare enum PulseValue {
+    declare const enum PulseValue {
     //% block=high
     High = 4,  // MICROBIT_PIN_EVT_PULSE_HI
     //% block=low
@@ -445,7 +445,7 @@ declare namespace led {
     }
 
 
-    declare enum PinPullMode {
+    declare const enum PinPullMode {
     //% block="down"
     PullDown = 0,
     //% block="up"
@@ -455,7 +455,7 @@ declare namespace led {
     }
 
 
-    declare enum PinEventType {
+    declare const enum PinEventType {
     //% block="edge"
     Edge = 1,  // MICROBIT_PIN_EVENT_ON_EDGE
     //% block="pulse"
@@ -467,7 +467,7 @@ declare namespace led {
     }
 
 
-    declare enum SerialPin {
+    declare const enum SerialPin {
     P0 = 7,  // MICROBIT_ID_IO_P0
     P1 = 8,  // MICROBIT_ID_IO_P1
     P2 = 9,  // MICROBIT_ID_IO_P2
@@ -480,7 +480,7 @@ declare namespace led {
     }
 
 
-    declare enum BaudRate {
+    declare const enum BaudRate {
     //% block=115200
     BaudRate115200 = 115200,
     //% block=57600
@@ -508,7 +508,7 @@ declare namespace led {
     }
 
 
-    declare enum Delimiters {
+    declare const enum Delimiters {
     //% block="new line"
     NewLine = 1,
     //% block=","
@@ -526,7 +526,7 @@ declare namespace serial {
 }
 
 
-    declare enum NumberFormat {
+    declare const enum NumberFormat {
     Int8LE = 1,
     UInt8LE = 2,
     Int16LE = 3,

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -73,12 +73,16 @@ namespace game {
             _backgroundAnimation = true;
             control.inBackground(() => {
                 led.stopAnimation();
-                led.setDisplayMode(DisplayMode.BackAndWhite);
+                const dm = led.displayMode();
+                if (dm != DisplayMode.BackAndWhite)
+                    led.setDisplayMode(DisplayMode.BackAndWhite);
                 basic.showAnimation(`0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0
     0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
     0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
     0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0`, 20);
+                if (dm != DisplayMode.BackAndWhite)
+                    led.setDisplayMode(dm);
                 _backgroundAnimation = false;
             });
         }
@@ -763,7 +767,8 @@ namespace game {
             return;
         }
         // ensure greyscale mode
-        if (led.displayMode() != DisplayMode.Greyscale)
+        const dm = led.displayMode();
+        if (dm != DisplayMode.Greyscale)            
             led.setDisplayMode(DisplayMode.Greyscale);
         // render sprites
         const now = input.runningTime();

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -35,6 +35,7 @@ namespace game {
     let _img: Image;
     let _sprites: LedSprite[];
     let _paused: boolean = false;
+    let _backgroundAnimation = false; // indicates if an auxiliary animation (and fiber) is already running
 
     /**
      * Creates a new LED sprite pointing to the right.
@@ -68,7 +69,8 @@ namespace game {
     //% parts="ledmatrix"
     export function addScore(points: number): void {
         setScore(_score + points);
-        if (!_paused)
+        if (!_paused && !_backgroundAnimation) {
+            _backgroundAnimation = true;
             control.inBackground(() => {
                 led.stopAnimation();
                 basic.showAnimation(`0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0
@@ -76,7 +78,9 @@ namespace game {
     0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
     0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0`, 20);
+                _backgroundAnimation = false;
             });
+        }
     }
 
     /**
@@ -731,22 +735,22 @@ namespace game {
     }
 
     function init(): void {
-        if (_img == null) {
-            _img = images.createImage(
-                `0 0 0 0 0
+        if (_img) return;
+        const img = images.createImage(
+`0 0 0 0 0
 0 0 0 0 0
 0 0 0 0 0
 0 0 0 0 0
 0 0 0 0 0`);
-            _sprites = (<LedSprite[]>[]);
-            basic.forever(() => {
-                basic.pause(30);
-                plot();
-                if (game.isGameOver()) {
-                    basic.pause(600);
-                }
-            });
-        }
+        _sprites = (<LedSprite[]>[]);
+        basic.forever(() => {
+            basic.pause(30);
+            plot();
+            if (game.isGameOver()) {
+                basic.pause(600);
+            }
+        });
+        _img = img;
     }
 
     /**

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -73,6 +73,7 @@ namespace game {
             _backgroundAnimation = true;
             control.inBackground(() => {
                 led.stopAnimation();
+                led.setDisplayMode(DisplayMode.BackAndWhite);
                 basic.showAnimation(`0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0
     0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
     0 0 1 0 0 0 1 1 1 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
@@ -765,7 +766,7 @@ namespace game {
         if (led.displayMode() != DisplayMode.Greyscale)
             led.setDisplayMode(DisplayMode.Greyscale);
         // render sprites
-        let now = input.runningTime();
+        const now = input.runningTime();
         _img.clear();
         for (let i = 0; i < _sprites.length; i++) {
             _sprites[i]._plot(now);

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -758,7 +758,7 @@ namespace game {
      */
     //% parts="ledmatrix"
     function plot(): void {
-        if (game.isGameOver() || game.isPaused() || !_img) {
+        if (game.isGameOver() || game.isPaused() || !_img || _backgroundAnimation) {
             return;
         }
         // ensure greyscale mode

--- a/libs/devices/enums.d.ts
+++ b/libs/devices/enums.d.ts
@@ -1,7 +1,7 @@
 // Auto-generated. Do not edit.
 
 
-    declare enum MesCameraEvent {
+    declare const enum MesCameraEvent {
     //% block="take photo"
     TakePhoto = 3,  // MES_CAMERA_EVT_TAKE_PHOTO
     //% block="start video capture"
@@ -21,7 +21,7 @@
     }
 
 
-    declare enum MesAlertEvent {
+    declare const enum MesAlertEvent {
     //% block="display toast"
     DisplayToast = 1,  // MES_ALERT_EVT_DISPLAY_TOAST
     //% block="vibrate"
@@ -47,7 +47,7 @@
     }
 
 
-    declare enum MesDeviceInfo {
+    declare const enum MesDeviceInfo {
     //% block="incoming call"
     IncomingCall = 7,  // MES_DEVICE_INCOMING_CALL
     //% block="incoming message"
@@ -65,7 +65,7 @@
     }
 
 
-    declare enum MesRemoteControlEvent {
+    declare const enum MesRemoteControlEvent {
     //% block="play"
     play = 1,  // MES_REMOTE_CONTROL_EVT_PLAY
     //% block="pause"


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt/issues/2837. The fix is to only allow a single "add score" animation running to avoid allocating multiple fibers and running out of memory.