### PR TITLE
Put 'writeLine' into serial ref example

### DIFF
--- a/docs/reference/serial/write-line.md
+++ b/docs/reference/serial/write-line.md
@@ -1,6 +1,6 @@
 # Serial Write Line
 
-Write a string to the [serial](/device/serial) port and start a new line of text
+Write a string to the [serial](/device/serial) port and start a new line of text 
 by writing `\r\n`.
 
 ```sig
@@ -11,9 +11,11 @@ serial.writeLine("");
 
 * `text` is the [string](/types/string) to write to the serial port
 
-## Example: simple serial
+## Examples
 
-This program writes the word `BOFFO` to the serial port repeatedly.
+### Simple serial
+
+Write the word `BOFFO` to the serial port repeatedly.
 
 ```blocks
 basic.forever(() => {
@@ -22,29 +24,36 @@ basic.forever(() => {
 });
 ```
 
-## Example: streaming data
+### Streaming data
 
-This program checks the
-[compass heading](/reference/input/compass-heading) and sends the
-direction to the serial port repeatedly.
+Check the [compass heading](/reference/input/compass-heading) and show the direction on the screen. Also, send both the direction and degree heading to the serial port.
 
 ```blocks
 let degrees = 0
+let direction = ""
 basic.forever(() => {
     degrees = input.compassHeading()
     if (degrees < 45) {
         basic.showArrow(ArrowNames.North)
+        direction = "North"
     } else if (degrees < 135) {
         basic.showArrow(ArrowNames.East)
+        direction = "East"
     } else if (degrees < 225) {
         basic.showArrow(ArrowNames.South)
+        direction = "South"
     } else if (degrees < 315) {
         basic.showArrow(ArrowNames.West)
+        direction = "West"
     } else {
         basic.showArrow(ArrowNames.North)
+        direction = "North"
     }
+    serial.writeLine(direction + " @ " + degrees + "degrees")
+    basic.pause(500)
 })
 ```
+
 ## See also
 
 [serial](/device/serial),


### PR DESCRIPTION
The actual use of ``serial.writeLine()`` was missing in the example....doh!

RE: #1746