### PR TITLE
Fix acceleration giving NaN on iOS

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -909,8 +909,13 @@ path.sim-board {
                 }
 
                 const bbox = this.element.getBoundingClientRect();
-                const ax = (ev.clientX - bbox.width / 2) / (bbox.width / 3);
-                const ay = (ev.clientY - bbox.height / 2) / (bbox.height / 3);
+
+                // ev.clientX and ev.clientY are not defined on mobile iOS
+                const xPos = ev.clientX != null ? ev.clientX : ev.pageX;
+                const yPos = ev.clientY != null ? ev.clientY : ev.pageY;
+
+                const ax = (xPos - bbox.width / 2) / (bbox.width / 3);
+                const ay = (yPos - bbox.height / 2) / (bbox.height / 3);
 
                 const x = - Math.max(- 1023, Math.min(1023, Math.floor(ax * 1023)));
                 const y = - Math.max(- 1023, Math.min(1023, Math.floor(ay * 1023)));


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1974

This does 'turn on' the acceleration on iOS (see gif below with simulator moving, vs. gif from the issue this resolves), as they were only not working due to the ``ax`` / ``ay`` / ``az`` all being ``NaN``.

![demo on xcode simulator](https://user-images.githubusercontent.com/5615930/55758711-614c2b80-5a0c-11e9-91b9-07433961910c.gif)
