### PR TITLE
Goto title case for 'projects' - v1

### DIFF
--- a/docs/projects/guitar/accelerometer.md
+++ b/docs/projects/guitar/accelerometer.md
@@ -1,4 +1,4 @@
-# Accelerometer Beat control
+# Accelerometer Beat Control
 
 ## @description @boardname@ guitar: using accelerometer to control tempo
 

--- a/docs/projects/guitar/displaybuttons.md
+++ b/docs/projects/guitar/displaybuttons.md
@@ -1,4 +1,5 @@
 # Buttons, Display & Sound
+
 ## @description @boardname@ guitar: using buttons with display and sound
 
 ## ~avatar avatar

--- a/docs/projects/guitar/make.md
+++ b/docs/projects/guitar/make.md
@@ -1,4 +1,5 @@
 # Making the Guitar Body
+
 ## @description Maker Project for Guitar Body for @boardname@
 
 ## ~avatar avatar

--- a/docs/projects/hack-your-headphones.md
+++ b/docs/projects/hack-your-headphones.md
@@ -1,4 +1,4 @@
-# Hack your headphones 
+# Hack Your Headphones 
 
 ## @description An intermediate maker activity, making a @boardname@ music player using headphones
 

--- a/docs/projects/inchworm.md
+++ b/docs/projects/inchworm.md
@@ -1,4 +1,3 @@
-
 # Inchworm
 
 ## @description A inchworm-like robot built with the @boardname@

--- a/docs/projects/inchworm/code.md
+++ b/docs/projects/inchworm/code.md
@@ -1,4 +1,5 @@
 # Code
+
 ## @description code to make the inchworm alive
 
 ## ~avatar avatar

--- a/docs/projects/inchworm/make.md
+++ b/docs/projects/inchworm/make.md
@@ -1,4 +1,5 @@
 # Make
+
 ## @description Building the cardboard inchworm
 
 ## ~avatar avatar

--- a/docs/projects/light-monster.md
+++ b/docs/projects/light-monster.md
@@ -1,4 +1,3 @@
-
 # Light Monster
 
 ## @description A monster made of coffee cup holders that responds to light

--- a/docs/projects/love-meter.md
+++ b/docs/projects/love-meter.md
@@ -1,4 +1,4 @@
-# Love meter
+# Love Meter
 
 Make a love meter, how sweet! The @boardname@ is feeling the love, then sometimes not so much!
 

--- a/docs/projects/magic-button-trick.md
+++ b/docs/projects/magic-button-trick.md
@@ -1,4 +1,4 @@
-# Magic button trick 
+# Magic Button Trick 
 
 ## ~avatar avatar
 

--- a/docs/projects/milk-carton-robot/code.md
+++ b/docs/projects/milk-carton-robot/code.md
@@ -1,4 +1,5 @@
 # Code
+
 ## @description code to make the Milk Carton Robot alive
 
 ## ~avatar avatar

--- a/docs/projects/milk-carton-robot/make.md
+++ b/docs/projects/milk-carton-robot/make.md
@@ -1,4 +1,5 @@
 # Make
+
 ## @description Building the cardboard Milk Carton Robot
 
 ## ~avatar avatar

--- a/docs/projects/milky-monster.md
+++ b/docs/projects/milky-monster.md
@@ -1,5 +1,5 @@
 
-# Milk monster
+# Milk Monster
 
 ## @description A milky-monster like robot built with the @boardname@
 

--- a/docs/projects/milky-monster/code.md
+++ b/docs/projects/milky-monster/code.md
@@ -1,4 +1,5 @@
 # Code
+
 ## @description code to make the Milky Monster alive
 
 ## ~avatar avatar

--- a/docs/projects/milky-monster/make.md
+++ b/docs/projects/milky-monster/make.md
@@ -1,4 +1,5 @@
 # Make
+
 ## @description Building the cardboard Milky Monster
 
 ## ~avatar avatar

--- a/docs/projects/railway-crossing.md
+++ b/docs/projects/railway-crossing.md
@@ -1,4 +1,4 @@
-# Railway crossing
+# Railway Crossing
 
 ## ~
 

--- a/docs/projects/rc-car.md
+++ b/docs/projects/rc-car.md
@@ -1,4 +1,4 @@
-# RC car
+# RC Car
 
 ### ~avatar avatar
 

--- a/docs/projects/reaction-time/code.md
+++ b/docs/projects/reaction-time/code.md
@@ -1,4 +1,5 @@
 # Code
+
 ## @description code to make the Reaction Time interactive
 
 This lesson uses the @boardname@ to measure a student's reaction time in completing a circuit path on a cardboard pad. The student's reaction time is measured in both a distracted and an undistracted environment.

--- a/docs/projects/states-of-matter/code.md
+++ b/docs/projects/states-of-matter/code.md
@@ -1,4 +1,5 @@
 # Code
+
 ## @description code to detect States of Matter 
 
 Have you ever tried to represent the states of matter? Let's try to visually represent various states of matter based on atmospheric temperatures!

--- a/docs/projects/states-of-matter/make.md
+++ b/docs/projects/states-of-matter/make.md
@@ -1,4 +1,5 @@
 # Make
+
 ## @description Building the states of matter experiment.
 
 ## ~avatar avatar

--- a/docs/projects/telegraph.md
+++ b/docs/projects/telegraph.md
@@ -1,4 +1,4 @@
-# telegraph activity 
+# Telegraph
 
 ![](/static/mb/lessons/telegraph-0.png)
 

--- a/docs/projects/timing-gates.md
+++ b/docs/projects/timing-gates.md
@@ -1,4 +1,4 @@
-# Timing gates
+# Timing Gates
 
 ## ~avatar
 

--- a/docs/projects/watch.md
+++ b/docs/projects/watch.md
@@ -1,4 +1,4 @@
-# the watch
+# The Watch
 
 ## ~avatar
 

--- a/docs/projects/watch/digital-watch.md
+++ b/docs/projects/watch/digital-watch.md
@@ -1,4 +1,4 @@
-# Digital watch
+# Digital Watch
 
 ### ~avatar avatar
 

--- a/docs/projects/watch/make.md
+++ b/docs/projects/watch/make.md
@@ -1,4 +1,4 @@
-# The watch - Make
+# The Watch - Make
 
 ## @description Maker Project for Watch
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting Started
 
 ## Step 1
 


### PR DESCRIPTION
Fixes #1116 

Change titles in 'projects' to title case (first letter of principal words to caps).