### PR TITLE
Add check in RefObject::decr(); Fix decr() in removeAt 

### DIFF
--- a/libs/core/pxt.cpp
+++ b/libs/core/pxt.cpp
@@ -394,10 +394,7 @@ namespace pxt {
 
     uint32_t RefCollection::removeAt(int i)
     {
-      if (isRef())
-      {
-        decr(head.get(i));
-      }
+      // no decr() - we return the result
       return head.remove(i);
     }
 
@@ -464,7 +461,8 @@ namespace pxt {
     {
       int idx = indexOf(x, 0);
       if (idx >= 0) {
-        removeAt(idx);
+        uint32_t elt = removeAt(idx);
+        if (isRef()) decr(elt);
         return 1;
       }
       return 0;

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -160,6 +160,7 @@ namespace pxt {
     inline void unref()
     {
       //printf("DECR "); this->print();
+      check(refcnt > 0, ERR_REF_DELETED);
       refcnt -= 2;
       if (refcnt == 0) {
         destroy();


### PR DESCRIPTION
https://github.com/Microsoft/pxt/issues/3093

The added check may unmask some problems we have not seen before, but not very likely.