### PR TITLE
BLE mode by default

### DIFF
--- a/docs/projects/micro-chat.md
+++ b/docs/projects/micro-chat.md
@@ -11,13 +11,9 @@ Use the **radio** to send and receive messages with other @boardname@.
 Use ``||input:on button pressed||`` to send a text message over radio with ``||radio:send string||``.
 Every @boardname@ nearby will receive this message.
 
-You can also add the ``||basic:show icon||`` and ``||basic:clear screen||`` blocks to show a simple animation when the message is sent.
-
 ```blocks
 input.onButtonPressed(Button.A, () => {
     radio.sendString("Yo");
-    basic.showIcon(IconNames.Chessboard)
-    basic.clearScreen();
 });
 ```
 
@@ -48,8 +44,6 @@ Press button **A** on the simulator, you will notice that a second @boardname@ a
 ```blocks
 input.onButtonPressed(Button.A, () => {
     radio.sendString("Yo");
-    basic.showIcon(IconNames.Chessboard)
-    basic.clearScreen();
 });
 radio.onReceivedString(function (receivedString) {
     basic.showString(receivedString);
@@ -65,9 +59,6 @@ If you two @boardname@s, download the program to each one. Press button **A** on
 Use the ``||radio:set group||`` block to assign a **group** number to your program. You will only receive messages from @boardname@s within the same group. Use this to avoid receiving messages from every @boardname@ that is transmitting.
 
 ```blocks
-/**
-* Pick a unique group in your classroom!
-*/
 radio.setGroup(123)
 ```
 

--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -57,7 +57,7 @@
                     "device_info_service": 1,
                     "eddystone_url": 1,
                     "eddystone_uid": 1,
-                    "open": 0,
+                    "open": 1,
                     "pairing_mode": 1,
                     "whitelist": 1,
                     "security_level": "SECURITY_MODE_ENCRYPTION_NO_MITM",
@@ -67,11 +67,11 @@
         },
         "userConfigs": [
             {
-                "description": "No Pairing Required: Anyone can connect via Bluetooth.",
+                "description": "No Pairing Required (default): Anyone can connect via Bluetooth.",
                 "config": {
                     "microbit-dal": {
                         "bluetooth": {
-                            "open": 1,
+                            "open": null,
                             "pairing_mode": null,
                             "whitelist": 0,
                             "security_level": null
@@ -80,11 +80,11 @@
                 }
             },
             {
-                "description": "JustWorks pairing (default): Pairing is automatic once the pairing is initiated.",
+                "description": "JustWorks pairing: Pairing is automatic once the pairing is initiated.",
                 "config": {
                     "microbit-dal": {
                         "bluetooth": {
-                            "open": null,
+                            "open": 0,
                             "pairing_mode": null,
                             "whitelist": null,
                             "security_level": null

--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -59,7 +59,7 @@
                     "eddystone_uid": 1,
                     "open": 1,
                     "pairing_mode": 1,
-                    "whitelist": 1,
+                    "whitelist": 0,
                     "security_level": "SECURITY_MODE_ENCRYPTION_NO_MITM",
                     "partial_flashing": 1
                 }
@@ -72,8 +72,7 @@
                     "microbit-dal": {
                         "bluetooth": {
                             "open": null,
-                            "pairing_mode": null,
-                            "whitelist": 0,
+                            "whitelist": null,
                             "security_level": null
                         }
                     }
@@ -85,8 +84,7 @@
                     "microbit-dal": {
                         "bluetooth": {
                             "open": 0,
-                            "pairing_mode": null,
-                            "whitelist": null,
+                            "whitelist": 1,
                             "security_level": null
                         }
                     }
@@ -98,7 +96,6 @@
                     "microbit-dal": {
                         "bluetooth": {
                             "open": 0,
-                            "pairing_mode": null,
                             "whitelist": 1,
                             "security_level": "SECURITY_MODE_ENCRYPTION_WITH_MITM"
                         }


### PR DESCRIPTION
* Make the BLE open mode default
* always allow to go into pairing mode
Tested with iOS/WebBLE