### PR TITLE
render project categories instead of listing

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -2,192 +2,56 @@
 
 Here are some cool projects that you can build with your @boardname@!
 
-## Games
-
-Fun games to build with your @boardname@.
+## Categories
 
 ```codecard
 [{
-  "name": "Rock Paper Scissors",
-  "url":"/projects/rock-paper-scissors",
+  "name": "Tutorials",
+  "url": "/tutorials",
+  "imageUrl": "/static/mb/projects/a4-motion.png"
+}, {
+  "name": "Games",
+  "url":"/projects/games",
   "imageUrl":"/static/mb/projects/a4-motion.png"
 }, {
-  "name": "Magic Button Trick",
-  "url":"/projects/magic-button-trick",
-  "imageUrl":"/static/mb/projects/magic-button-trick.png"
+  "name": "Radio Games",
+  "url":"/projects/radio-games",
+  "imageUrl":"/static/mb/projects/mood-radio.png"
 }, {
-  "name": "Salute!",
-  "url":"/projects/salute",
-  "imageUrl":"/static/mb/projects/salute.png"
-}]
-```
-
-## Multiplayer Games
-
-```codecard
-[{
-  "name": "Mood Radio",
-  "url": "/projects/mood-radio",
-  "imageUrl": "/static/mb/projects/mood-radio.png"
-}, {
-  "name": "Tele-potato",
-  "url": "/projects/tele-potato",
-  "imageUrl": "/static/mb/projects/tele-potato.png"
-}, {
-  "name": "Fireflies",
-  "url": "/projects/fireflies",
-  "imageUrl": "/static/mb/projects/fireflies.png"
-}, {
-  "name": "Infection",
-  "url": "/projects/infection",
-  "imageUrl": "/static/mb/projects/infection.png"
-}, {
-  "name": "Hot or Cold",
-  "url": "/projects/hot-or-cold",
-  "imageUrl": "/static/mb/projects/hot-or-cold.jpg"
-}, {
-  "name": "Voting Machine",
-  "url": "/projects/voting-machine",
-  "imageUrl": "/static/mb/projects/voting-machine.png"
-}, {
-  "name": "Rock Paper Scissors Teams",
-  "url": "/projects/rps-teams",
-  "imageUrl": "/static/mb/projects/rpsteams.png"
-}]
-```
-
-## Music
-
-```codecard
-[{
-  "name": "Hack Your Headphones",
-  "url":"/projects/hack-your-headphones",
-  "imageUrl":"/static/mb/projects/a6-music.png"
-}, {
-  "name": "Banana Keyboard",
-  "url":"/projects/banana-keyboard",
-  "imageUrl":"/static/mb/projects/a7-conductive.png"
-}, {
-  "name": "Guitar",
-  "url":"/projects/guitar",
-  "imageUrl":"/static/mb/projects/guitar.png"
-}]
-```
-
-## Fashion
-
-```codecard
-[{
-  "name": "Duct Tape Wallet",
-  "url":"/projects/wallet",
+  "name": "Fashion",
+  "url":"/projects/fashion",
   "imageUrl":"/static/mb/projects/wallet.png"
 }, {
-  "name": "Watch",
-  "url":"/projects/watch",
-  "imageUrl":"/static/mb/projects/a10-watch.png"
-}]
-```
-
-## Toys
-
-```codecard
-[{
-  "name": "Inchworm",
-  "url":"/projects/inchworm",
+  "name": "Music",
+  "url":"/projects/music",
+  "imageUrl":"/static/mb/projects/a6-music.png"
+},{
+  "name": "Toys",
+  "url":"/projects/toys",
   "imageUrl":"/static/mb/projects/inchworm.jpg"
 }, {
-  "name": "Milk Carton Robot",
-  "url":"/projects/milk-carton-robot",
-  "imageUrl":"/static/mb/projects/milk-carton-robot.jpg"
-}, {
-  "name": "Milky Monster",
-  "url":"/projects/milky-monster",
-  "imageUrl":"/static/mb/projects/milky-monster.jpg"
-}, {
-  "name": "Railway Crossing",
-  "url":"/projects/railway-crossing",
-  "imageUrl":"/static/mb/projects/railway-crossing.png"
-},{
-  "name": "Kitronik RC Car Hack",
-  "url": "/projects/rc-car",
-  "imageUrl":"/static/mb/projects/rc-car.jpg"
-}]
-```
-
-## STEM
-
-```codecard
-[{
-  "name": "Timing Gates",
-  "url":"/projects/timing-gates",
+  "name": "Science",
+  "url":"/projects/science",
   "imageUrl":"/static/mb/projects/timegate.jpg"
-},{
-  "name": "Soil Moisture",
-  "url":"/projects/soil-moisture",
-  "imageUrl":"/static/mb/projects/soilmoisture.jpg"
 }, {
-  "name": "Plant Watering",
-  "url":"/projects/plant-watering",
-  "imageUrl":"/static/mb/projects/plantwatering.jpg"
+  "name": "Tools",
+  "url": "/projects/tools",
+  "imageUrl": "/static/mb/projects/light-level-meter.png"
 }, {
-  "name": "Reaction Time",
-  "url":"/projects/reaction-time",
-  "imageUrl":"/static/mb/projects/reaction.jpg"
-}, {
-  "name": "States of Matter",
-  "url":"/projects/states-of-matter",
-  "imageUrl":"/static/mb/projects/som.jpg"
-}]
-```
-
-## Tools
-
-```codecard
-[{
-  "name": "Light Level Meter",
-  "description": "Measure light input",
-  "url": "/projects/light-level-meter",
-  "imageUrl": "/static/mb/projects/light-level-meter.png",
-  "cardType": "side"
-}, {
-  "name": "Analog Pin Tester",
-  "description": "Test analog input",
-  "url": "/projects/analog-pin-tester",
-  "imageUrl": "/static/mb/projects/analog-pin-tester.png",
-  "cardType": "side"
-}, {
-  "name": "Servo Calibrator",
-  "description": "Calibrate a servo",
-  "url": "/projects/servo-calibrator",
-  "imageUrl": "/static/mb/projects/servo-calibrator.png",
-  "cardType": "side"
-}]
-```
-
-## More
-
-```codecard
-[{
-  "name": "Compass",
-  "url":"/projects/compass",
-  "imageUrl":"/static/mb/projects/a5-compass.png",
-  "cardType": "side"
-},{
-  "name": "Telegraph",
-  "url":"/projects/telegraph",
-  "imageUrl":"/static/mb/projects/a8-network.png"
-}, {
-  "name": "Karel the LED",
-  "url": "/projects/karel",
-  "imageUrl": "/static/mb/projects/karel.png"
+  "name": "Turtle",
+  "url": "/projects/turtle",
+  "imageUrl":"/static/mb/projects/turtle-square.png",
 }]
 ```
 
 ## See Also
 
