### PR TITLE
Bump to 4.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "pxt-common-packages": "0.25.10",
-    "pxt-core": "4.6.2"
+    "pxt-core": "4.4.7"
   }
 }


### PR DESCRIPTION
https://github.com/Microsoft/pxt-microbit/commit/383ebc4579a59ad22a813f82a1ec3a0f4526b340 moved to pxt/v6 but I actually need it at 4.4 for the release. 
Updating to v4.4.7 with Android touch fixes. 

Once this is in I'll bump.