### PR TITLE
Add local storage prefixes for different major versions

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -401,6 +401,9 @@
         ],
         "monacoColors": {
             "editor.background": "#ecf0f1"
+        },
+        "browserDbPrefixes": {
+            "1": "v1"
         }
     }
 }


### PR DESCRIPTION
Requires the changes in https://github.com/Microsoft/pxt/pull/4553, which will require a bump of pxt-core dependency in v1

v0 does not need to change anything, as it is not impacted and will continue to work normally

Fixes #956 