### PR TITLE
Renamed bitbuggy, added tinkerkit

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -76,7 +76,7 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
   "url":"/pkg/4tronix/Robobit",
   "cardType": "package"
 }, {
-  "name": "Pi Supply Bit Buggy",
+  "name": "Pi Supply Bit:Buggy",
   "url":"/pkg/PiSupply/pxt-bitbuggy",
   "cardType": "package"
 }, {
@@ -226,6 +226,11 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
     "name": "MakerBit Pins",
     "url": "/pkg/1010Technologies/pxt-makerbit-pins",
     "cardType": "package"
+},
+{
+   "name": "Pi Supply tinker:kit",
+   "url": "/pkg/PiSupply/pxt-tinker-kit",
+   "cardType": "package"
 }]
 ```
 


### PR DESCRIPTION
We've renamed the repository for one of our libraries to match our branding. And added the missing part for one of our other products to the card list.