### PR TITLE
Update font size of blocks

### DIFF
--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -11,6 +11,14 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
+
+text.blocklyText {
+    font-weight: 600;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: subpixel-antialiased;
+    -webkit-font-smoothing: antialiased;
+}
+
 /* Blockly Field: Grid picker */
 .blocklyGridPickerTooltip {
     padding: 3px 5px;

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -77,6 +77,7 @@
 @blocklyFlyoutColor: #4b4949;
 @blocklyFlyoutColorOpacity: 1.0;
 @monacoFlyoutColor: @blocklyFlyoutColor;
+@blocklyFlyoutButtonColor: @secondaryColor;
 
 /*-------------------
    Serial


### PR DESCRIPTION
Make the text more readable on all browsers. 

Also: set Flyout button color to the secondary color. 

Chrome: 
![screen shot 2018-10-01 at 2 34 30 pm](https://user-images.githubusercontent.com/16690124/46317216-35e11380-c587-11e8-9c26-9815a0767f3e.png)


Safari: 
![screen shot 2018-10-01 at 2 34 37 pm](https://user-images.githubusercontent.com/16690124/46317222-38436d80-c587-11e8-9b4b-09dd0420d3ec.png)
