### PR TITLE
Make 'experiments' an override page

### DIFF
--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,16 +1,6 @@
-# Experiments
+# @extends
 
-Experiments are new features that may become part of the editor in the future or they are just cool new ideas to try out! Once you enable an experimental feature, you can try it out and see how you like it.
-
-## Enable Experiments
-
-You can see which experiments are available by going to the **Settings** menu and clicking on **About...**. In the **About** dialog, press the **Experiments** button. A selection of available experiments is displayed and you can enable them by clicking on them. If you click on one, the label for the experiment will change from **Disabled** to **Enabled**. The experimental feature is then ready for you to use. When you go back to the editor, a message at the top will appear briefly telling you that experments are enabled. Later, you can go back to the experiments selection and click again on the ones you want to set back to disabled.
-
-## Using an Experimental Feature
-
-Depending on the type of feature the experiment is providing, you will work with it in the editor using some new element such as a button or a menu selection (most likely in **Settings**). Once the experiment is enabled and you go back to the editor, the new button or menu choice will show up.
-
-## Current Experiments
+## Current Experiments #current
 
 The current experimental features we're testing and making available are:
 
@@ -21,7 +11,3 @@ The current experimental features we're testing and making available are:
 * Debugger
 * Bluetooth Console
 * Bluetooth Download
-
-## Feedback
-
-On each experiment selection is a feedback link for you tell us how the feature worked or to make a suggestion if you want. Any feedback is welcome, thanks!


### PR DESCRIPTION
Change _experiments.md_ to an override page from _pxt/expermiments.md_.

Depends on  https://github.com/Microsoft/pxt/pull/4936

RE: https://github.com/Microsoft/pxt-microbit/pull/1550#issuecomment-433787557
