### PR TITLE
Fix block display for examples in 'inBackground'

### DIFF
--- a/docs/reference/control/in-background.md
+++ b/docs/reference/control/in-background.md
@@ -25,7 +25,7 @@ changes what is stored there.
 let num = 0
 control.inBackground(() => {
     while (true) {
-        basic.showNumber(num, 150)
+        basic.showNumber(num)
         basic.pause(100)
     }
 })
@@ -40,7 +40,7 @@ with a ``forever`` loop.
 ```blocks
 let num = 0
 basic.forever(() => {
-    basic.showNumber(num, 150)
+    basic.showNumber(num)
 })
 input.onButtonPressed(Button.A, () => {
     num++;


### PR DESCRIPTION
Set to 'showNumber' to use default time for block render.

Translator reported problem:

https://crowdin.com/translate/kindscript/912/en-zhtw#39313
