### PR TITLE
Add white stroke to sim border

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -164,7 +164,7 @@ namespace pxsim.visuals {
     const MB_HIGHCONTRAST = `
 path.sim-board {
     stroke: white;
-    stroke-width: 2;
+    stroke-width: 3;
 }
 .sim-led {
     stroke: red;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -162,8 +162,9 @@ namespace pxsim.visuals {
         }
     `;
     const MB_HIGHCONTRAST = `
-svg.sim {
-    border: solid white 0.15em;
+path.sim-board {
+    stroke: white;
+    stroke-width: 2;
 }
 .sim-led {
     stroke: red;


### PR DESCRIPTION
Use a stroke instead of a border, which looks much better and works when other sim parts are present

Fixes https://github.com/Microsoft/pxt-microbit/issues/1176

![image](https://user-images.githubusercontent.com/14299377/45184433-e3fdd580-b1f4-11e8-9971-1f2d48e007e7.png)

![image](https://user-images.githubusercontent.com/14299377/45184459-f546e200-b1f4-11e8-8d49-41e00f3c00d6.png)
