### PR TITLE
Insert kitronik servo guide link

### DIFF
--- a/docs/device/servo.md
+++ b/docs/device/servo.md
@@ -10,6 +10,12 @@ If you are conducting a class or group activity, you should consider preparing a
 
 The @boardname@ provides just enough current to operate the SG90 microservo. This servo requires 3 connections: **GND**, **3V** and a logic **pin**. In this tutorial, we will equip the servo with crocodile clips to make it easier to use. However, you could also use a shield or crocodile clips with a male connector on one end to achieve the same result.
 
+### ~ hint
+
+To better understand how servos work and how they are controlled, take a few minutes to read this [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf).
+
+### ~
+
 ## The easy way: Alligator/Crocodile Clip to Male Jumpers #hintconnection
 
 The easiest way to connect a servo to the @boardname@ is to use cables with an **Alligator/Crocodile clip** on one end

--- a/docs/projects/servo-calibrator.md
+++ b/docs/projects/servo-calibrator.md
@@ -24,3 +24,7 @@ basic.forever(() => {
 })
 pins.servoWritePin(AnalogPin.P0, angle)
 ```
+
+## See also
+
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)

--- a/docs/reference/pins/servo-set-pulse.md
+++ b/docs/reference/pins/servo-set-pulse.md
@@ -27,3 +27,6 @@ pins.servoSetPulse(AnalogPin.P0, 1000)
 [analog read pin](/reference/pins/analog-read-pin),
 [digital read pin](/reference/pins/digital-read-pin),
 [digital write pin](/reference/pins/digital-write-pin)
+
+ [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+

--- a/docs/reference/pins/servo-set-pulse.md
+++ b/docs/reference/pins/servo-set-pulse.md
@@ -28,5 +28,5 @@ pins.servoSetPulse(AnalogPin.P0, 1000)
 [digital read pin](/reference/pins/digital-read-pin),
 [digital write pin](/reference/pins/digital-write-pin)
 
- [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
 

--- a/docs/reference/pins/servo-write-pin.md
+++ b/docs/reference/pins/servo-write-pin.md
@@ -46,3 +46,4 @@ pins.servoWritePin(AnalogPin.P0, 0)
 
 [@boardname@ pins](/device/pins), [servo set pulse](/reference/pins/servo-set-pulse)
 
+ [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)

--- a/docs/reference/pins/servo-write-pin.md
+++ b/docs/reference/pins/servo-write-pin.md
@@ -46,4 +46,4 @@ pins.servoWritePin(AnalogPin.P0, 0)
 
 [@boardname@ pins](/device/pins), [servo set pulse](/reference/pins/servo-set-pulse)
 
- [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)


### PR DESCRIPTION
Include a link to the Kitronik servo guide in the servo pages.

https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf

RE: https://github.com/Microsoft/pxt-common-packages/pull/753