### PR TITLE
renamed Blockytalky and added tinkertanker

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -3,7 +3,8 @@
         "approvedOrgs": [
             "Microsoft",
             "microbit-foundation",
-            "KitronikLtd"
+            "KitronikLtd",
+            "tinkertanker"
         ],
         "approvedRepos": [
             "CoderDojoOlney/pxt-olney",
@@ -13,9 +14,8 @@
             "sparkfun/pxt-gamer-bit",
             "sparkfun/pxt-moto-bit",
             "sparkfun/pxt-weather-bit",
-            "Tinkertanker/pxt-ssd1306-microbit",
             "minodekit/pxt-minode",
-            "LaboratoryForPlayfulComputation/pxt-blockytalkybluetooth"
+            "LaboratoryForPlayfulComputation/pxt-blockytalkyBLE"
         ],
         "preferredRepos": [
             "Microsoft/pxt-neopixel"


### PR DESCRIPTION
1) At request of Lab for playful computation, pxt-blockytalkyBLE has been changed to reflect how it is drawn in the editor.
2) tinkertanker is added as an approved organisation after completing micro:bit process. They are developing a range of packages and understand the dev/beta process for development.