### PR TITLE
make example code work with blocks

### DIFF
--- a/docs/reference/input/pin-is-pressed.md
+++ b/docs/reference/input/pin-is-pressed.md
@@ -32,9 +32,9 @@ This program shows `1` if `P0` is pressed, and `0` if `P0` is not pressed:
 ```blocks
 basic.forever(() => {
     if (input.pinIsPressed(TouchPin.P0)) {
-        basic.showNumber(1, 150)
+        basic.showNumber(1)
     } else {
-        basic.showNumber(0, 150)
+        basic.showNumber(0)
     }
 })
 ```


### PR DESCRIPTION
The example code used javascript that can't be made in blocks. After this change it can be reproduced in blocks.