### PR TITLE
Remove 'showAnimation' from Basic category page

### DIFF
--- a/docs/reference/basic.md
+++ b/docs/reference/basic.md
@@ -19,13 +19,6 @@ basic.forever(() => {
 });
 basic.pause(100);
 basic.showArrow(ArrowNames.North);
-basic.showAnimation(`
-. . . . .
-. . . . .
-. . # . .
-. . . . .
-. . . . .
-`);
 ```
 
 ## See also


### PR DESCRIPTION
The showAnimation function is not defined as a block in basic.cpp. The card renders no block and forms an incorrect help path.