### PR TITLE
Extend offline page to include app section

### DIFF
--- a/docs/offline.md
+++ b/docs/offline.md
@@ -2,4 +2,4 @@
 
 ## Offline app #target-app
 
-The MakeCode editor is available as app which you can install on a computer with Windows or Mac OS. Once installed, the [MakeCode Offline App](offline-app) lets you create, run, and download your projects to the @boardname@. It works the same as the Web application does in your browser but it's a stand-alone application that will work when a connection to the internet is restricted or not available.
+The MakeCode editor is available as app which you can install on a computer with Windows or Mac OS. Once installed, the **[MakeCode Offline App](offline-app)** lets you create, run, and download your projects to the @boardname@. It works the same as the Web application does in your browser but it's a stand-alone application that will work when a connection to the internet is restricted or not available.

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,5 @@
+# @extends
+
+## Offline app #target-app
+
+The MakeCode editor is available as app which you can install on a computer with Windows or Mac OS. Once installed, the [MakeCode Offline App](offline-app) lets you create, run, and download your projects to the @boardname@. It works the same as the Web application does in your browser but it's a stand-alone application that will work when a connection to the internet is restricted or not available.


### PR DESCRIPTION
Extend the pxt offline base page to include a section for the offline app.

Move this section to the top above **Web application**?

RE: #1852 
