### PR TITLE
Reuse radio translations for new APIs

### DIFF
--- a/libs/radio/_locales/radio-jsdoc-strings.json
+++ b/libs/radio/_locales/radio-jsdoc-strings.json
@@ -10,13 +10,18 @@
   "radio._packetProperty|param|type": "the packet property type, eg: PacketProperty.time",
   "radio.getReceivedPacketProperty": "Returns properties of the last radio packet received.",
   "radio.getReceivedPacketProperty|param|type": "the type of property to retrieve from the last packet",
+  "radio.onDataPacketReceived": "Registers code to run when the radio receives a packet. Also takes the\nreceived packet from the radio queue.",
+  "radio.onDataReceived": "Registers code to run when a packet is received over radio.",
   "radio.onReceivedBuffer": "Registers code to run when the radio receives a buffer.",
   "radio.onReceivedNumber": "Registers code to run when the radio receives a number.",
   "radio.onReceivedString": "Registers code to run when the radio receives a string.",
   "radio.onReceivedValue": "Registers code to run when the radio receives a key value pair.",
+  "radio.receiveNumber": "Reads the next packet from the radio queue and returns the packet's number\npayload or 0 if the packet did not contain a number.",
+  "radio.receiveString": "Reads the next packet from the radio queue and returns the packet's string\npayload or the empty string if the packet did not contain a string.",
   "radio.receivedBuffer": "Returns the buffer payload from the last packet taken from the radio queue\n(via ``receiveNumber``, ``receiveString``, etc) or the empty string if that\npacket did not contain a string.",
   "radio.receivedNumber": "Returns the number payload from the last packet taken from the radio queue\n(via ``receiveNumber``, ``receiveString``, etc) or 0 if that packet did not\ncontain a number.",
   "radio.receivedSerial": "Returns the serial number of the sender micro:bit from the last packet taken\nfrom the radio queue (via ``receiveNumber``, ``receiveString``, etc) or 0 if\nthat packet did not send a serial number.",
+  "radio.receivedSignalStrength": "Gets the received signal strength indicator (RSSI) from the last packet taken\nfrom the radio queue (via ``receiveNumber``, ``receiveString``, etc). Not supported in simulator.\nnamespace=radio",
   "radio.receivedString": "Returns the string payload from the last packet taken from the radio queue\n(via ``receiveNumber``, ``receiveString``, etc) or the empty string if that\npacket did not contain a string.",
   "radio.receivedTime": "Returns the system time of the sender micro:bit at the moment when it sent the\nlast packet taken from the radio queue (via ``receiveNumber``,\n``receiveString``, etc).",
   "radio.sendBuffer": "Broadcasts a buffer (up to 19 bytes long) along with the device serial number\nand running time to any connected micro:bit in the group.",
@@ -31,5 +36,6 @@
   "radio.setTransmitPower|param|power": "a value in the range 0..7, where 0 is the lowest power and 7 is the highest. eg: 7",
   "radio.setTransmitSerialNumber": "Set the radio to transmit the serial number in each message.",
   "radio.setTransmitSerialNumber|param|transmit": "value indicating if the serial number is transmitted, eg: true",
-  "radio.writeReceivedPacketToSerial": "Writes the last received packet to serial as JSON. This should be called\nwithin an ``onDataPacketReceived`` callback."
+  "radio.writeReceivedPacketToSerial": "Writes the last received packet to serial as JSON. This should be called\nwithin an ``onDataPacketReceived`` callback.",
+  "radio.writeValueToSerial": "Reads the next packet from the radio queue and and writes it to serial\nas JSON."
 }

--- a/libs/radio/_locales/radio-strings.json
+++ b/libs/radio/_locales/radio-strings.json
@@ -4,10 +4,15 @@
   "radio.PacketProperty.Time|block": "time",
   "radio._packetProperty|block": "%note",
   "radio.getReceivedPacketProperty|block": "received packet %type=radio_packet_property",
+  "radio.onDataPacketReceived|block": "on radio received",
+  "radio.onDataReceived|block": "radio on data received",
   "radio.onReceivedBuffer|block": "on radio received",
   "radio.onReceivedNumber|block": "on radio received",
   "radio.onReceivedString|block": "on radio received",
   "radio.onReceivedValue|block": "on radio received",
+  "radio.receiveNumber|block": "radio receive number",
+  "radio.receiveString|block": "radio receive string",
+  "radio.receivedSignalStrength|block": "radio received signal strength",
   "radio.sendNumber|block": "radio send number %value",
   "radio.sendString|block": "radio send string %msg",
   "radio.sendValue|block": "radio send|value %name|= %value",
@@ -15,6 +20,7 @@
   "radio.setTransmitPower|block": "radio set transmit power %power",
   "radio.setTransmitSerialNumber|block": "radio set transmit serial number %transmit",
   "radio.writeReceivedPacketToSerial|block": "radio write received packet to serial",
+  "radio.writeValueToSerial|block": "radio write value to serial",
   "radio|block": "radio",
   "{id:category}Radio": "Radio"
 }

--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -74,6 +74,7 @@ namespace radio {
      */
     //% help=radio/on-received-number blockHandlerKey="radioreceived"
     //% blockId=radio_on_number block="on radio received" blockGap=8
+    //% useLoc="radio.onDataPacketReceived"
     export function onReceivedNumber(cb: (receivedNumber: number) => void) {
         onDataReceived(() => {
             receiveNumber();
@@ -92,6 +93,7 @@ namespace radio {
      */
     //% help=radio/on-received-value blockHandlerKey="radioreceived"
     //% blockId=radio_on_value block="on radio received" blockGap=8
+    //% useLoc="radio.onDataPacketReceived"
     export function onReceivedValue(cb: (name: string, value: number) => void) {
         onDataReceived(() => {
             receiveNumber();
@@ -111,6 +113,7 @@ namespace radio {
      */
     //% help=radio/on-received-string blockHandlerKey="radioreceived"
     //% blockId=radio_on_string block="on radio received" blockGap=8
+    //% useLoc="radio.onDataPacketReceived"
     export function onReceivedString(cb: (receivedString: string) => void) {
         onDataReceived(() => {
             receiveNumber();
@@ -129,6 +132,7 @@ namespace radio {
      */
     //% help=radio/on-received-buffer blockHandlerKey="radioreceived" blockHidden=1
     //% blockId=radio_on_buffer block="on radio received" blockGap=8
+    //% useLoc="radio.onDataPacketReceived"
     export function onReceivedBuffer(cb: (buffer: Buffer) => void) {
         onDataReceived(() => {
             receiveNumber();


### PR DESCRIPTION
Leverages https://github.com/Microsoft/pxt/pull/4626 for the new radio APIs that have the same block definition as an already translated one.

Requires a bump of pxt to work

Note that part of https://github.com/Microsoft/pxt/pull/4626 required enabling extraction of deprecated strings, so the added strings you see in this PR are for deprecated APIs that we were ignoring until now

Fixes https://github.com/Microsoft/pxt-microbit/issues/907