### PR TITLE
Redirect logic to v0

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -429,6 +429,9 @@
         },
         "browserDbPrefixes": {
             "1": "v1"
+        },
+        "editorVersionPaths": {
+            "0": "v0"
         }
     }
 }


### PR DESCRIPTION
Redirect to latest v0 if the upgrade fails. We don't want to redirect to internal builds. 