### PR TITLE
Set loading background to blue

### DIFF
--- a/theme/site/modules/dimmer.variables
+++ b/theme/site/modules/dimmer.variables
@@ -1,3 +1,5 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+@backgroundColor: fade(@blue, 40%);


### PR DESCRIPTION
Updating the loading background to blue in the editor:
![microbit editor with blue background](https://user-images.githubusercontent.com/34112083/55366761-0449f600-549f-11e9-8263-980cd7c92389.gif)

@jaustin To address the loading overlay color from #1103, we set the background to blue. Let us know how this looks!