### PR TITLE
Update some music ref docs

### DIFF
--- a/docs/reference/music.md
+++ b/docs/reference/music.md
@@ -19,6 +19,6 @@ music.setTempo(120);
 
 [playTone](/reference/music/play-tone), [ringTone](/reference/music/ring-tone), [rest](/reference/music/rest),
 [beginMelody](/reference/music/begin-melody), 
-[stop melody](/reference/music/stop-melody),
+[stopMelody](/reference/music/stop-melody),
 [onEvent](/reference/music/on-event),
 [beat](/reference/music/beat), [tempo](/reference/music/tempo), [changeTempoBy](/reference/music/change-tempo-by), [setTempo](/reference/music/set-tempo),

--- a/docs/reference/music/beat.md
+++ b/docs/reference/music/beat.md
@@ -2,13 +2,13 @@
 
 Returns the duration of a beat in milli-seconds
 
-## Simulator
-
-This function only works on the @boardname@ and in some browsers.
-
 ```sig
 music.beat(BeatFraction.Whole)
 ```
+
+## Simulator
+
+This function only works on the @boardname@ and in some browsers.
 
 ## Parameters
 

--- a/docs/reference/music/beat.md
+++ b/docs/reference/music/beat.md
@@ -6,9 +6,11 @@ Returns the duration of a beat in milli-seconds
 music.beat(BeatFraction.Whole)
 ```
 
-## Simulator
+## ~ hint
 
-This function only works on the @boardname@ and in some browsers.
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
 
 ## Parameters
 

--- a/docs/reference/music/begin-melody.md
+++ b/docs/reference/music/begin-melody.md
@@ -60,5 +60,5 @@ music.beginMelody(['g4:1', 'c5', 'e', 'g:2', 'e:1', 'g:3'], MelodyOptions.Foreve
 [tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
 [change tempo by](/reference/music/change-tempo-by)
 
-[Making Melodies](/reference/music/making/melodies)
+[Making Melodies](/reference/music/making-melodies)
 

--- a/docs/reference/music/begin-melody.md
+++ b/docs/reference/music/begin-melody.md
@@ -1,24 +1,43 @@
-# Begin Melody
+# begin Melody
 
 Begin playing a musical melody through pin ``P0`` of the @boardname@.
-
-## Simulator
-
-This function only works on the @boardname@ and in some browsers.
 
 ```sig
 music.beginMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once)
 ```
-or in the format ``NOTE[octave][:duration] eg: ['g5:1']``
-```sig
+
+## ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
+
+There are built-in melodies that you can choose from the ``||start melody||`` block. These are already composed for you and are easy to use by just selecting the one you want. If you want to play your own melody, you can [compose](/reference/music/making-melodies) one and use it instead of one of the built-in ones.
+
+Melodies are a sequence of notes, each played for some small amount time, one after the other. The notes in a melody are held in an [array](/types/array) of [strings](/types/string). Each string in the array is a note of the melody. You make a melody by assembling the notes along with the _duration_ that the note plays for. The melody is [formed](/reference/music/making-melodies) like this:
+
+``NOTE[octave][:duration] eg: ['g5:1']``
+
+```block
 music.beginMelody(['g4:1', 'c5', 'e', 'g:2', 'e:1', 'g:3'], MelodyOptions.Once)
 ```
 
+Melodies are played either in the _foreground_ or _background_. This allows more than one melody to be active at once. If a melody is set to play in the background, it can be interrupeted, or paused, temporarily while a melody set for the foreground is played. If the foreground melody is not set to play ``forever``, then the background melody resumes when the foreground melody is finished.
+
+You can set options for how you want the melody to play. You can ask that the melody plays just one time, ``once``, or have it keep repeating, ``forever``. With these options the melody will play in the foreground either once or continue to repeat. Of course, if you set ``forever``, any melody that was started in background will never play unless you [stop](/reference/music/stop-melody) the foreground melody. To make a background melody, set the option to ``once in background`` or ``forever in background``.
+
 ## Parameters
 
