### PR TITLE
Update block gaps to account for extra space taken by event blocks

### DIFF
--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -28,7 +28,7 @@ namespace basic {
      * @param interval how fast to shift characters; eg: 150, 100, 200, -100
      */
     //% help=basic/show-string
-    //% weight=87 blockGap=8
+    //% weight=87 blockGap=16
     //% block="show|string %text"
     //% async
     //% blockId=device_print_message
@@ -85,7 +85,7 @@ namespace basic {
      * Repeats the code forever in the background. On each iteration, allows other codes to run.
      * @param body code to execute
      */
-    //% help=basic/forever weight=55 blockGap=8 blockAllowMultiple=1 afterOnStart=true
+    //% help=basic/forever weight=55 blockGap=16 blockAllowMultiple=1 afterOnStart=true
     //% blockId=device_forever block="forever" icon="\uf01e"
     void forever(Action a) {
       runForever(a);
@@ -96,7 +96,7 @@ namespace basic {
      * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
      */
     //% help=basic/pause weight=54
-    //% async block="pause (ms) %pause"
+    //% async block="pause (ms) %pause" blockGap=16
     //% blockId=device_pause icon="\uf110"
     void pause(int ms) {
       fiber_sleep(ms);

--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -165,7 +165,7 @@ namespace input {
      * @param button the button that needs to be pressed
      * @param body code to run when event is raised
      */
-    //% help=input/on-button-pressed weight=85 blockGap=8
+    //% help=input/on-button-pressed weight=85 blockGap=16
     //% blockId=device_button_event block="on button|%NAME|pressed"
     //% parts="buttonpair"
     void onButtonPressed(Button button, Action body) {
@@ -177,7 +177,7 @@ namespace input {
      * @param gesture the type of gesture to track, eg: Gesture.Shake
      * @param body code to run when gesture is raised
      */
-    //% help=input/on-gesture weight=84 blockGap=8
+    //% help=input/on-gesture weight=84 blockGap=16
     //% blockId=device_gesture_event block="on |%NAME"
     //% parts="accelerometer"
     //% NAME.fieldEditor="gestures" NAME.fieldOptions.columns=4
@@ -195,7 +195,7 @@ namespace input {
      * @param name the pin that needs to be pressed, eg: TouchPin.P0
      * @param body the code to run when the pin is pressed
      */
-    //% help=input/on-pin-pressed weight=83
+    //% help=input/on-pin-pressed weight=83 blockGap=32
     //% blockId=device_pin_event block="on pin %name|pressed"
     void onPinPressed(TouchPin name, Action body) {
         auto pin = getPin((int)name);
@@ -211,7 +211,7 @@ namespace input {
      * @param name the pin that needs to be released, eg: TouchPin.P0
      * @param body the code to run when the pin is released
      */
-    //% help=input/on-pin-released weight=6 blockGap=8
+    //% help=input/on-pin-released weight=6 blockGap=16
     //% blockId=device_pin_released block="on pin %NAME|released"
     //% advanced=true
     void onPinReleased(TouchPin name, Action body) {
@@ -350,7 +350,7 @@ namespace input {
     /**
      * Gets the number of milliseconds elapsed since power on.
      */
-    //% help=input/running-time weight=50 blockGap=8
+    //% help=input/running-time weight=50 blockGap=16
     //% blockId=device_get_running_time block="running time (ms)"
     //% advanced=true
     int runningTime() {

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -300,7 +300,7 @@ namespace music {
      * Registers code to run on various melody events
      */
     //% blockId=melody_on_event block="music on %value"
-    //% help=music/on-event weight=59
+    //% help=music/on-event weight=59 blockGap=32
     export function onEvent(value: MusicEvent, handler: () => void) {
         control.onEvent(MICROBIT_MELODY_ID, value, handler);
     }
@@ -311,7 +311,7 @@ namespace music {
      * @param melodyArray the melody array to play
      * @param options melody options, once / forever, in the foreground / background
      */
-    //% help=music/begin-melody weight=60 blockGap=8
+    //% help=music/begin-melody weight=60 blockGap=16
     //% blockId=device_start_melody block="start melody %melody=device_builtin_melody| repeating %options"
     //% parts="headphone"
     export function beginMelody(melodyArray: string[], options: MelodyOptions = 1) {

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -202,7 +202,7 @@ namespace pins {
     * @param name digital pin to register to, eg: DigitalPin.P0
     * @param pulse the value of the pulse, eg: PulseValue.High
     */
-    //% help=pins/on-pulsed weight=22 blockGap=8 advanced=true
+    //% help=pins/on-pulsed weight=22 blockGap=16 advanced=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
     //% pin.fieldEditor="gridpicker" pin.fieldOptions.columns=4
     //% pin.fieldOptions.tooltips="false" pin.fieldOptions.width="300"

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -149,7 +149,7 @@ declare namespace basic {
      * @param interval how fast to shift characters; eg: 150, 100, 200, -100
      */
     //% help=basic/show-string
-    //% weight=87 blockGap=8
+    //% weight=87 blockGap=16
     //% block="show|string %text"
     //% async
     //% blockId=device_print_message
@@ -187,7 +187,7 @@ declare namespace basic {
      * Repeats the code forever in the background. On each iteration, allows other codes to run.
      * @param body code to execute
      */
-    //% help=basic/forever weight=55 blockGap=8 blockAllowMultiple=1 afterOnStart=true
+    //% help=basic/forever weight=55 blockGap=16 blockAllowMultiple=1 afterOnStart=true
     //% blockId=device_forever block="forever" icon="\uf01e" shim=basic::forever
     function forever(a: () => void): void;
 
@@ -196,7 +196,7 @@ declare namespace basic {
      * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
      */
     //% help=basic/pause weight=54
-    //% async block="pause (ms) %pause"
+    //% async block="pause (ms) %pause" blockGap=16
     //% blockId=device_pause icon="\uf110" shim=basic::pause
     function pause(ms: int32): void;
 }
@@ -211,7 +211,7 @@ declare namespace input {
      * @param button the button that needs to be pressed
      * @param body code to run when event is raised
      */
-    //% help=input/on-button-pressed weight=85 blockGap=8
+    //% help=input/on-button-pressed weight=85 blockGap=16
     //% blockId=device_button_event block="on button|%NAME|pressed"
     //% parts="buttonpair" shim=input::onButtonPressed
     function onButtonPressed(button: Button, body: () => void): void;
@@ -221,7 +221,7 @@ declare namespace input {
      * @param gesture the type of gesture to track, eg: Gesture.Shake
      * @param body code to run when gesture is raised
      */
-    //% help=input/on-gesture weight=84 blockGap=8
+    //% help=input/on-gesture weight=84 blockGap=16
     //% blockId=device_gesture_event block="on |%NAME"
     //% parts="accelerometer"
     //% NAME.fieldEditor="gestures" NAME.fieldOptions.columns=4 shim=input::onGesture
@@ -232,7 +232,7 @@ declare namespace input {
      * @param name the pin that needs to be pressed, eg: TouchPin.P0
      * @param body the code to run when the pin is pressed
      */
-    //% help=input/on-pin-pressed weight=83
+    //% help=input/on-pin-pressed weight=83 blockGap=32
     //% blockId=device_pin_event block="on pin %name|pressed" shim=input::onPinPressed
     function onPinPressed(name: TouchPin, body: () => void): void;
 
@@ -241,7 +241,7 @@ declare namespace input {
      * @param name the pin that needs to be released, eg: TouchPin.P0
      * @param body the code to run when the pin is released
      */
-    //% help=input/on-pin-released weight=6 blockGap=8
+    //% help=input/on-pin-released weight=6 blockGap=16
     //% blockId=device_pin_released block="on pin %NAME|released"
     //% advanced=true shim=input::onPinReleased
     function onPinReleased(name: TouchPin, body: () => void): void;
@@ -323,7 +323,7 @@ declare namespace input {
     /**
      * Gets the number of milliseconds elapsed since power on.
      */
-    //% help=input/running-time weight=50 blockGap=8
+    //% help=input/running-time weight=50 blockGap=16
     //% blockId=device_get_running_time block="running time (ms)"
     //% advanced=true shim=input::runningTime
     function runningTime(): int32;
@@ -604,7 +604,7 @@ declare namespace pins {
      * @param name digital pin to register to, eg: DigitalPin.P0
      * @param pulse the value of the pulse, eg: PulseValue.High
      */
-    //% help=pins/on-pulsed weight=22 blockGap=8 advanced=true
+    //% help=pins/on-pulsed weight=22 blockGap=16 advanced=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
     //% pin.fieldEditor="gridpicker" pin.fieldOptions.columns=4
     //% pin.fieldOptions.tooltips="false" pin.fieldOptions.width="300" shim=pins::onPulsed

--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -73,7 +73,7 @@ namespace radio {
      * Registers code to run when the radio receives a number.
      */
     //% help=radio/on-received-number blockHandlerKey="radioreceived"
-    //% blockId=radio_on_number block="on radio received" blockGap=8
+    //% blockId=radio_on_number block="on radio received" blockGap=16
     //% useLoc="radio.onDataPacketReceived"
     export function onReceivedNumber(cb: (receivedNumber: number) => void) {
         onDataReceived(() => {
@@ -92,7 +92,7 @@ namespace radio {
      * Registers code to run when the radio receives a key value pair.
      */
     //% help=radio/on-received-value blockHandlerKey="radioreceived"
-    //% blockId=radio_on_value block="on radio received" blockGap=8
+    //% blockId=radio_on_value block="on radio received" blockGap=16
     //% useLoc="radio.onDataPacketReceived"
     export function onReceivedValue(cb: (name: string, value: number) => void) {
         onDataReceived(() => {
@@ -112,7 +112,7 @@ namespace radio {
      * Registers code to run when the radio receives a string.
      */
     //% help=radio/on-received-string blockHandlerKey="radioreceived"
-    //% blockId=radio_on_string block="on radio received" blockGap=8
+    //% blockId=radio_on_string block="on radio received" blockGap=16
     //% useLoc="radio.onDataPacketReceived"
     export function onReceivedString(cb: (receivedString: string) => void) {
         onDataReceived(() => {
@@ -131,7 +131,7 @@ namespace radio {
      * Registers code to run when the radio receives a buffer.
      */
     //% help=radio/on-received-buffer blockHandlerKey="radioreceived" blockHidden=1
-    //% blockId=radio_on_buffer block="on radio received" blockGap=8
+    //% blockId=radio_on_buffer block="on radio received" blockGap=16
     //% useLoc="radio.onDataPacketReceived"
     export function onReceivedBuffer(cb: (buffer: Buffer) => void) {
         onDataReceived(() => {
@@ -152,7 +152,7 @@ namespace radio {
      * @param type the type of property to retrieve from the last packet
      */
     //% help=radio/get-received-packet-property advanced=true
-    //% blockId=radio_received_packet_property block="received packet %type=radio_packet_property" blockGap=8
+    //% blockId=radio_received_packet_property block="received packet %type=radio_packet_property" blockGap=16
     export function getReceivedPacketProperty(type: number) {
         if (lastPacket) {
             switch(type) {


### PR DESCRIPTION
After switching to the new rendering, it seems the event blocks take up a bit more space than they're supposed to. This gives them a bit more space, although the correct fix is to fix this on the Blockly side, so this is temporary until we fix it there.

Here's an example of the basic category:
![screen shot 2018-09-26 at 4 17 44 pm](https://user-images.githubusercontent.com/16690124/46114506-ca263180-c1a7-11e8-8322-0c48a015f922.png)
