### PR TITLE
reduce GC heap size when BLE is used

### DIFF
--- a/libs/core/pxtcore.h
+++ b/libs/core/pxtcore.h
@@ -14,7 +14,11 @@ void debuglog(const char *format, ...);
 #define xmalloc malloc
 #define xfree free
 
+#if CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
+#define GC_BLOCK_SIZE 256
+#else
 #define GC_BLOCK_SIZE 1000
+#endif
 
 #define DMESG NOLOG
 


### PR DESCRIPTION
Reducing to 256bytes by default.