### PR TITLE
Turtle tutorial step text continuity

### DIFF
--- a/docs/projects/turtle-square.md
+++ b/docs/projects/turtle-square.md
@@ -2,12 +2,11 @@
 
 ## Introduction @unplugged
 
-Imagine that a virtual turtle, as big as an LED, that you can control it with commands.
-In this tutorial, you will learn to use the turtle and draw a square.
+Imagine that there's a virtual turtle, as small as an LED, that you can control with commands. In this tutorial, you will learn to use the turtle and draw a square.
 
 ## Moving the turtle @fullscreen
 
-The turtle starts in the center of the screen facing up. Place a ``||turtle:forward||`` block to make it move up.
+The turtle starts in the center of the screen heading upward. Place a ``||turtle:forward||`` block to make it move up.
 
 ```blocks
 turtle.forward(1)
@@ -25,10 +24,9 @@ turtle.forward(1)
 
 ## Drawing a square
 
-If you add enough ``||turtle:turnRight||`` and ``||turtle:forward||`` block, the turtle 
-will eventually draw a square. 
+If you add enough ``||turtle:turnRight||`` and ``||turtle:forward||`` blocks, the turtle will eventually draw a square. 
 
-You can move the blocks in a ``||input:on button pressed||`` to easily run the code again.
+You can move the blocks into a ``||input:on button pressed||`` to easily run the code again.
 
 ```blocks
 input.onButtonPressed(Button.A, function() {
@@ -43,10 +41,9 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## "For" is for repetition
+## "for" is for repetition
 
-Have you notice the repetition pattern in the blocks needed to draw a square?
-Try to use a ``for`` loop to achieve the same effect.
+Did you notice the pattern of repeated blocks needed to draw a square? Try using a ``for`` loop to achieve the same effect.
 
 ```blocks
 input.onButtonPressed(Button.A, function() {
@@ -57,11 +54,9 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-
 ## Leaving a trail
 
-The turtle holds a pen that turns on LEDs. If you add the ``||turtle:pen||`` block,
-it will leave a trail as it moves.
+The turtle holds a **pen** that can turn on LEDs. If you add the ``||turtle:pen||`` block, it will leave a trail as the turtle moves.
 
 ```blocks
 input.onButtonPressed(Button.A, function() {

--- a/docs/projects/turtle.md
+++ b/docs/projects/turtle.md
@@ -7,19 +7,19 @@ Turtle graphics on your @boardname@ screen!
 ```codecard
 [{
   "name": "Square",
-  "description": "Move in a square",
+  "description": "Move the turtle in a square pattern.",
   "url": "/projects/turtle-square",
   "imageUrl":"/static/mb/projects/turtle-square.png",
   "cardType": "tutorial"
 }, {
   "name": "Spiral",
-  "description": "Move in a spiral",
+  "description": "Move the turtle in a spiral.",
   "url": "/projects/turtle-spiral",
   "imageUrl":"/static/mb/projects/turtle-spiral.png",
   "cardType": "side"
 }, {
   "name": "Scanner",
-  "description": "Scan down the screen",
+  "description": "Let the turtle scan across and down the screen.",
   "url": "/projects/turtle-scanner",
   "imageUrl":"/static/mb/projects/turtle-scanner.png",
   "cardType": "side"


### PR DESCRIPTION
Tutorial text is split out on the first newline rather than the second (i.e. paragraph break). To fix this the newlines are removed from the paragraphs.

- [x] Put step text in one continuous line.
- [x] Few minor edits too.

RE: #1509