### PR TITLE
Update extensions.md

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -92,7 +92,7 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
   "url":"/pkg/1010Technologies/pxt-makerbit-motor",
   "cardType": "package"
 }, {
-  "name": "Prokit Tobbie II",
+  "name": "Tobbie II",
   "url":"/pkg/kaku111/pxt-tobbieII",
   "cardType": "package"
 }, {


### PR DESCRIPTION
@microbit-mark 
Hello!!
Because this extension will be used by more than two companies at the same time, it cannot add the company name. So we want to be able to delete the company name, leaving only the name of the robot in the Extension Gallery website. thanks!!