### PR TITLE
C++: Round towards positive infinity

### DIFF
--- a/libs/core/core.cpp
+++ b/libs/core/core.cpp
@@ -772,7 +772,9 @@ TNumber trunc(TNumber x){SINGLE(trunc)}
 
 //%
 TNumber round(TNumber x) {
-    SINGLE(round)
+    // In C++, round(-1.5) == -2, while in JS, round(-1.5) == -1. Align to the JS convention for consistency between
+    // simulator and device. The following does rounding with ties (x.5) going towards positive infinity.
+    return fromDouble(::floor(toDouble(x) + 0.5));
 }
 
 //%


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1131

With this change, the following are consistent on both the device and the sim:

Value | Rounded
-|-
1.8 | 2
1.3 | 1
1.5 | 2
-1.8 | -2
-1.3 | -1
-1.5 | -1
