### PR TITLE
Fix snap the dot tutorial

### DIFF
--- a/docs/projects/snap-the-dot.md
+++ b/docs/projects/snap-the-dot.md
@@ -70,7 +70,7 @@ basic.forever(function () {
 
 Finally, pull out an ``||game:add score||`` and a ``||game:game over||`` block to handle both success (sprite in the center) and failure (sprite not in the center).
 
- ```blocks
+```blocks
 let sprite: game.LedSprite = null
 input.onButtonPressed(Button.A, function () {
     if (sprite.get(LedSpriteProperty.X) == 2) {


### PR DESCRIPTION
Remove extra whitespace from ```blocks causing tutorial not to decompile. 

Our engine should probably handle this case..

Fixes https://github.com/Microsoft/pxt-microbit/issues/1650