### PR TITLE
Switch to printChar() so interval is honored

### DIFF
--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -44,8 +44,7 @@ namespace basic {
       } else if (l > 1) {
         uBit.display.scroll(MSTR(text), interval);
       } else {
-        uBit.display.print(text->data[0], interval * 5);
-        fiber_sleep(interval * 5); // TODO remove when display.print() honors the interval arg
+        uBit.display.printChar(text->data[0], interval * 5);
       }
     }
 

--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -45,6 +45,7 @@ namespace basic {
         uBit.display.scroll(MSTR(text), interval);
       } else {
         uBit.display.print(text->data[0], interval * 5);
+        fiber_sleep(interval * 5); // TODO remove when display.print() honors the interval arg
       }
     }
 


### PR DESCRIPTION
Fixes #1059 (workaround)

`uBit.display.print()` ignores the `interval` argument, so use `printChar()` instead.

@jaustin @mmoskal I am not sure of the side effects of this change. It's what we are using for `showNumber()` in v0, so I assume it's ok to use it...

