### PR TITLE
Fixes for infection game

### DIFF
--- a/docs/projects/infection.md
+++ b/docs/projects/infection.md
@@ -510,7 +510,7 @@ basic.forever(() => {
     }
 })
 
-basic.showIcon(GameIcons.Pairing)  
+basic.showIcon(GameIcons.Pairing)
 ```
 
 ```package


### PR DESCRIPTION
Fixes Microsoft/pxt-microbit#1752

The previous infection game relied on sending the devices' serial number through the field parameter as a string. Since this string is limited to only a few characters, the serial number was getting cut off so when the player compared their serial number with the one sent, it didn't match.

The problem is made worse since the toString on serial numbers results in adding more significant figures as shown in Microsoft/pxt-microbit#1640.

Since the values it sends during these steps are the icon/player number and health (as a value of 0 to 3), it is simple enough to append the value to the field name and send the serial numbers as the value.