### PR TITLE
support for MIDI simulator in v0

### DIFF
--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -53,4 +53,14 @@ namespace control {
      */
     //% shim=pxtrt::runtimeWarning
     export function runtimeWarning(message: string) { }
+
+    
+    /**
+     * Informs simulator/runtime of a MIDI message
+     * Internal function to support the simulator.
+     */
+    //% part=midioutput
+    export function __midiSend(buffer: Buffer): void {
+        // implemented in v1
+    }
 }


### PR DESCRIPTION
Adds "control.__midiSend" function (implemented in v1) to allow package v0/v1 to work. v1 PR is https://github.com/Microsoft/pxt-microbit/pull/1332