### PR TITLE
Fixing parseInt()

### DIFF
--- a/libs/core/core.cpp
+++ b/libs/core/core.cpp
@@ -239,6 +239,9 @@ double mystrtod(const char *p, char **endp) {
         int pw = strtol(p, endp, 10);
         v *= p10(pw);
     }
+    else {
+        *endp = (char *) p;
+    }
 
     return v;
 }
@@ -626,7 +629,7 @@ void mycvt(double d, char *buf) {
     if (*buf == '.')
         buf--;
     buf++;
-    
+
     if (e != 1) {
         *buf++ = 'e';
         itoa(e, buf);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/942

`parseInt()` was always returning `NaN` for integer strings because our implementation of `strtod` wasn't updating the end pointer
