### PR TITLE
Reconnect the reused packetIO when deploying

### DIFF
--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -83,8 +83,16 @@ namespace pxt.editor {
                     packetIoPromise = null;
                     return Promise.reject(err);
                 });
+            return packetIoPromise;
+        } else {
+            let packetIo: pxt.HF2.PacketIO;
+            return packetIoPromise
+                .then((io) => {
+                    packetIo = io;
+                    return io.reconnectAsync();
+                })
+                .then(() => packetIo);
         }
-        return packetIoPromise;
     }
 
     let previousDapWrapper: DAPWrapper;


### PR DESCRIPTION
Hadn't tested my previous changes correctly. When reusing a previous PacketIO we have to make sure we reconnect, otherwise only the 1st deploy succeeds, subsequent ones hang forever