### PR TITLE
Fix brightness led visuals offset bug in simulator

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -396,6 +396,7 @@ namespace pxsim.visuals {
                     const transfrom = imgbr > 0 ? imgbr / 255 * 0.4 + 0.6 : 0;
                     sel.style.opacity = (opacity / 255) + "";
                     if (transfrom > 0) {
+                        (sel.style as any).transformBox = 'fill-box';
                         sel.style.transformOrigin = '50% 50%';
                         sel.style.transform = `scale(${transfrom})`;
                     }


### PR DESCRIPTION
Fix led brightness visuals where it's offset on latest Chrome, Firefox and Edge. 
Fix was to add an extra attribute "transform-box" equal to "fill-box". 

Fixes https://github.com/Microsoft/pxt/issues/3702
Fixes https://github.com/Microsoft/pxt/issues/2700