-* ``melody`` is the array representation of a melody you wish to play
+* **melody**: A built-in melody or an [array](/types/array) representation of a [melody](reference/music/making-melodies) you wish to play.
+* **options**: the play option for the melody:
+>* ``once``: play the melody in the foreground one time
+>* ``forever``: play the melody in the foreground and keep repeating it
+>* ``once in background``: play the melody in the background one time
+>* ``forever in background``: play the melody in the background and keep repeating it
 
-## Example
+## Examples
+
+### Play the "Entertainer"
 
 This example plays the ``Entertainer`` built-in melody.
 
@@ -26,8 +45,20 @@ This example plays the ``Entertainer`` built-in melody.
 music.beginMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once)
 ```
 
+### Play a composed melody forever
+
+Play a made-up melody in the background forever.
+
+```blocks
+music.beginMelody(['g4:1', 'c5', 'e', 'g:2', 'e:1', 'g:3'], MelodyOptions.ForeverInBackground)
+```
+
 ## See also
 
-[play tone](/reference/music/play-tone), [rest](/reference/music/rest), [ring tone](/reference/music/ring-tone) , [tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo), 
+[stop melody](/reference/music/stop-melody), [play tone](/reference/music/play-tone),
+[rest](/reference/music/rest), [ring tone](/reference/music/ring-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
 [change tempo by](/reference/music/change-tempo-by)
+
+[Making Melodies](/reference/music/making/melodies)
 

--- a/docs/reference/music/change-tempo-by.md
+++ b/docs/reference/music/change-tempo-by.md
@@ -3,13 +3,15 @@
 Makes the [tempo](/reference/music/tempo) (speed of a piece of music)
 faster or slower by the amount you say.
 
-## Simulator
-
-This function only works on the @boardname@ and in some browsers.
-
 ```sig
 music.changeTempoBy(20)
 ```
+
+## ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
 
 ## Parameters
 

--- a/docs/reference/music/making-melodies.md
+++ b/docs/reference/music/making-melodies.md
@@ -1,0 +1,66 @@
+# Making melodies
+
+Composing some sound, or maybe some music, is done by putting tones to together, one after another. A _melody_ is a sequence of these tones each played, for some short amount of time, one after the other until all notes have played.
+
+## Musical notes
+
+A _note_ is a tone that is recognized as part of music. A note has a name like '**C**'. A note is played for an amount of time called its _duration_. 
+
+On your @boardname@, a note is played on the speaker by sending a signal to a it with a certain _frequency_ called [Hertz](http://wikipedia.org/Hertz). Frequency is how fast something vibrates during one second. If you ring a bell that was made to play an '**A**' note, the bell will vibrate at 440 Hertz (440 times per second). So, notes are just certain frequencies that have special names.
+
+In history, music came from tones that seemed nice to hear. The tones were played on wood, strings, metal, and skins. These tones were given names and they became what we know today as musical notes. Notes were named so we could write them down and remember how to play them again later.
+
+## How are notes named?
+
+Basic notes have names that use one of the first nine letters of the alphabet. They are:
+
+``|A|``, ``|B|``, ``|C|``, ``|D|``, ``|E|``, ``|F|``, ``|G|``
+
+Ther are other notes named like the basic notes but have extra parts to the name called _sharp_ and _flat_. These other notes are just a bit different from the basic notes and have frequencies a little higher or lower than the basic note. This makes music a little more complicated but much more interesting!
+
+Some of these other notes look like:
+
+``|C#|``, ``|Eb|``
+
+When a small amount music or even a song is written down it is called [sheet music](https://wikipedia.org/wiki/Sheet_music).
+
+## Sounds and music in code
+
+Of course, we can't use written music in our code. We can make music another way. The way to do it is to put names of notes in [strings](/types/string). We make our notes using letters, symbols, and numbers. The notes of a melody are put together in an array like:
+
+```block
+let melody = ['E3:3', 'R:1', 'D#:3', 'R:1', 'D:4', 'R:1', 'C#:8']
+```
+
+In JavaScript code, it looks like this:
+
+```typescript
+let melody = ['E3:3', 'R:1', 'D#:3', 'R:1', 'D:4', 'R:1', 'C#:8']
+```
+
+What you see here is not some alien language but a bunch of notes with their duration. The form of a single note is **note : duration** or ``'C:2'``. This means play the '**C**' note for **2** beats of time. The notes are placed one after the other, in an array, with a comma between them, like ``'B:2', 'C#:6'``. If you want a note to play for **4** beats, you don't need to use any duration number (a note with 4 beats is called a _whole_ note). Just say something like ``'E'`` with no colon (leave out the ``':'``) and no duration number.
+
+You might notice that the sound string has an ``'R:1'`` in it. The '**R**` means _rest_ and to rest for one beat. A rest is a pause, or a time of silence, in the sound.
+
+
+#### ~ hint
+
+**Duration**
+
+The amount of time a note is played (duration) is measured as _beats_. The standard number _beats per minute_ (bpm) in music is 120 bpm which is one-half of a second of time. A _whole_ note lasts for 4 beats and a _quarter_ note takes just one beat.
+
+#### ~
+
+## Example
+
+Compose the first few notes of Beethoven's 5th symphony.
+
+```blocks
+let beet5 = ['G:1', 'G:1', 'G:1', 'Eb', 'F:1', 'F:1', 'F:1', 'D']
+```
+
+## See also
+
+[begin melody](/reference/music/begin-melody)
+
+[Tempo](https://wikipedia.org/wiki/Tempo)

--- a/docs/reference/music/rest.md
+++ b/docs/reference/music/rest.md
@@ -2,13 +2,15 @@
 
 Rest (play no sound) through pin `PO` for the amount of time you say.
 
-## Simulator
-
-This function only works on the @boardname@ and in some browsers.
-
 ```sig
 music.rest(400)
 ```
+
+### ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
 
 ## Parameters
 

--- a/docs/reference/music/ring-tone.md
+++ b/docs/reference/music/ring-tone.md
@@ -3,13 +3,15 @@
 Play a musical tone through pin `P0` with the pitch as high or low as you say.
 The tone will keep playing until you tell it not to.
 
-## Simulator
-
-This function only works on the @boardname@ and in some browsers.
-
 ```sig
 music.ringTone(440)
 ```
+
+## ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
 
 ## Parameters
 

--- a/docs/reference/music/set-tempo.md
+++ b/docs/reference/music/set-tempo.md
@@ -5,9 +5,11 @@ Makes the tempo (speed of a piece of music) as fast or slow as you say.
 ```sig
 music.setTempo(60)
 ```
-## Simulator
+## ~ hint
 
-This function only works on the @boardname@ and in some browsers.
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
 
 ## Parameters
 

--- a/docs/reference/music/stop-melody.md
+++ b/docs/reference/music/stop-melody.md
@@ -1,20 +1,33 @@
-# Stop Melody
+# stop Melody
 
-Stops playing a musical melody.
-
-## Simulator
+Stop playing a musical melody.
 
 ```sig
 music.stopMelody(MelodyStopOptions.All)
 ```
 
+Melodies are played either in the _foreground_ or _background_. This allows more than one melody to be active at once. If a melody is set to play in the background, it can be interrupeted, or paused, temporarily while a melody set for the foreground is played. If the foreground melody is not set to play ``forever``, then the background melody resumes when the foreground melody is finished.
+
+When a melody begins, it has an option set for how the melody is to play. The melody plays just one time, ``once``, or it will keep repeating, ``forever``. With these options the melody will play in the foreground either once or continue to repeat. Of course, if you set ``forever``, any melody that was started in background will never play unless you stop the foreground melody.
+
+You can stop either a ``foreground`` melody, a ``background`` melody, or ``all`` melodies.
+
+## ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
+
 ## Parameters
 
-* ``options`` specifies which melodies (foreground, background or both) need to be stopped
+* **options**: specify which melodies (foreground, background or both) to stop:
+>* ``all``: stop all melodies
+>* ``foreground``: stop the foreground melody
+>* ``background``: stop the background melody
 
 ## Example
 
-This example plays the ``Entertainer`` built-in melody.
+Play the ``Entertainer`` built-in melody and then stop it after 5 seconds.
 
 ```blocks
 music.beginMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Forever)


### PR DESCRIPTION
- [x] Change the nasty **Simulator** sections into a note.
- [x] Add more descriptive stuff to _begin-melody_ and _stop-melody_.
- [x] Adapt the _composing-sounds_ doc from common-packages into _making-melodies_ as a side-ref.
- [x] Touch up example sections.

RE: #1633 
