### PR TITLE
missing platform.h from pxt.json

### DIFF
--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -4,6 +4,7 @@
     "additionalFilePath": "../../node_modules/pxt-common-packages/libs/base",
     "files": [
         "README.md",
+        "platform.h",
         "pxt.cpp",
         "pxt.h",
         "pxtbase.h",


### PR DESCRIPTION
Was missing from pxt.json

Fix for https://github.com/Microsoft/pxt-microbit/issues/1281