### PR TITLE
Disable instructions for micro:bit

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -110,7 +110,6 @@
         "streams": false,
         "aspectRatio": 1.22,
         "parts": true,
-        "instructions": true,
         "partsAspectRatio": 0.69,
         "boardDefinition": {
             "visual": "microbit",


### PR DESCRIPTION
After discussion we've decided that the Assembly Instructions feature was not quite ready for targets other than Maker, so let's disable it for now

Closes https://github.com/Microsoft/pxt-microbit/issues/1088
Closes https://github.com/Microsoft/pxt-microbit/issues/1097
Closes https://github.com/Microsoft/pxt-microbit/issues/1098