### PR TITLE
bump to pxt 4.2 -- bump pxt-microbit to 1.2...

### DIFF
--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -8,80 +8,37 @@ Learn how to use the LEDs and make a flashing heart!
 
 ## Step 1 @fullscreen
 
-Place the ``||basic:show leds||`` block in the ``||basic:on start||`` block and draw a heart.
+Place the ``||basic:show leds||`` block in the ``||basic:forever||`` block and draw a heart.
 
 ![An animation that shows how to drag a block and paint a heart](/static/mb/projects/flashing-heart/showleds.gif)
 
 ## Step 2 @fullscreen
 
-Place another ``||basic:show leds||`` block under the heart to make it blink. Check in the simulator to see the heart blink.
+Place another ``||basic:show leds||`` block. You can leave it blank and draw what you want.
 
 ```blocks
-basic.showLeds(`
-    . # . # .
-    # # # # #
-    # # # # #
-    . # # # .
-    . . # . .`);
-basic.showLeds(`
-    . . . . .
-    . . . . .
-    . . . . .
-    . . . . .
-    . . . . .`);
-```
-
-## Step 3 @fullscreen
-
-But we only see the heart blink once. To have it continue to blink, move the blocks inside the ``||basic:forever||`` to make the animation repeat.
-
-```blocks
-basic.forever(() => {
+basic.forever(function() {
     basic.showLeds(`
         . # . # .
         # # # # #
         # # # # #
         . # # # .
-        . . # . .`
-        );
-    basic.showLeds(`
-        . . . . .
-        . . . . .
-        . . . . .
-        . . . . .
-        . . . . .`
-        );
-})
-```
-
-## Step 4 @fullscreen
-
-Now let's get fancy and place more ``||basic:show leds||`` blocks to create your own animation.
-
-```blocks
-basic.forever(() => {
-    basic.showLeds(`
-        . # . # .
-        # # # # #
-        # # # # #
-        . # # # .
-        . . # . .`
-        );
-    basic.showLeds(`
-        . # . # .
-        # . # . #
-        # . . . #
-        . # . # .
         . . # . .`);
     basic.showLeds(`
         . . . . .
-        . # . # .
-        . # # # .
-        . . # . .
+        . . . . .
+        . . . . .
+        . . . . .
         . . . . .`);
 })
 ```
 
-## Step 5 @fullscreen
+## Step 3 @fullscreen
+
+Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
+
+![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
+
+## Step 4 @fullscreen
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -8,7 +8,7 @@ Tell everyone who you are. Show you name on the LEDs.
 
 ## Step 1 @fullscreen
 
-Place the ``||basic:show string||`` block in the ``||basic:on start||`` block. Change the text to your name.
+Place the ``||basic:show string||`` block in the ``||basic:forever||`` block. Change the text to your name.
 
 ```blocks
 basic.forever(() => {
@@ -20,20 +20,15 @@ basic.forever(() => {
 
 Look at the simulator and make sure it shows up your name on the screen.
 
+![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
+
 ## Step 3 @fullscreen
 
-Place more ``||basic:show leds||`` or ``||basic:show string||`` blocks to create your own animation.
+Place more ``||basic:show string||`` blocks to create your own story.
 
 ```blocks
 basic.forever(() => {
     basic.showString("MICRO");
-    basic.showLeds(`
-        . # . # .
-        # # # # #
-        # # # # #
-        . # # # .
-        . . # . .`
-        );
     basic.showString("<3<3<3");
 })
 ```

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -8,7 +8,7 @@ Tell everyone who you are. Show you name on the LEDs.
 
 ## Step 1 @fullscreen
 
-Place the ``||basic:show string||`` block in the ``||basic:forever||`` block. Change the text to your name.
+Place the ``||basic:show string||`` block in the ``||basic:forever||`` block to repeat it. Change the text to your name.
 
 ```blocks
 basic.forever(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-microbit",
-  "version": "1.1.90",
+  "version": "1.2.0",
   "description": "micro:bit target for Microsoft MakeCode (PXT)",
   "keywords": [
     "JavaScript",
@@ -42,7 +42,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "0.24.12",
-    "pxt-core": "4.1.49"
+    "pxt-common-packages": "0.25.2",
+    "pxt-core": "4.2.12"
   }
 }


### PR DESCRIPTION
We can do a 4.1 branch before this change.
- [x] fixing flashing-heart, name-tag
- [x] this fix contains the targetstrings.json harvesting bug which means "download"dialog strings will be available in crowding after bumpding.