### PR TITLE
Fix packages urls

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -75,11 +75,11 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
     "cardType": "package"
 }, {
     "name": "Pimoroni Envirobit",
-    "url": "pkg/pimoroni/pxt-envirobit",
+    "url": "/pkg/pimoroni/pxt-envirobit",
     "cardType": "package"
 }, {
     "name": "MakerBit",
-    "url": "pkg/1010Technologies/pxt-makerbit",
+    "url": "/pkg/1010Technologies/pxt-makerbit",
     "cardType": "package"
 }]
 ```


### PR DESCRIPTION
I assume the missing backslash is responsible for not showing the packages icons at https://makecode.microbit.org/packages