### PR TITLE
Don't allow decimal inputs for led x y fields

### DIFF
--- a/libs/core/led.cpp
+++ b/libs/core/led.cpp
@@ -20,6 +20,7 @@ namespace led {
     //% blockId=device_plot block="plot|x %x|y %y" blockGap=8
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     void plot(int x, int y) {
       uBit.display.image.setPixelValue(x, y, 0xff);
     }
@@ -34,6 +35,7 @@ namespace led {
     //% blockId=device_plot_brightness block="plot|x %x|y %y|brightness %brightness" blockGap=8
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4 brightness.min=0 brightness.max=255
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     //% advanced=true
     void plotBrightness(int x, int y, int brightness) {
         brightness = max(0, min(0xff, brightness));
@@ -52,6 +54,7 @@ namespace led {
     //% blockId=device_unplot block="unplot|x %x|y %y" blockGap=8
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     void unplot(int x, int y) {
       uBit.display.image.setPixelValue(x, y, 0);
     }
@@ -65,6 +68,7 @@ namespace led {
     //% blockId=device_point block="point|x %x|y %y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     bool point(int x, int y) {
       int pix = uBit.display.image.getPixelValue(x, y);
       return pix > 0;

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -62,6 +62,7 @@
     //% blockId=device_led_toggle block="toggle|x %x|y %y" icon="\uf204" blockGap=8
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     export function toggle(x: number, y: number): void {
         if (led.point(x, y)) {
             led.unplot(x, y);

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -467,6 +467,7 @@ declare namespace led {
     //% blockId=device_plot_brightness block="plot|x %x|y %y|brightness %brightness" blockGap=8
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4 brightness.min=0 brightness.max=255
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
     //% advanced=true shim=led::plotBrightness
     function plotBrightness(x: int32, y: int32, brightness: int32): void;
 
@@ -478,7 +479,8 @@ declare namespace led {
     //% help=led/unplot weight=77
     //% blockId=device_unplot block="unplot|x %x|y %y" blockGap=8
     //% parts="ledmatrix"
-    //% x.min=0 x.max=4 y.min=0 y.max=4 shim=led::unplot
+    //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1 shim=led::unplot
     function unplot(x: int32, y: int32): void;
 
     /**
@@ -489,7 +491,8 @@ declare namespace led {
     //% help=led/point weight=76
     //% blockId=device_point block="point|x %x|y %y"
     //% parts="ledmatrix"
-    //% x.min=0 x.max=4 y.min=0 y.max=4 shim=led::point
+    //% x.min=0 x.max=4 y.min=0 y.max=4
+    //% x.fieldOptions.precision=1 y.fieldOptions.precision=1 shim=led::point
     function point(x: int32, y: int32): boolean;
 
     /**


### PR DESCRIPTION
Don't allow decimal inputs for led x y fields, since it doesn't make sense here.

You should only be allowed to input positive integer values.
We currently clamp the negative value (ie: only allowing positive numbers), but if we add support for clamping the max value, we could consider that for these blocks as well. 

