### PR TITLE
Bringing text back in the sim

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -140,6 +140,9 @@ namespace pxsim.visuals {
             stroke: none;
             fill: #777;
         }
+        .sim-label, .sim-button-label {
+            fill: #000;
+        }
         .sim-wireframe .sim-board {
             stroke-width: 2px;
         }


### PR DESCRIPTION
The button labels disappeared from the sim in beta:

![image](https://user-images.githubusercontent.com/13754588/54321043-90f24a00-45ac-11e9-9cb5-21afc3f2fa57.png)

The GIF generation changes caused it, but I'm not totally sure why. Adding an explicit CSS rule to fix it.