### PR TITLE
Modify tutorials for single download step

### DIFF
--- a/docs/projects/coin-flipper.md
+++ b/docs/projects/coin-flipper.md
@@ -4,7 +4,7 @@ Let's create a coin flipping program to simulate a real coin toss. We'll use ico
 
 ## Step 1
 
-Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. We'll our coin flipping code in here.
+Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. We'll put our coin flipping code in here.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {

--- a/docs/projects/coin-flipper.md
+++ b/docs/projects/coin-flipper.md
@@ -4,7 +4,7 @@ Let's create a coin flipping program to simulate a real coin toss. We'll use ico
 
 ## Step 1
 
-Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. The coin flip code we add will run when button **A** is pressed.
+Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. The coin flip code we add later will run when button **A** is pressed.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -27,7 +27,7 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 3
 
-Now, put a ``||basic:show icon||`` block inside both the ``||logic:if||`` and the ``||logic:else||``. Pick images to mean ``heads`` and ``tails``.
+Now, put a ``||basic:show icon||`` block inside both the ``||logic:if||`` and the ``||logic:else||``. Pick images to mean ``heads`` and ``tails``. Press button **A** in the simulator to try our coin toss code.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -38,10 +38,6 @@ input.onButtonPressed(Button.A, () => {
     }
 })
 ```
-
-## Step 4
-
-Click ``|Download|`` to transfer your code into your @boardname@. Press button **A** to "toss a coin" and see the result.
 
 ## Step 5
 
@@ -63,4 +59,4 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 6
 
-Click ``|Download|`` to transfer your code to your @boardname@ again and press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!
+If your have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code. Press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!

--- a/docs/projects/coin-flipper.md
+++ b/docs/projects/coin-flipper.md
@@ -4,7 +4,7 @@ Let's create a coin flipping program to simulate a real coin toss. We'll use ico
 
 ## Step 1
 
-Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. The coin flip code we add later will run when button **A** is pressed.
+Get an ``||input:on button A pressed||`` block from the ``||input:Input||`` drawer in the toolbox. We'll our coin flipping code in here.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -27,7 +27,7 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 3
 
-Now, put a ``||basic:show icon||`` block inside both the ``||logic:if||`` and the ``||logic:else||``. Pick images to mean ``heads`` and ``tails``. Press button **A** in the simulator to try our coin toss code.
+Now, put a ``||basic:show icon||`` block inside both the ``||logic:if||`` and the ``||logic:else||``. Pick images to mean ``heads`` and ``tails``.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -39,9 +39,13 @@ input.onButtonPressed(Button.A, () => {
 })
 ```
 
+## Step 4
+
+Press button **A** in the simulator to try our coin toss code.
+
 ## Step 5
 
-You can animate the coin toss to add the feeling of suspense. Place different ``||basic:show icon||`` blocks before the ``||logic:if||`` to show that the coin is flipping before the result appears.
+You can animate the coin toss to add the feeling of suspense. Place different ``||basic:show icon||`` blocks before the ``||logic:if||`` to show that the coin is flipping.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -59,4 +63,8 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 6
 
