### PR TITLE
add Gigglebot

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -33,7 +33,8 @@
             "DFRobot/pxt-Obloq",
             "pimoroni/pxt-automationbit",
             "k8robotics/pxt-k8",
-            "dexterind/pxt-giggle"
+            "dexterind/pxt-giggle",
+            "dexterind/pxt-gigglebot"
         ],
         "preferredRepos": [
             "Microsoft/pxt-neopixel"


### PR DESCRIPTION
add Gigglebot package to compliment Giggle.  Gigglebot on it's own can be used with bluetooth, whereas Giggle loads radio and neopixels.

Haven't added to packages.md, this is just so users have the option of using either. @cleoQc