### PR TITLE
MIDI support in simulator

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -213,6 +213,7 @@
   "control.raiseEvent|param|value": "Component specific code indicating the cause of the event.",
   "control.reset": "Resets the BBC micro:bit.",
   "control.runtimeWarning": "Display warning in the simulator.",
+  "control.sendMidiMessage": "Internal function to support the simulator",
   "control.waitMicros": "Blocks the current fiber for the given microseconds",
   "control.waitMicros|param|micros": "number of micro-seconds to wait. eg: 4",
   "game": "A single-LED sprite game engine",

--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -213,7 +213,6 @@
   "control.raiseEvent|param|value": "Component specific code indicating the cause of the event.",
   "control.reset": "Resets the BBC micro:bit.",
   "control.runtimeWarning": "Display warning in the simulator.",
-  "control.sendMidiMessage": "Internal function to support the simulator",
   "control.waitMicros": "Blocks the current fiber for the given microseconds",
   "control.waitMicros|param|micros": "number of micro-seconds to wait. eg: 4",
   "game": "A single-LED sprite game engine",

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -306,8 +306,8 @@ namespace control {
     /**
     * Internal function to support the simulator
     */
-    //%
-    void sendMidiMessage(Buffer buffer, int offset) {
+    //% part=midioutput
+    void sendMidiMessage(Buffer buffer) {
         // this is a stub to support the simulator
     }
 }

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -304,10 +304,11 @@ namespace control {
     }
 
     /**
-    * Internal function to support the simulator
+    * Informs simulator/runtime of a MIDI message
+    * Internal function to support the simulator.
     */
-    //% part=midioutput
-    void sendMidiMessage(Buffer buffer) {
+    //% part=midioutput block
+    void __midiSend(Buffer buffer) {
         // this is a stub to support the simulator
     }
 }

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -302,4 +302,12 @@ namespace control {
     int deviceSerialNumber() {
         return microbit_serial_number();
     }
+
+    /**
+    * Internal function to support the simulator
+    */
+    //%
+    void sendMidiMessage(Buffer buffer, int offset) {
+        // this is a stub to support the simulator
+    }
 }

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -433,10 +433,11 @@ declare namespace control {
     function deviceSerialNumber(): int32;
 
     /**
-     * Internal function to support the simulator
+     * Informs simulator/runtime of a MIDI message
+     * Internal function to support the simulator.
      */
-    //% part=midioutput shim=control::sendMidiMessage
-    function sendMidiMessage(buffer: Buffer): void;
+    //% part=midioutput block shim=control::__midiSend
+    function __midiSend(buffer: Buffer): void;
 }
 
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -435,8 +435,8 @@ declare namespace control {
     /**
      * Internal function to support the simulator
      */
-    //% shim=control::sendMidiMessage
-    function sendMidiMessage(buffer: Buffer, offset: int32): void;
+    //% part=midioutput shim=control::sendMidiMessage
+    function sendMidiMessage(buffer: Buffer): void;
 }
 
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -431,6 +431,12 @@ declare namespace control {
     //% blockId="control_device_serial_number" block="device serial number" weight=9
     //% advanced=true shim=control::deviceSerialNumber
     function deviceSerialNumber(): int32;
+
+    /**
+     * Internal function to support the simulator
+     */
+    //% shim=control::sendMidiMessage
+    function sendMidiMessage(buffer: Buffer, offset: int32): void;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "pxt-common-packages": "0.23.57",
-    "pxt-core": "4.1.12"
+    "pxt-core": "4.1.13"
   }
 }

--- a/sim/state/midi.ts
+++ b/sim/state/midi.ts
@@ -1,6 +1,7 @@
 namespace pxsim.control {
-    export function sendMidiMessageAsync(data: RefBuffer, offset: number): Promise<void> {
+    export function sendMidiMessage(data: RefBuffer, offset: number) {
         const b = board();
-        return pxsim.AudioContextManager.sendMidiMessageAsync(data, offset);
+        pxsim.AudioContextManager.sendMidiMessageAsync(data, offset)
+            .done();
     }
 }

--- a/sim/state/midi.ts
+++ b/sim/state/midi.ts
@@ -1,7 +1,7 @@
 namespace pxsim.control {
-    export function sendMidiMessage(data: RefBuffer, offset: number) {
+    export function __midiSend(data: RefBuffer) {
         const b = board();
-        pxsim.AudioContextManager.sendMidiMessageAsync(data, offset)
+        pxsim.AudioContextManager.sendMidiMessageAsync(data)
             .done();
     }
 }

--- a/sim/state/midi.ts
+++ b/sim/state/midi.ts
@@ -1,0 +1,6 @@
+namespace pxsim.control {
+    export function sendMidiMessageAsync(data: RefBuffer, offset: number): Promise<void> {
+        const b = board();
+        return pxsim.AudioContextManager.sendMidiMessageAsync(data, offset);
+    }
+}


### PR DESCRIPTION
- [x] requires https://github.com/Microsoft/pxt/pull/4761
- [ ]  **REQUIRES https://github.com/Microsoft/pxt-microbit/pull/1331** to be deployed

Adds an API that allows libraries to "tell" the simulator which MIDI command they are running. Once this is done, I will be able to update the pxt-midi package and use this API.