### PR TITLE
Fixing authoring on a few APIs for Monaco toolbox

### DIFF
--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -687,7 +687,7 @@ namespace game {
          * @param this sprite to delete
          */
         //% weight=59 help=game/delete
-        //% blockId="game_delete_sprite" block="delete %this"
+        //% blockId="game_delete_sprite" block="delete %this(sprite)"
         public delete(): void {
             this._enabled = false;
             if (_sprites.removeElement(this))

--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -64,7 +64,7 @@ void plotImage(Image i, int xOffset = 0) {
  * @param xOffset column index to start displaying the image
  */
 //% help=images/show-image weight=80 blockNamespace=images
-//% blockId=device_show_image_offset block="show image %sprite|at offset %offset" blockGap=8
+//% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset" blockGap=8
 //% parts="ledmatrix" async
 void showImage(Image sprite, int xOffset, int interval = 400) {
     uBit.display.print(MicroBitImage(sprite->img), -xOffset, 0, 0, interval);
@@ -88,7 +88,7 @@ void plotFrame(Image i, int xOffset) {
  */
 //% help=images/scroll-image weight=79 async blockNamespace=images
 //% blockId=device_scroll_image
-//% block="scroll image %sprite|with offset %frameoffset|and interval (ms) %delay"
+//% block="scroll image %sprite(myImage)|with offset %frameoffset|and interval (ms) %delay"
 //% blockGap=8 parts="ledmatrix"
 void scrollImage(Image id, int frameOffset, int interval) {
     MicroBitImage i(id->img);

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -308,7 +308,7 @@ namespace music {
     /**
      * Starts playing a melody.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param melodyArray the melody array to play, eg: Melodies.Dadadadum
+     * @param melodyArray the melody array to play
      * @param options melody options, once / forever, in the foreground / background
      */
     //% help=music/begin-melody weight=60 blockGap=8

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -39,7 +39,7 @@ declare interface Image {
      * @param xOffset column index to start displaying the image
      */
     //% help=images/show-image weight=80 blockNamespace=images
-    //% blockId=device_show_image_offset block="show image %sprite|at offset %offset" blockGap=8
+    //% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset" blockGap=8
     //% parts="ledmatrix" async interval.defl=400 shim=ImageMethods::showImage
     showImage(xOffset: int32, interval?: int32): void;
 
@@ -58,7 +58,7 @@ declare interface Image {
      */
     //% help=images/scroll-image weight=79 async blockNamespace=images
     //% blockId=device_scroll_image
-    //% block="scroll image %sprite|with offset %frameoffset|and interval (ms) %delay"
+    //% block="scroll image %sprite(myImage)|with offset %frameoffset|and interval (ms) %delay"
     //% blockGap=8 parts="ledmatrix" shim=ImageMethods::scrollImage
     scrollImage(frameOffset: int32, interval: int32): void;
 


### PR DESCRIPTION
Fixes a few bugs:
 * In the game category: `sprite.delete()` was setting the default instance name to `this` 
 * In the image category: the default instance name is `sprite` which is confusing next to the game category which has a class named sprite
 * In the music category, the default value for `beginMelody()` was invalid and breaking the Monaco toolbox's snippet