-If your have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code. Press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!
+If your have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code.
+
+## Step 7
+
+Press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -16,11 +16,7 @@ basic.showLeds(`
 
 ## Step 2
 
-Click ``|Download|`` to transfer your code in your @boardname@!
-
-## Step 3
-
-Place another ``||basic:show leds||`` block under the heart to make it blink.
+Place another ``||basic:show leds||`` block under the heart to make it blink. Check in the simulator to see the blinking heart.
 
 ```blocks
 basic.showLeds(`
@@ -37,7 +33,7 @@ basic.showLeds(`
     . . # . .`);
 ```
 
-## Step 4
+## Step 3
 
 Move the blocks inside the ``||basic:forever||`` to repeat the animation.
 
@@ -59,11 +55,7 @@ basic.forever(() => {
 })
 ```
 
-## Step 5
-
-Click ``|Download|`` to transfer your code in your @boardname@ and watch the hearts flash!
-
-## Step 6
+## Step 4
 
 Place more ``||basic:show leds||`` blocks to create your own animation.
 
@@ -91,6 +83,6 @@ basic.forever(() => {
 })
 ```
 
-## Step 7
+## Step 5
 
-Click ``|Download|`` to transfer your code in your @boardname@!
+If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -16,7 +16,7 @@ basic.showLeds(`
 
 ## Step 2
 
-Place another ``||basic:show leds||`` block under the heart to make it blink. Check in the simulator to see the blinking heart.
+Place another ``||basic:show leds||`` block under the heart to make it blink. Check in the simulator to see the heart blink.
 
 ```blocks
 basic.showLeds(`

--- a/docs/projects/love-meter.md
+++ b/docs/projects/love-meter.md
@@ -4,7 +4,7 @@ Make a love meter, how sweet! The @boardname@ is feeling the love, then sometime
 
 ## Step 1
 
-Let's build a **LOVE METER** machine. Place a ``||input:on pin pressed||`` block to run code when pin ``P0`` is pressed.
+Let's build a **LOVE METER** machine. Place a ``||input:on pin pressed||`` block to run code when pin **0** is pressed. Use ``P0`` from the list of pin inputs.
 
 ```blocks
 input.onPinPressed(TouchPin.P0, () => {
@@ -13,25 +13,28 @@ input.onPinPressed(TouchPin.P0, () => {
 
 ## Step 2
 
-Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from 0 to 100 when pin ``P0`` is pressed. Click on pin **0** in the simulator and see which number is chosen.
+Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from 0 to 100 when pin **0** is pressed.
 
 ```blocks
 input.onPinPressed(TouchPin.P0, () => {
-    basic.showNumber(Math.randomRange(0, 101));
+    basic.showNumber(Math.randomRange(0, 100));
 });
 ```
-
 ## Step 3
+
+Click on pin **0** in the simulator and see which number is chosen.
+
+## Step 4
 
 Show ``"LOVE METER"`` on the screen when the @boardname@ starts.
 
 ```blocks
 basic.showString("LOVE METER");
 input.onPinPressed(TouchPin.P0, () => {
-    basic.showNumber(Math.randomRange(0, 101));
+    basic.showNumber(Math.randomRange(0, 100));
 });
 ```
 
-## Step 4
+## Step 5
 
-Click ``|Download|`` to transfer your code in your @boardname@. Hold the **GND** pin with other hand and press pin **0** with the other hand to trigger this code.
+Click ``|Download|`` to transfer your code in your @boardname@. Hold the **GND** pin with one hand and press pin **0** with the other hand to trigger this code.

--- a/docs/projects/love-meter.md
+++ b/docs/projects/love-meter.md
@@ -10,9 +10,10 @@ Let's build a **LOVE METER** machine. Place a ``||input:on pin pressed||`` block
 input.onPinPressed(TouchPin.P0, () => {
 });
 ```
+
 ## Step 2
 
-Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from 0 to 100 when pin ``P0`` is pressed.
+Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from 0 to 100 when pin ``P0`` is pressed. Click on pin **0** in the simulator and see which number is chosen.
 
 ```blocks
 input.onPinPressed(TouchPin.P0, () => {
@@ -33,4 +34,4 @@ input.onPinPressed(TouchPin.P0, () => {
 
 ## Step 4
 
-Click ``|Download|`` to transfer your code in your @boardname@. Hold the ``GND`` pin with other hand and press pin ``P0`` with the other hand to trigger this code.
+Click ``|Download|`` to transfer your code in your @boardname@. Hold the **GND** pin with other hand and press pin **0** with the other hand to trigger this code.

--- a/docs/projects/smiley-buttons.md
+++ b/docs/projects/smiley-buttons.md
@@ -70,9 +70,5 @@ If you have a @boardname@, connect it to USB and click ``|Download|`` to transfe
 
 ## Step 6
 
-Click ``|Download|`` to transfer your code in your @boardname@ and try pressing button A or B.
-
-## Step 7
-
 Nice! Now go and show it off to your friends!
 

--- a/docs/projects/smiley-buttons.md
+++ b/docs/projects/smiley-buttons.md
@@ -11,7 +11,7 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 2
 
-Place a ``||basic:show leds||`` block inside ``||input:on button pressed||`` to display a smiley on the screen.
+Place a ``||basic:show leds||`` block inside ``||input:on button pressed||`` to display a smiley on the screen. Press the **A** button in the simulator to see the smiley.
 
 ```blocks
 input.onButtonPressed(Button.A, () => { 
@@ -27,10 +27,6 @@ input.onButtonPressed(Button.A, () => {
 
 ## Step 3
 
-Click ``|Download|`` to transfer your code in your @boardname@ and try pressing button **A**.
-
-## Step 4
-
 Add ``||input:on button pressed||`` and ``||basic:show leds||`` blocks to display a frowney when button **B** is pressed.
 
 ```blocks
@@ -45,13 +41,9 @@ input.onButtonPressed(Button.B, () => {
 });
 ```
 
-## Step 5
+## Step 4
 
-Click ``|Download|`` to transfer your code in your @boardname@ and try pressing button A or B.
-
-## Step 6
-
-Add a secret mode where ``A`` and ``B`` are pressed together. In that case, add multiple ``||basic:show leds||`` blocks to create an animation...
+Add a secret mode that happens when **A** and **B** are pressed together. In that case, add multiple ``||basic:show leds||`` blocks to create an animation...
 
 ```blocks
 input.onButtonPressed(Button.AB, () => {
@@ -72,8 +64,15 @@ input.onButtonPressed(Button.AB, () => {
 })
 ```
 
+## Step 5
+
+If you have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code. Press button **A** on your @boardname@. Try button **B** and then **A** and **B** together.
+
+## Step 6
+
+Click ``|Download|`` to transfer your code in your @boardname@ and try pressing button A or B.
+
 ## Step 7
 
-Click ``|Download|`` to transfer your code in your @boardname@ 
-and show it off to your friends!
+Nice! Now go and show it off to your friends!
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -2,17 +2,13 @@
 
 ## Step 1
 
-Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot. Replace the ``"Hello"`` text with your name. Did you see it scroll?
+Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot. Replace the ``"Hello"`` text with your name. Did you see it scroll in the simulator?
 
 ```blocks
 basic.showString("Micro!")
 ```
 
 ## Step 2
-
-Connect a USB cable to the @boardname@ and click ``|Download|``. Save the program to the **@drivename@** drive. This transfers your code to the @boardname@!
-
-## Step 3
 
 Well, the text stopped. Place the ``||basic:show string||`` block in the ``||input:on button pressed||`` slot to scroll your name when button **A** is pressed.
 
@@ -22,15 +18,9 @@ input.onButtonPressed(Button.A, () => {
 });
 ```
 
-## Step 4
-
-Click ``|Download|`` to save and transfer your code again, then press button **A** to scroll your text.
-
-## Step 5
+## Step 3
 
 Place some blocks to display a smiley when button **B** is pressed.
-
-###
 
 Use the dropdown to find ``B``!
 
@@ -46,11 +36,9 @@ input.onButtonPressed(Button.B, () => {
 })
 ```
 
-## Step 6
+## Step 4
 
 Place the ``||basic:show number||`` and ``||Math:pick random||`` blocks in an ``||input:on shake||`` slot to build a dice. A typical dice can show values from 1 to 6, so don't forget to choose the right minimum and maximum values!
-
-###
 
 When the @boardname@ is shaken, a random number between ``1`` and ``6`` is displayed on the screen.
 
@@ -60,7 +48,14 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
+## Step 5
+
+If you have a @boardname@, connect a USB cable it and click ``|Download|``. Save the program to the **@drivename@** drive. This transfers your code to the @boardname@!
+
+## Step 6
+
+On the @boardname@, press button **A** to scroll your text. Press button **B** to show a smiley. Shake the @boardname@ and see which number is chosen.
+
 ## Step 7
 
 Well done! You've completed your first Microsoft MakeCode activity.
-

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -10,7 +10,7 @@ basic.showString("Micro!")
 
 ## Step 2
 
-Well, the text stopped. Place the ``||basic:show string||`` block in the ``||input:on button pressed||`` slot to scroll your name when button **A** is pressed.
+Well, the text stopped scrolling. Place the ``||basic:show string||`` block in the ``||input:on button pressed||`` slot to scroll your name when button **A** is pressed.
 
 ```blocks
 input.onButtonPressed(Button.A, () => {
@@ -38,9 +38,17 @@ input.onButtonPressed(Button.B, () => {
 
 ## Step 4
 
-Place the ``||basic:show number||`` and ``||Math:pick random||`` blocks in an ``||input:on shake||`` slot to build a dice. A typical dice can show values from 1 to 6, so don't forget to choose the right minimum and maximum values!
+Place the ``||basic:show number||`` and ``||Math:pick random||`` blocks in an ``||input:on shake||`` block to build a dice.
 
-When the @boardname@ is shaken, a random number between ``1`` and ``6`` is displayed on the screen.
+```blocks
+input.onGesture(Gesture.Shake, () => {
+    basic.showNumber(Math.randomRange(0, 10))
+})
+```
+
+## Step 5
+
+A typical dice shows values from `1` to `6`. So, in ``||Math:pick random||``, don't forget to choose the right minimum and maximum values!
 
 ```blocks
 input.onGesture(Gesture.Shake, () => {
@@ -48,14 +56,14 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
-## Step 5
+## Step 6
 
 If you have a @boardname@, connect a USB cable it and click ``|Download|``. Save the program to the **@drivename@** drive. This transfers your code to the @boardname@!
 
-## Step 6
+## Step 7
 
 On the @boardname@, press button **A** to scroll your text. Press button **B** to show a smiley. Shake the @boardname@ and see which number is chosen.
 
-## Step 7
+## Step 8
 
 Well done! You've completed your first Microsoft MakeCode activity.


### PR DESCRIPTION
Fixes : #928

Download steps are removed and a single, optional download is placed at/near the end. At the first step where feedback from the code is visible, the tutorial user is directed to try it in the sim.

Also, the ``###`` blank headings are removed from _getting-started.md_ since ``newAuthoring == true`` now (see ``parseTutorialSteps()`` in pxtlib).