### PR TITLE
Bring 'approval' back into visible docs

### DIFF
--- a/docs/packages/approval.md
+++ b/docs/packages/approval.md
@@ -1,8 +1,10 @@
+# @extends
+
 ## #approval
 
 ## ~ hint
 
-All packages need to be approved by the Micro:bit Foundation before being available in the web editor. See
+All packages need approval by the Micro:bit Foundation before being available in the web editor. See:
 
 https://support.microbit.org/solution/articles/19000054952-package-approval
 

--- a/docs/packages/build-your-own.md
+++ b/docs/packages/build-your-own.md
@@ -1,0 +1,13 @@
+# Building your own package
+
+In MakeCode you can create new custom blocks to use in the editor and include them in your projects. You do this by building a package. Packages are really useful for publishing drivers for accessories and hardware, as well as adding in new software features.
+
+Only packages on the 'approved package list' are available to users directly to add into the MakeCode editor at https://makecode.microbit.org.
+
+## Publishing packages
+
+You publish a package on GitHub and request **[approval](./approval)** for it if necessary.
+
+## How do I start building a package?
+
+Go to the MakeCode package documentation and see the [getting started](https://makecode.com/packages/getting-started) page.


### PR DESCRIPTION
- [x] Make a copy of _build-your-own.md_ specific for mbit.
- [x] Link in an updated _approval.md_ for Foundation approval note.