### PR TITLE
Update the the connect code for 'inchworm'

### DIFF
--- a/docs/projects/inchworm/connect.md
+++ b/docs/projects/inchworm/connect.md
@@ -11,7 +11,7 @@ Remote control your inchworm with another @boardname@
 You will need one more @boardname@ for this part. By using the radio, we can control the inchworm with another @boardname@. Download the code below to the @boardname@ on the inchworm and then again onto a "controller" @boardname@. Whenever button **A** is pressed, the inchworm moves once.
 
 ```blocks
-radio.onReceivedNumber(({ receivedNumber }) => {
+radio.onReceivedNumber(function (receivedNumber: number) {
     pins.servoWritePin(AnalogPin.P0, 0)
     basic.pause(500)
     pins.servoWritePin(AnalogPin.P0, 180)


### PR DESCRIPTION
Old syntax fails compilation in block example for the Inchworm Connect page.