### PR TITLE
Update the max length of a name in a sendValue packet

### DIFF
--- a/docs/reference/radio/send-value.md
+++ b/docs/reference/radio/send-value.md
@@ -1,7 +1,7 @@
 # send Value
 
 Send a [string]() and [number]() together by ``radio`` to other @boardname@s.
-The maximum [string]() length is 12 characters.
+The maximum [string]() length is 8 characters.
 
 ```sig
 radio.sendValue("name", 0);

--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -71,7 +71,7 @@ namespace radio {
     /**
     * Sends an event over radio to neigboring devices
     */
-    //% blockId=radioRaiseEvent block="radio raise event|from source %src=control_event_source_id|with value %value=control_event_value_id" 
+    //% blockId=radioRaiseEvent block="radio raise event|from source %src=control_event_source_id|with value %value=control_event_value_id"
     //% blockExternalInputs=1
     //% advanced=true
     //% weight=1
@@ -259,8 +259,9 @@ namespace radio {
 
     /**
     * Broadcasts a name / value pair along with the device serial number
-    * and running time to any connected micro:bit in the group.
-    * @param name the field name (max 12 characters), eg: "name"
+    * and running time to any connected micro:bit in the group. The name can
+    * include no more than 8 characters.
+    * @param name the field name (max 8 characters), eg: "name"
     * @param value the numeric value
     */
     //% help=radio/send-value
@@ -360,7 +361,7 @@ namespace radio {
             return fromInt(ivalue);
         else if (type == PACKET_TYPE_DOUBLE || type == PACKET_TYPE_DOUBLE_VALUE)
             return fromDouble(dvalue);
-        else 
+        else
             return fromInt(0);
     }
 

--- a/libs/radio/shims.d.ts
+++ b/libs/radio/shims.d.ts
@@ -27,7 +27,7 @@ declare namespace radio {
      * Broadcasts a name / value pair along with the device serial number
      * and running time to any connected micro:bit in the group.
      * @param name the field name (max 12 characters), eg: "name"
-     * @param value the numberic value
+     * @param value the numeric value
      */
     //% help=radio/send-value
     //% weight=59

--- a/sim/state/radio.ts
+++ b/sim/state/radio.ts
@@ -160,7 +160,7 @@ namespace pxsim.radio {
     }
 
     export function sendValue(name: string, value: number) {
-        name = name.substr(0, 12);
+        name = name.substr(0, 8);
         const msg: number[] = [];
         msg.push()
         board().radioState.datagram.send({


### PR DESCRIPTION
It went from 12 characters to 8 when we started supporting floating points. This PR fixes the simulator, JS doc, and reference for the function. @ganicke feel free to push any changes to this branch!