### PR TITLE
Add descriptions to gallery cards

### DIFF
--- a/docs/projects/fashion.md
+++ b/docs/projects/fashion.md
@@ -6,20 +6,22 @@
 [{
   "name": "Duct Tape Wallet",
   "url":"/projects/wallet",
+  "description": "A stylish wallet that holds your digital money and even real money",
   "imageUrl":"/static/mb/projects/wallet.png"
 }, {
   "name": "Watch",
   "url":"/projects/watch",
+  "description": "Keep up with the times using your fancy micro:bit watch",
   "imageUrl":"/static/mb/projects/a10-watch.png"
 }, {
   "name": "Stop Watch",
-  "description": "Easily track time",
+  "description": "How time passes, keep track of how much",
   "url": "/projects/stopwatch",
   "imageUrl":"/static/mb/projects/stopwatch.png",
   "cardType": "side"
 }, {
   "name": "Step counter",
-  "description": "Count your steps",
+  "description": "Catch your stride and count your steps",
   "url": "/projects/step-counter",
   "imageUrl":"/static/mb/projects/step-counter.png",
   "cardType": "side"

--- a/docs/projects/games.md
+++ b/docs/projects/games.md
@@ -1,6 +1,6 @@
 # Games
 
-Here are some cool projects that you can build with your @boardname@!
+Here are some cool game projects that you can build with your @boardname@!
 
 ## Fun games
 
@@ -10,21 +10,26 @@ Fun games to build with your @boardname@.
 [{
   "name": "Rock Paper Scissors",
   "url":"/projects/rock-paper-scissors",
+  "description": "Make the Rock-Paper-Scissors game on your micro:bit and challenge your friends.",
   "imageUrl":"/static/mb/projects/a4-motion.png"
 }, {
   "name": "Magic Button Trick",
   "url":"/projects/magic-button-trick",
+  "description": "Build a magic trick that uses the compass to detect a nearby magnet!",
   "imageUrl":"/static/mb/projects/magic-button-trick.png"
 }, {
   "name": "Reaction Time",
   "url":"/projects/reaction-time",
+  "description": "Make a reaction time experiment that responds to your body's conductivity!",
   "imageUrl":"/static/mb/projects/reaction.jpg"
 }, {
   "name": "Salute!",
   "url":"/projects/salute",
+  "description": "Using simple math, try to guess the other player's micro:bit card.",
   "imageUrl":"/static/mb/projects/salute.png"
 }, {
   "name": "Karel the LED",
+  "description": "Karel likes to draw, help Karel make LED art!",
   "url": "/projects/karel",
   "imageUrl": "/static/mb/projects/karel.png"
 }]

--- a/docs/projects/music.md
+++ b/docs/projects/music.md
@@ -8,14 +8,17 @@ Get your headphone and let's do music!
 [{
   "name": "Hack Your Headphones",
   "url":"/projects/hack-your-headphones",
+  "description": "Hook up your headphones to the micro:bit, does that sound good to you?",
   "imageUrl":"/static/mb/projects/a6-music.png"
 }, {
   "name": "Banana Keyboard",
   "url":"/projects/banana-keyboard",
+  "description": "Use a banana to play music like a keyboard",
   "imageUrl":"/static/mb/projects/a7-conductive.png"
 }, {
   "name": "Guitar",
   "url":"/projects/guitar",
+  "description": "An awesome cardboard guitar project, get ready to riff!",
   "imageUrl":"/static/mb/projects/guitar.png"
 }]
 ```

--- a/docs/projects/radio-games.md
+++ b/docs/projects/radio-games.md
@@ -3,34 +3,42 @@
 Here are some cool projects that you can build with your @boardname@!
 
 ## Multiplayer Games
+
 ```codecard
 [{
   "name": "Mood Radio",
   "url": "/projects/mood-radio",
+  "description": "Send a mood message to your friends",
   "imageUrl": "/static/mb/projects/mood-radio.png"
 }, {
   "name": "Tele-potato",
   "url": "/projects/tele-potato",
+  "description": "Play a radio version of the hot potato game",
   "imageUrl": "/static/mb/projects/tele-potato.png"
 }, {
   "name": "Fireflies",
   "url": "/projects/fireflies",
+  "description": "Simulate fireflies with micro:bits, try it in the dark!",
   "imageUrl": "/static/mb/projects/fireflies.png"
 }, {
   "name": "Infection",
   "url": "/projects/infection",
+  "description": "An epidemic has broken out, see who will survive.",
   "imageUrl": "/static/mb/projects/infection.png"
 }, {
   "name": "Hot or Cold",
   "url": "/projects/hot-or-cold",
+  "description": "Find the hidden player by seeing if your close or not.",
   "imageUrl": "/static/mb/projects/hot-or-cold.jpg"
 }, {
   "name": "Voting Machine",
   "url": "/projects/voting-machine",
+  "description": "Send in your vote and be counted, YES or NO!",
   "imageUrl": "/static/mb/projects/voting-machine.png"
 }, {
   "name": "Rock Paper Scissors Teams",
   "url": "/projects/rps-teams",
+  "description": "The Rock-Paper-Scissors game with lots and lots of players.",
   "imageUrl": "/static/mb/projects/rpsteams.png"
 }]
 ```

--- a/docs/projects/science.md
+++ b/docs/projects/science.md
@@ -6,6 +6,7 @@
 [{
   "name": "Timing Gates",
   "url":"/projects/timing-gates",
+  "description": "Setup timing gates to measure the speed of a moving object",
   "imageUrl":"/static/mb/projects/timegate.jpg"
 }]
 ```
@@ -16,10 +17,12 @@
 [{
   "name": "Soil Moisture",
   "url":"/projects/soil-moisture",
+  "description": "Keep track of the moisture level of your plants",
   "imageUrl":"/static/mb/projects/soilmoisture.jpg"
 }, {
   "name": "Plant Watering",
   "url":"/projects/plant-watering",
+  "description": "Automatically water you plants!",
   "imageUrl":"/static/mb/projects/plantwatering.jpg"
 }]
 ```
@@ -30,6 +33,7 @@
 [{
   "name": "States of Matter",
   "url":"/projects/states-of-matter",
+  "description": "A simulation of a substance changing state: solid, liquid, and gas",
   "imageUrl":"/static/mb/projects/som.jpg"
 }]
 ```

--- a/docs/projects/toys.md
+++ b/docs/projects/toys.md
@@ -6,14 +6,17 @@
 [{
   "name": "Inchworm",
   "url":"/projects/inchworm",
+  "description": "Create an inchworm robot that creeps along",
   "imageUrl":"/static/mb/projects/inchworm.jpg"
 }, {
   "name": "Milk Carton Robot",
   "url":"/projects/milk-carton-robot",
+  "description": "Make a robot from a milk carton",
   "imageUrl":"/static/mb/projects/milk-carton-robot.jpg"
 }, {
   "name": "Milky Monster",
   "url":"/projects/milky-monster",
+  "description": "Make a funny milky-monster robot!",
   "imageUrl":"/static/mb/projects/milky-monster.jpg"
 }]
 ```
@@ -24,10 +27,12 @@
 [{
   "name": "Railway Crossing",
   "url":"/projects/railway-crossing",
+  "description": "Use the light sensor to detect if a train is passing by",
   "imageUrl":"/static/mb/projects/railway-crossing.png"
 },{
   "name": "Kitronik RC Car Hack",
   "url": "/projects/rc-car",
+  "description": "Control an RC car with the micro:bit and Kitronic parts",
   "imageUrl":"/static/mb/projects/rc-car.jpg"
 }]
 ```

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -8,6 +8,7 @@ Here are some cool tutorials to get you started with your @boardname@!
 [{
   "name": "Flashing Heart",
   "url":"/projects/flashing-heart",
+  "description": "Make an animated flashing heart.",
   "imageUrl": "/static/mb/projects/a1-display.png",
   "cardType": "tutorial"
 }, {
@@ -19,21 +20,25 @@ Here are some cool tutorials to get you started with your @boardname@!
 }, {
   "name": "Smiley Buttons",
   "url":"/projects/smiley-buttons",
+  "description": "Show different smiley images by pressing the buttons.",
   "imageUrl": "/static/mb/projects/a2-buttons.png",
   "cardType": "tutorial"
 }, {
   "name": "Dice",
   "url":"/projects/dice",
+  "description": "Shake the dice and see what number comes up!",
   "imageUrl": "/static/mb/projects/dice.png",
   "cardType": "tutorial"
 }, {
   "name": "Love Meter",
   "url":"/projects/love-meter",
+  "description": "Is the micro:bit is feeling the love, see how much!",
   "imageUrl":"/static/mb/projects/a3-pins.png",
   "cardType": "tutorial"
 }, {
   "name": "Coin Flipper",
   "url":"/projects/coin-flipper",
+  "description": "Guess the coin toss and see if you're lucky.",
   "imageUrl": "/static/mb/projects/coin-flipper.png",
   "cardType": "tutorial"
 }]


### PR DESCRIPTION
Include description strings in the gallery cards. Fixes #1206. The _Examples_ gallery is going away so descriptions aren't added to those.