### PR TITLE
game sprite brightness

### DIFF
--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -300,6 +300,7 @@
   "led.plot|block": "plot|x %x|y %y",
   "led.point|block": "point|x %x|y %y",
   "led.setBrightness|block": "set brightness %value",
+  "led.setDisplayMode|block": "set display mode $mode",
   "led.stopAnimation|block": "stop animation",
   "led.toggle|block": "toggle|x %x|y %y",
   "led.unplot|block": "unplot|x %x|y %y",

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -774,9 +774,6 @@ namespace game {
             _sprites[i]._plot(now);
         }
         _img.plotImage(0);
-        // restore previous display mode
-        if (dm != DisplayMode.Greyscale)
-            led.setDisplayMode(dm);
     }
 
     /**

--- a/libs/core/led.cpp
+++ b/libs/core/led.cpp
@@ -110,7 +110,8 @@ namespace led {
      * @param mode mode the display mode in which the screen operates
      */
     //% weight=1 help=led/set-display-mode
-    //% parts="ledmatrix" advanced=true
+    //% parts="ledmatrix" advanced=true weight=1
+    //% blockId="led_set_display_mode" block="set display mode $mode"
     void setDisplayMode(DisplayMode_ mode) {
         uBit.display.setDisplayMode((DisplayMode)mode);
     }

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -526,7 +526,8 @@ declare namespace led {
      * @param mode mode the display mode in which the screen operates
      */
     //% weight=1 help=led/set-display-mode
-    //% parts="ledmatrix" advanced=true shim=led::setDisplayMode
+    //% parts="ledmatrix" advanced=true weight=1
+    //% blockId="led_set_display_mode" block="set display mode $mode" shim=led::setDisplayMode
     function setDisplayMode(mode: DisplayMode): void;
 
     /**


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-microbit/issues/1344

The game engine needs the screen to go in greyscale mode. In v0, this had sideeffects on showLeds because showLeds was setting the brightness to 1 so it would just go dark.

In this change, the game engine sets the greyscale mode and keeps it there. ShowLeds creates images with 255 brightness so there is no visible side effect.

![brightness](https://user-images.githubusercontent.com/4175913/46832473-f8387380-cd5a-11e8-9e29-13a5353bf3b5.gif)

To allow users to control the screen mode, I have expose led.setDisplayMode as a block

![image](https://user-images.githubusercontent.com/4175913/46832469-f53d8300-cd5a-11e8-94f2-f3fb12e3db33.png)
