### PR TITLE
Add more desc to on-received-buffer

### DIFF
--- a/docs/reference/radio/on-received-buffer.md
+++ b/docs/reference/radio/on-received-buffer.md
@@ -6,13 +6,15 @@ Run part of a program when the @boardname@ receives a buffer over ``radio``.
 radio.onReceivedBuffer(function (receivedBuffer) {})
 ```
 
+The data contained in **receivedBuffer** is put there as a data [type](/types). The data might be a [number](/types/number) or a [string](/types/string). When using buffers though, the way the data is placed in the buffer must have a specific format. In particular, numbers must have a certain order when their individual _bytes_ are placed into the buffer. The numbers must also be retrieved from the buffer using the order that they were placed in when set there. You can read more about [number formats](/types/buffer/number-format).
+
 ## Parameters
 
 * **receivedBuffer**: The buffer that was sent in this packet or the empty string if this packet did not contain a string. See [send buffer](/reference/radio/send-buffer)
 
 ## Example: Remote level
 
-If you load this program onto two @boardname@s, each board will send the level information to the other board.
+Two @boardname@s work like remote levels. They lie flat and detect any change in the horizontal position of the plane that they sit in. Each board sends its level measurements to the other. Each level measurment is shown on the screen.
 
 ```typescript
 let ax = 0;
@@ -51,7 +53,8 @@ A radio that can both transmit and receive is called a _transceiver_.
 
 ## See also
 
-[send buffer](/reference/radio/send-buffer)
+[send buffer](/reference/radio/send-buffer),
+[number formats](/types/buffer/number-format)
 
 ```package
 radio

--- a/docs/reference/radio/on-received-number.md
+++ b/docs/reference/radio/on-received-number.md
@@ -50,7 +50,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 The ``||radio:onReceivedNumber||`` event can only be created once, due to the hardware restrictions.
 
-The radio set group might need to be set, synchronized , before the radio events will function.
+The radio set group might need to be set, synchronized, before the radio events will function.
 
 ## See also
 

--- a/docs/reference/radio/on-received-string.md
+++ b/docs/reference/radio/on-received-string.md
@@ -27,7 +27,7 @@ radio.onReceivedString(function (receivedString) {
 
 The ``||radio:on received string||`` event can only be created once, due to the hardware restrictions.
 
-The radio set group might need to be set, synchronized , before the radio events will function.
+The radio set group might need to be set, synchronized, before the radio events will function.
 
 ## See also
 


### PR DESCRIPTION
RE: #1430 

Add some extra description to _on_received_buffer_.

Technically, what does "set, synchronized, before the radio..." mean? Is there a period of time (500ms, etc.) before the group numbers are known between stations?