### PR TITLE
Adding a regex for upgrading Math.random()

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -68,7 +68,8 @@
                         "input\\s*\\.calibrate\\s*\\(": "input.calibrateCompass(",
                         "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedNumber\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedNumber(function (receivedNumber) {",
                         "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString: name, receivedNumber: value\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedValue(function (name, value) {",
-                        "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedString(function (receivedString) {"
+                        "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedString(function (receivedString) {",
+                        "Math\\s*\\.random\\(\\s*((?:-|\\+)?\\s*(?:(?:\\d+)|(?:0x[0-9a-fA-F]+)))\\s*\\)": "Math.randomRange(0, $1)"
                     }
                 },
                 {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -69,7 +69,7 @@
                         "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedNumber\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedNumber(function (receivedNumber) {",
                         "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString: name, receivedNumber: value\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedValue(function (name, value) {",
                         "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedString(function (receivedString) {",
-                        "Math\\s*\\.\\s*random\\(": "Math.randomRange(0, "
+                        "Math\\s*\\.\\s*random\\s*\\(": "Math.randomRange(0, "
                     }
                 },
                 {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -63,13 +63,13 @@
                 {
                     "type": "api",
                     "map": {
-                        "bluetooth\\s*\\.uartRead\\s*\\((.*?)\\)": "bluetooth.uartReadUntil($1)",
-                        "bluetooth\\s*\\.uartWrite\\s*\\((.*?)\\)": "bluetooth.uartWriteUntil($1)",
-                        "input\\s*\\.calibrate\\s*\\(": "input.calibrateCompass(",
-                        "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedNumber\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedNumber(function (receivedNumber) {",
-                        "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString: name, receivedNumber: value\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedValue(function (name, value) {",
-                        "radio\\s*\\.onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedString(function (receivedString) {",
-                        "Math\\s*\\.random\\(\\s*((?:-|\\+)?\\s*(?:(?:\\d+)|(?:0x[0-9a-fA-F]+)))\\s*\\)": "Math.randomRange(0, $1)"
+                        "bluetooth\\s*\\.\\s*uartRead\\s*\\((.*?)\\)": "bluetooth.uartReadUntil($1)",
+                        "bluetooth\\s*\\.\\s*uartWrite\\s*\\((.*?)\\)": "bluetooth.uartWriteUntil($1)",
+                        "input\\s*\\.\\s*calibrate\\s*\\(": "input.calibrateCompass(",
+                        "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedNumber\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedNumber(function (receivedNumber) {",
+                        "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString: name, receivedNumber: value\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedValue(function (name, value) {",
+                        "radio\\s*\\.\\s*onDataPacketReceived\\(\\s*\\(\\{\\s*receivedString\\s*\\}\\)\\s*=>\\s*\\{": "radio.onReceivedString(function (receivedString) {",
+                        "Math\\s*\\.\\s*random\\(": "Math.randomRange(0, "
                     }
                 },
                 {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1378

Should match all of the following:

```typescript
Math.random(123)
Math.random(  -  3   )
Math.random(0xabcd)
Math.random(+ 0xCAFE)
```