### PR TITLE
explictely set radio default power to 6

### DIFF
--- a/docs/reference/radio/set-transmit-power.md
+++ b/docs/reference/radio/set-transmit-power.md
@@ -1,6 +1,6 @@
 # set Transmit Power
 
-Make the ``radio`` signal of the @boardname@ stronger or weaker. It can be as weak as `0` and as strong as `7`.
+Make the ``radio`` signal of the @boardname@ stronger or weaker. It can be as weak as `0` and as strong as `7`. Default is ``6``.
 
 The scientific name for the strength of the ``radio`` signal is
 **dBm**, or **decibel-milliwatts**. A signal strength of `0`

--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -53,6 +53,7 @@ namespace radio {
         }
         if (!radioEnabled) {
             uBit.radio.setGroup(pxt::programHash());
+            uBit.radio.setTransmitPower(6); // start with high power by default
             radioEnabled = true;
         }
         return r;

--- a/sim/state/radio.ts
+++ b/sim/state/radio.ts
@@ -60,6 +60,7 @@ namespace pxsim {
 
         constructor(private runtime: Runtime) {
             this.datagram = new RadioDatagram(runtime);
+            this.power = 6; // default value
         }
 
         setTransmitPower(power: number) {


### PR DESCRIPTION
Explicitely set randio power to 6
Fix for https://github.com/Microsoft/pxt-microbit/issues/1284
