### PR TITLE
Sim: greyscale display now respects brightness

### DIFF
--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -134,6 +134,7 @@ namespace pxsim.ImageMethods {
         let cb = getResume();
         let first = true;
 
+        clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval,
             frame: () => {
@@ -151,6 +152,7 @@ namespace pxsim.ImageMethods {
     export function plotImage(leds: Image, offset: number): void {
         pxtrt.nullCheck(leds)
 
+        clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval: 0,
             frame: () => {
@@ -211,6 +213,7 @@ namespace pxsim.ImageMethods {
         let off = stride > 0 ? 0 : leds.width - 1;
         let display = board().ledMatrixState.image;
 
+        clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval: interval,
             frame: () => {
@@ -229,6 +232,19 @@ namespace pxsim.ImageMethods {
             },
             whenDone: cb
         })
+    }
+
+    function clampPixelBrightness(img: Image) {
+        if (led.displayMode() === DisplayMode.greyscale) {
+            const b = led.brightness();
+            for (let x = 0; x < img.width; ++x) {
+                for (let y = 0; y < 5; ++y) {
+                    if (pixelBrightness(img, x, y) > b) {
+                        setPixelBrightness(img, x, y, b);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -235,18 +235,19 @@ namespace pxsim.ImageMethods {
     }
 
     function clampPixelBrightness(img: Image): Image {
-        const imgCopy = new Image(img.width, img.data);
-        if (led.displayMode() === DisplayMode.greyscale) {
+        let res = img;
+        if (led.displayMode() === DisplayMode.greyscale && led.brightness() < 0xff) {
+            res = new Image(img.width, img.data);
             const b = led.brightness();
-            for (let x = 0; x < imgCopy.width; ++x) {
+            for (let x = 0; x < res.width; ++x) {
                 for (let y = 0; y < 5; ++y) {
-                    if (pixelBrightness(imgCopy, x, y) > b) {
-                        setPixelBrightness(imgCopy, x, y, b);
+                    if (pixelBrightness(res, x, y) > b) {
+                        setPixelBrightness(res, x, y, b);
                     }
                 }
             }
         }
-        return imgCopy;
+        return res;
     }
 }
 

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -134,7 +134,7 @@ namespace pxsim.ImageMethods {
         let cb = getResume();
         let first = true;
 
-        clampPixelBrightness(leds);
+        leds = clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval,
             frame: () => {
@@ -152,7 +152,7 @@ namespace pxsim.ImageMethods {
     export function plotImage(leds: Image, offset: number): void {
         pxtrt.nullCheck(leds)
 
-        clampPixelBrightness(leds);
+        leds = clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval: 0,
             frame: () => {
@@ -213,7 +213,7 @@ namespace pxsim.ImageMethods {
         let off = stride > 0 ? 0 : leds.width - 1;
         let display = board().ledMatrixState.image;
 
-        clampPixelBrightness(leds);
+        leds = clampPixelBrightness(leds);
         board().ledMatrixState.animationQ.enqueue({
             interval: interval,
             frame: () => {
@@ -234,17 +234,19 @@ namespace pxsim.ImageMethods {
         })
     }
 
-    function clampPixelBrightness(img: Image) {
+    function clampPixelBrightness(img: Image): Image {
+        const imgCopy = new Image(img.width, img.data);
         if (led.displayMode() === DisplayMode.greyscale) {
             const b = led.brightness();
-            for (let x = 0; x < img.width; ++x) {
+            for (let x = 0; x < imgCopy.width; ++x) {
                 for (let y = 0; y < 5; ++y) {
-                    if (pixelBrightness(img, x, y) > b) {
-                        setPixelBrightness(img, x, y, b);
+                    if (pixelBrightness(imgCopy, x, y) > b) {
+                        setPixelBrightness(imgCopy, x, y, b);
                     }
                 }
             }
         }
+        return imgCopy;
     }
 }
 
@@ -296,7 +298,7 @@ namespace pxsim.led {
 
     export function plotBrightness(x: number, y: number, brightness: number) {
         const state = board().ledMatrixState;
-        brightness = Math.max(0, Math.min(0xff, brightness));
+        brightness = Math.max(0, Math.min(led.brightness(), brightness));
         if (brightness != 0 && brightness != 0xff && state.displayMode != DisplayMode.greyscale)
             state.displayMode = DisplayMode.greyscale;
         state.image.set(x, y, brightness);


### PR DESCRIPTION
https://github.com/Microsoft/pxt/pull/4637 is needed to fix https://github.com/Microsoft/pxt-microbit/issues/628#issuecomment-417247530, but it also introduces a second problem.

Images are now always at brightness 255 in greyscale mode in the simulator. This makes it so the sim respects the max brightness always.