### PR TITLE
Add MakerBit Pins extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -206,6 +206,10 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
     "name": "MakerBit",
     "url": "/pkg/1010Technologies/pxt-makerbit",
     "cardType": "package"
+}, {
+    "name": "MakerBit Pins",
+    "url": "/pkg/1010Technologies/pxt-makerbit-pins",
+    "cardType": "package"
 }]
 ```
 

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -72,6 +72,7 @@
             "1010Technologies/pxt-makerbit-lcd1602",
             "1010Technologies/pxt-makerbit-ir-receiver",
             "1010Technologies/pxt-makerbit-touch",
+            "1010Technologies/pxt-makerbit-pins",
             "pimoroni/pxt-automationbit",
             "k8robotics/pxt-k8",
             "dexterind/pxt-giggle",


### PR DESCRIPTION
We decided to move our pin supporting blocks from [pxt-makerbit](https://github.com/1010Technologies/pxt-makerbit) to a [dedicated extension](https://github.com/1010Technologies/pxt-makerbit-pins) as well (because users asked for it).

@microbit-mark Please approve :-)