### PR TITLE
Fix shake button

### DIFF
--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -261,7 +261,7 @@ namespace pxsim {
             this.setGesture(g);
         }
 
-        private setGesture(g: number) {
+        private setGesture(g: number, force?: boolean) {
             // Perform some low pass filtering to reduce jitter from any detected effects
             if (g == this.currentGesture) {
                 if (this.sigma < DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING)
@@ -273,7 +273,7 @@ namespace pxsim {
             }
 
             // If we've reached threshold, update our record and raise the relevant event...
-            if (this.currentGesture != this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
+            if (this.currentGesture != this.lastGesture && (this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING || force)) {
                 this.lastGesture = this.currentGesture;
                 board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
             }
@@ -281,7 +281,7 @@ namespace pxsim {
 
         forceGesture(g: number) {
             this.sigma = DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING + 1;
-            this.setGesture(g);
+            this.setGesture(g, true);
         }
 
         /**

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -267,7 +267,7 @@ namespace pxsim {
                 ++this.sigma;
             }
 
-            if (this.currentGesture != this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
+            if (this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
                 this.enqueueCurrentGesture();
             }
         }
@@ -278,8 +278,10 @@ namespace pxsim {
         }
 
         private enqueueCurrentGesture() {
-            this.lastGesture = this.currentGesture;
-            board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
+            if (this.currentGesture != this.lastGesture) {
+                this.lastGesture = this.currentGesture;
+                board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
+            }
         }
 
         /**

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -258,29 +258,28 @@ namespace pxsim {
         updateGesture() {
             // Determine what it looks like we're doing based on the latest sample...
             let g = this.instantaneousPosture();
-            this.setGesture(g);
-        }
 
-        private setGesture(g: number, force?: boolean) {
             // Perform some low pass filtering to reduce jitter from any detected effects
-            if (g == this.currentGesture) {
-                if (this.sigma < DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING)
-                    this.sigma++;
-            }
-            else {
+            if (g != this.currentGesture) {
                 this.currentGesture = g;
                 this.sigma = 0;
+            } else if (this.sigma < DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
+                ++this.sigma;
             }
 
-            // If we've reached threshold, update our record and raise the relevant event...
-            if (force || (this.currentGesture != this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING)) {
-                this.lastGesture = this.currentGesture;
-                board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
+            if (this.currentGesture != this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
+                this.enqueueCurrentGesture();
             }
         }
 
-        forceGesture(g: number) {
-            this.setGesture(g, /* force */ true);
+        forceGesture(gesture: number) {
+            this.currentGesture = gesture;
+            this.enqueueCurrentGesture();
+        }
+
+        private enqueueCurrentGesture() {
+            this.lastGesture = this.currentGesture;
+            board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
         }
 
         /**

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -273,7 +273,7 @@ namespace pxsim {
             }
 
             // If we've reached threshold, update our record and raise the relevant event...
-            if (this.currentGesture != this.lastGesture && (this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING || force)) {
+            if (force || (this.currentGesture != this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING)) {
                 this.lastGesture = this.currentGesture;
                 board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
             }

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -280,8 +280,7 @@ namespace pxsim {
         }
 
         forceGesture(g: number) {
-            this.sigma = DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING + 1;
-            this.setGesture(g, true);
+            this.setGesture(g, /* force */ true);
         }
 
         /**


### PR DESCRIPTION
Fixes #1970 
Fixes #1971 

Issue is that the ``sigma`` for the gesture is getting reset to 0 immediately before it is tested, even though it was just set to be a valid sigma in the ``forceGesture`` method. 