### PR TITLE
Missing simulator functions and behavior

### DIFF
--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -35,6 +35,10 @@ namespace pxsim.basic {
 namespace pxsim.control {
     export var inBackground = thread.runInBackground;
 
+    export function createBuffer(sz: number) {
+        return pxsim.BufferMethods.createBuffer(sz)
+    }
+
     export function reset() {
         U.userError("reset not implemented in simulator yet")
     }

--- a/sim/state/radio.ts
+++ b/sim/state/radio.ts
@@ -6,6 +6,11 @@ namespace pxsim {
         time: number;
     }
 
+    // Extends interface in pxt-core
+    export interface SimulatorRadioPacketPayload {
+        bufferData?: Uint8Array;
+    }
+
     export class RadioDatagram {
         datagram: PacketBuffer[] = [];
         lastReceived: PacketBuffer = RadioDatagram.defaultPacket();
@@ -24,7 +29,7 @@ namespace pxsim {
             const b = board();
             Runtime.postMessage(<SimulatorRadioPacketMessage>{
                 type: "radiopacket",
-                rssi: 70, // Not yet supported
+                rssi: -42, // -42 is the strongest signal
                 serial: b.radioState.bus.transmitSerialNumber ? pxsim.control.deviceSerialNumber() : 0,
                 time: new Date().getTime(),
                 payload
@@ -149,13 +154,12 @@ namespace pxsim.radio {
 
     export function sendBuffer(buf: RefBuffer): void {
         if (!buf) return;
-        
+
         const data = buf.data.slice(0, 18);
         board().radioState.bus.datagram.send({
             type: PacketPayloadType.STRING,
             groupId: board().radioState.groupId,
-            // TODO: (microbit master)
-            //bufferData: data
+            bufferData: data
         });
     }
 
@@ -212,10 +216,9 @@ namespace pxsim.radio {
         return initString(board().radioState.bus.datagram.lastReceived.payload.stringData || "");
     }
 
-    // TODO: (microbit master)
-    // export function receivedBuffer(): RefBuffer {
-    //     return new RefBuffer(board().radioState.bus.datagram.lastReceived.payload.bufferData || new Uint8Array(0))
-    // }
+    export function receivedBuffer(): RefBuffer {
+        return new RefBuffer(board().radioState.bus.datagram.lastReceived.payload.bufferData || new Uint8Array(0))
+    }
 
     export function receivedTime(): number {
         return board().radioState.bus.datagram.lastReceived.time;

--- a/sim/state/serial.ts
+++ b/sim/state/serial.ts
@@ -57,4 +57,8 @@ namespace pxsim.serial {
     export function redirectToUSB() {
         // TODO
     }
+
+    export function readBuffer(length: number) {
+        return pins.createBuffer(length);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/733
Fixes https://github.com/Microsoft/pxt-microbit/issues/861


Adding a few missing simulator functions. I'm not sure why exactly the buffer stuff was commented out but it works fine. My guess is that it was because the interface is in pxt-core and no one wanted to change it so I changed it here instead of in core.