### PR TITLE
Remove c++ macros that are moving to common packages

### DIFF
--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -1,28 +1,3 @@
 // helpful define to handle C++ differences in package
 #define PXT_MICROBIT_TAGGED_INT 1
-
-// cross version compatible way of access data field
-#ifndef PXT_BUFFER_DATA
-#define PXT_BUFFER_DATA(buffer) buffer->data
-#endif
-
-// cross version compatible way of access data length
-#ifndef PXT_BUFFER_LENGTH
-#define PXT_BUFFER_LENGTH(buffer) buffer->length
-#endif
-
-#ifndef PXT_CREATE_BUFFER
-#define PXT_CREATE_BUFFER(data, len) pxt::mkBuffer(data, len)
-#endif
-
-// cross version compatible way of accessing string data
-#ifndef PXT_STRING_DATA
-#define PXT_STRING_DATA(str) str->getUTF8Data()
-#endif
-
-// cross version compatible way of accessing string length
-#ifndef PXT_STRING_DATA_LENGTH
-#define PXT_STRING_DATA_LENGTH(str) str->getUTF8Size()
-#endif
-
 #define PXT_POWI 1

--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -3,7 +3,7 @@
 
 // cross version compatible way of access data field
 #ifndef PXT_BUFFER_DATA
-#define PXT_BUFFER_DATA(buffer) buffer->data
+#define PXT_BUFFER_DATA(buffer) buffer->getUTF8Data()
 #endif
 
 #ifndef PXT_CREATE_BUFFER

--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -21,8 +21,8 @@
 #endif
 
 // cross version compatible way of accessing string length
-#ifndef PXT_STRING_LENGTH
-#define PXT_STRING_LENGTH(str) str->getLength()
+#ifndef PXT_STRING_DATA_LENGTH
+#define PXT_STRING_DATA_LENGTH(str) str->getUTF8Size()
 #endif
 
 #define PXT_POWI 1

--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -3,11 +3,21 @@
 
 // cross version compatible way of access data field
 #ifndef PXT_BUFFER_DATA
-#define PXT_BUFFER_DATA(buffer) buffer->getUTF8Data()
+#define PXT_BUFFER_DATA(buffer) buffer->data
 #endif
 
 #ifndef PXT_CREATE_BUFFER
 #define PXT_CREATE_BUFFER(data, len) pxt::mkBuffer(data, len)
+#endif
+
+// cross version compatible way of accessing string data
+#ifndef PXT_BOXED_STRING_DATA
+#define PXT_BOXED_STRING_DATA(boxedString) boxedString->getUTF8Data()
+#endif
+
+// cross version compatible way of accessing string size
+#ifndef PXT_BOXED_STRING_SIZE
+#define PXT_BOXED_STRING_SIZE(boxedString) boxedString->getUTF8Size()
 #endif
 
 #define PXT_POWI 1

--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -6,18 +6,23 @@
 #define PXT_BUFFER_DATA(buffer) buffer->data
 #endif
 
+// cross version compatible way of access data length
+#ifndef PXT_BUFFER_LENGTH
+#define PXT_BUFFER_LENGTH(buffer) buffer->length
+#endif
+
 #ifndef PXT_CREATE_BUFFER
 #define PXT_CREATE_BUFFER(data, len) pxt::mkBuffer(data, len)
 #endif
 
 // cross version compatible way of accessing string data
-#ifndef PXT_BOXED_STRING_DATA
-#define PXT_BOXED_STRING_DATA(boxedString) boxedString->getUTF8Data()
+#ifndef PXT_STRING_DATA
+#define PXT_STRING_DATA(str) str->getUTF8Data()
 #endif
 
-// cross version compatible way of accessing string size
-#ifndef PXT_BOXED_STRING_SIZE
-#define PXT_BOXED_STRING_SIZE(boxedString) boxedString->getUTF8Size()
+// cross version compatible way of accessing string length
+#ifndef PXT_STRING_LENGTH
+#define PXT_STRING_LENGTH(str) str->getLength()
 #endif
 
 #define PXT_POWI 1

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "6.5.19",
+    "pxt-common-packages": "6.5.20",
     "pxt-core": "5.9.1"
   }
 }


### PR DESCRIPTION
see https://github.com/Microsoft/pxt-common-packages/pull/782, need to be using a version of common packages that includes that PR before this can be merged