### PR TITLE
Apply gridpicker

### DIFF
--- a/libs/core/icons.ts
+++ b/libs/core/icons.ts
@@ -274,6 +274,9 @@ namespace images {
     //% weight=50 blockGap=8
     //% help=images/icon-image
     //% blockId=builtin_image block="icon image %i"
+    //% i.fieldEditor="gridpicker"
+    //% i.fieldOptions.width="400" i.fieldOptions.columns="5"
+    //% i.fieldOptions.itemColour="black" i.fieldOptions.tooltips="true"
     export function iconImage(i: IconNames): Image {
         switch (i) {
             case IconNames.Heart: return images.createImage(`

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -148,6 +148,10 @@ namespace serial {
     //% help=serial/redirect-to
     //% blockId=serial_redirect block="serial|redirect to|TX %tx|RX %rx|at baud rate %rate"
     //% blockExternalInputs=1
+    //% tx.fieldEditor="gridpicker" tx.fieldOptions.columns=3
+    //% tx.fieldOptions.tooltips="false"
+    //% rx.fieldEditor="gridpicker" rx.fieldOptions.columns=3
+    //% rx.fieldOptions.tooltips="false"
     void redirect(SerialPin tx, SerialPin rx, BaudRate rate) {
       MicroBitPin* txp = getPin(tx); if (!tx) return;
       MicroBitPin* rxp = getPin(rx); if (!rx) return;

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -821,7 +821,11 @@ declare namespace serial {
     //% weight=10
     //% help=serial/redirect-to
     //% blockId=serial_redirect block="serial|redirect to|TX %tx|RX %rx|at baud rate %rate"
-    //% blockExternalInputs=1 shim=serial::redirect
+    //% blockExternalInputs=1
+    //% tx.fieldEditor="gridpicker" tx.fieldOptions.columns=3
+    //% tx.fieldOptions.tooltips="false"
+    //% rx.fieldEditor="gridpicker" rx.fieldOptions.columns=3
+    //% rx.fieldOptions.tooltips="false" shim=serial::redirect
     function redirect(tx: SerialPin, rx: SerialPin, rate: BaudRate): void;
 }
 


### PR DESCRIPTION
Apply grid picker to "icon image" and "serial redirect" blocks.

Fixes https://github.com/Microsoft/pxt/issues/3175