-[Flashing Heart](/projects/flashing-heart), [Smiley Buttons](/projects/smiley-buttons), [Love Meter](/projects/love-meter), [Rock Paper Scissors](/projects/rock-paper-scissors), [Compass](/projects/compass), [Hack your headphones](/projects/hack-your-headphones), [Banana keyboard](/projects/banana-keyboard), [Telegraph](/projects/telegraph), [Guitar](/projects/guitar), [Wallet](/projects/wallet), [Watch](/projects/watch),
-[Milk Monster](/projects/milky-monster), [Karel the LED](/projects/karel), [Infection](/projects/infection), [Voting Machine](/projects/voting-machine)
-[Fireflies](/projects/fireflies), [Soil Moisture](/projects/soil-moisture),
-[States Of Matter](/projects/states-of-matter), [Reaction Time](/projects/reaction-time),
-[Rock Paper Scissors Teams](/projects/rps-teams),
-[micro:coin](/projects/micro-coin)
+[Tutorials](/tutorials),
+[Games](/projects/games),
+[Radio games](/projects/radio-games),
+[Fashion](/projects/fashion)
+[Music](/projects/music),
+[Toys](/projects/toys),
+[Science](/projects/science),
+[Tools](/projects/tools),
+[Turtle](/projects/turtle)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -8,7 +8,7 @@ Here are some cool projects that you can build with your @boardname@!
 [{
   "name": "Tutorials",
   "url": "/tutorials",
-  "imageUrl": "/static/mb/projects/a4-motion.png"
+  "imageUrl": "/static/mb/projects/a1-display.png"
 }, {
   "name": "Games",
   "url":"/projects/games",
@@ -16,7 +16,7 @@ Here are some cool projects that you can build with your @boardname@!
 }, {
   "name": "Radio Games",
   "url":"/projects/radio-games",
-  "imageUrl":"/static/mb/projects/mood-radio.png"
+  "imageUrl":"/static/mb/projects/fireflies.png"
 }, {
   "name": "Fashion",
   "url":"/projects/fashion",
@@ -40,7 +40,7 @@ Here are some cool projects that you can build with your @boardname@!
 }, {
   "name": "Turtle",
   "url": "/projects/turtle",
-  "imageUrl":"/static/mb/projects/turtle-square.png",
+  "imageUrl":"/static/mb/projects/turtle-square.png"
 }]
 ```
 


### PR DESCRIPTION
In v1, projects are split in subpages so the project page only points to this sub-pages to avoid duplicating cards.