### PR TITLE
Show block for isGameOver(),isRunning(),isPaused()

### DIFF
--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -252,7 +252,8 @@ namespace game {
     /**
      * Gets a value indicating if the game is still running. Returns `false` if game over.
      */
-    //% weight=10
+    //% weight=5 help=game/isrunning
+    //% blockId=game_isrunning block="is running?" blockGap=8
     export function isRunning(): boolean {
         let running: boolean;
         return !_isGameOver;
@@ -272,6 +273,8 @@ namespace game {
     /**
      * Indicates if the game is display the game over sequence.
      */
+    //% weight=7 help=game/isgameover
+    //% blockId=game_isgameover block="is game over?" blockGap=8
     export function isGameOver(): boolean {
         return _isGameOver;
     }
@@ -279,7 +282,8 @@ namespace game {
     /**
      * Indicates if the game rendering is paused to allow other animations
      */
-    //%
+    //% weight=6 help=game/ispaused
+    //% blockId=game_ispaused block="is paused?" blockGap=8
     export function isPaused(): boolean {
         return _paused;
     }


### PR DESCRIPTION
Current gameOver function will showScore, when the user add the score after gameover(e.g. press A button to add the score), the score will changing always, to avoid this kind of issue for block kids/users, I add this three block to show, thanks.

showScore() issue in gameOver:
https://github.com/Microsoft/pxt-microbit/blob/08e9c9c4166c271e15ef802a4628cfe326fca62d/libs/core/game.ts#L140
