### PR TITLE
Slightly adjust non-advanced category weights

### DIFF
--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -4,7 +4,7 @@
 /**
  * Provides access to basic micro:bit functionality.
  */
-//% color=#0078D7 weight=100 icon="\uf00a"
+//% color=#0078D7 weight=116 icon="\uf00a"
 namespace basic {
 
     /**

--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -158,7 +158,7 @@ enum class MesDpadButtonInfo {
     _4Up = MES_DPAD_BUTTON_4_UP,
 };
 
-//% color=#B4009E weight=99 icon="\uf192"
+//% color=#B4009E weight=111 icon="\uf192"
 namespace input {
     /**
      * Do something when a button (A, B or both A+B) is pushed down and released again.
@@ -372,8 +372,8 @@ namespace input {
      */
     //% help=input/calibrate-compass advanced=true
     //% blockId="input_compass_calibrate" block="calibrate compass"
-    void calibrateCompass() { 
-        uBit.compass.calibrate();        
+    void calibrateCompass() {
+        uBit.compass.calibrate();
     }
 
     /**

--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -1,7 +1,7 @@
 /**
  * Events and data from sensors
  */
-//% color=#B4009E weight=99 icon="\uf192"
+//% color=#B4009E weight=111 icon="\uf192"
 namespace input {
     /**
      * Attaches code to run when the screen is facing up.

--- a/libs/core/led.cpp
+++ b/libs/core/led.cpp
@@ -8,7 +8,7 @@ enum class DisplayMode_ {
     // TODO DISPLAY_MODE_BLACK_AND_WHITE_LIGHT_SENSE
 };
 
-//% color=#5C2D91 weight=97 icon="\uf205"
+//% color=#5C2D91 weight=101 icon="\uf205"
 namespace led {
 
     /**

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -1,7 +1,7 @@
 /**
  * Control of the LED screen.
  */
-//% color=#5C2D91 weight=97 icon="\uf205"
+//% color=#5C2D91 weight=101 icon="\uf205"
     namespace led {
 
     // what's the current high value
@@ -31,9 +31,9 @@
             barGraphHighLast = now;
         }
 
-        // normalize lack of data to 0..1 
+        // normalize lack of data to 0..1
         if (barGraphHigh < 16 * Number.EPSILON)
-            barGraphHigh = 1;        
+            barGraphHigh = 1;
 
         // normalize value to 0..1
         const v = value / barGraphHigh;

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -163,7 +163,7 @@ enum MusicEvent {
 /**
  * Generation of music tones.
  */
-//% color=#D83B01 weight=98 icon="\uf025"
+//% color=#D83B01 weight=106 icon="\uf025"
 namespace music {
     let beatsPerMinute: number = 120;
     let freqTable: number[] = [];

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -127,7 +127,7 @@ declare interface Image {
     /**
      * Provides access to basic micro:bit functionality.
      */
-    //% color=#0078D7 weight=100 icon="\uf00a"
+    //% color=#0078D7 weight=116 icon="\uf00a"
 declare namespace basic {
 
     /**
@@ -203,7 +203,7 @@ declare namespace basic {
 
 
 
-    //% color=#B4009E weight=99 icon="\uf192"
+    //% color=#B4009E weight=111 icon="\uf192"
 declare namespace input {
 
     /**
@@ -435,7 +435,7 @@ declare namespace control {
 
 
 
-    //% color=#5C2D91 weight=97 icon="\uf205"
+    //% color=#5C2D91 weight=101 icon="\uf205"
 declare namespace led {
 
     /**


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1080

@jaustin @microbit-mark this might impact some existing packages, in that their category might move up or down a few categories in the toolbox. Nothing dramatic, but it might be worth notifying them. In the end, this is a desirable change, as it will give package authors more control on where their categories are placed in the toolbox.

Only the top 4 non-advanced categories were changed.

Category | Weight before | Weight after
---|---|---
Basic | 100 | 116
Input | 99 | 111
Music | 98 | 106
LED | 97 | 101
Bluetooth | 96 | 96 (no change)
Radio | 96 | 96 (no change)