### PR TITLE
Removing namespace from led sprite in function dialog

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -114,6 +114,7 @@
             "extraFunctionEditorTypes": [
                 {
                     "typeName": "game.LedSprite",
+                    "label": "LedSprite",
                     "icon": "send",
                     "defaultName": "sprite"
                 }


### PR DESCRIPTION
Went to go fix this in PXT but Guillaume was way ahead of us!

![image](https://user-images.githubusercontent.com/13754588/55645170-b11cbf80-578c-11e9-9285-2e3dfb6d758d.png)
