### PR TITLE
Add border around sim in high contrast

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -162,6 +162,9 @@ namespace pxsim.visuals {
         }
     `;
     const MB_HIGHCONTRAST = `
+svg.sim {
+    border: solid white;
+}
 .sim-led {
     stroke: red;
 }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -163,7 +163,7 @@ namespace pxsim.visuals {
     `;
     const MB_HIGHCONTRAST = `
 svg.sim {
-    border: solid white;
+    border: solid white 0.15em;
 }
 .sim-led {
     stroke: red;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1026

Helps especially with accelerometer.

Before:
![shake-no-border](https://user-images.githubusercontent.com/14299377/44933427-101de000-ad37-11e8-99db-e761b5178ed9.gif)


After:
![shake-border](https://user-images.githubusercontent.com/14299377/44933429-12803a00-ad37-11e8-8003-c7e96d0e0eb7.gif)

