### PR TITLE
Update radio event parm usage descriptions

### DIFF
--- a/docs/courses/csintro/radio/activity.md
+++ b/docs/courses/csintro/radio/activity.md
@@ -38,7 +38,7 @@ input.onButtonPressed(Button.B, () => {
 ```
 * To display the data sent between the micro:bits, drag an 'on radio received receivedString' block to the coding workspace
 * From the Basic Toolbox drawer, drag a 'show string' block into the 'on radio received receivedString' block
-* From the Variables Toolbox drawer, drag a 'receivedString' variable block into the default string value of "Hello" in the 'show string' block 
+* From the 'on radio received receivedString' block, drag the 'receivedString' variable block into the default string value of "Hello" in the 'show string' block 
 
 Here is the complete Marco Polo program:
 
@@ -129,7 +129,7 @@ In order to know whether to display a dot, a dash, or a space/stop image, we nee
 
 * From the Logic Toolbox drawer, drag a 0=0 comparison block into the coding workspace.
 * Replace the default value 'true' of the 'if...then' block with the comparison block.
-* From the Variables Toolbox drawer, drag a 'receivedNumber' variable block into the coding workspace, and drop it into the first slot of the comparison block
+* From the 'on radio received receivedNumber' block, pull down the 'receivedNumber' variable block and drop it into the first slot of the comparison block
 * Leave the righthand side default value of zero in the 0=0 block. 
 
 ```blocks

--- a/docs/courses/ucp-science/temperature/setup-procedure.md
+++ b/docs/courses/ucp-science/temperature/setup-procedure.md
@@ -102,7 +102,7 @@ basic.forever(() => {
 
 In the starting of the code the title is displayed, radio group `99` is setup, and the initial ``temperature`` variable is set to `0`.
 
-In the ``||radio:on received number||`` event, the temperature is received from sending the @boardname@ radio. The receive temperature is then displayed on the LED display. This is repeated whenever a radio signal is received.
+In the ``||radio:on received number||`` event, the temperature is received from sending the @boardname@ radio. The received temperature is then displayed on the LED display. This is repeated whenever a radio signal is received.
 
 ```blocks
 let temperature = 0

--- a/docs/fcp/ch1.md
+++ b/docs/fcp/ch1.md
@@ -63,7 +63,7 @@ input.onButtonPressed(Button.A, () => {
 input.onButtonPressed(Button.B, () => {
     radio.sendString("B")
 })
-radio.onReceivedNumber(({ receivedString }) => {
+radio.onReceivedNumber((receivedString) => {
     basic.showString(receivedString)
 })
 ```

--- a/docs/projects/best-friends.md
+++ b/docs/projects/best-friends.md
@@ -116,7 +116,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-Go to ``||variables:Variables||`` and get the ``||variables:receivedNumber||`` variable and put it in first slot of the ``||logic:0 = 0||``. Change the `0` in the second slot to `1`.
+Pull the ``||variables:receivedNumber||`` variable down from the ``||radio:radio on received receivedNumber||`` and put it in first slot of the ``||logic:0 = 0||``. Change the `0` in the second slot to `1`.
 
 
 ```blocks

--- a/docs/projects/micro-chat.md
+++ b/docs/projects/micro-chat.md
@@ -28,8 +28,7 @@ radio.onReceivedString(function (receivedString) {
 
 ## Displaying text @fullscreen
 
-Add a ``||basic:show string||`` to display the string on the screen. You will find the ``receivedString`` variable
-under **Variables** in the toolbox.
+Add a ``||basic:show string||`` to display the string on the screen. Pull the ``||variables:receivedString||`` out of ``||radio:on received string||`` and put it into ``||basic:show string||``.
 
 ```blocks
 radio.onReceivedString(function (receivedString) {

--- a/docs/projects/milk-carton-robot/connect.md
+++ b/docs/projects/milk-carton-robot/connect.md
@@ -12,7 +12,7 @@ You will need 2 @boardname@ for this part. By using the radio, we can make the M
 Download the code below to the @boardname@ on the Milk Carton Monster and another "controller" @boardname@. Whenever ``A`` is pressed, the Milk Carton Monster will move once.
 
 ```blocks
-radio.onReceivedNumber(({ receivedNumber }) => {
+radio.onReceivedNumber((receivedNumber) => {
     pins.servoWritePin(AnalogPin.P0, 0)
     basic.pause(500)
     pins.servoWritePin(AnalogPin.P0, 180)

--- a/docs/projects/milky-monster/connect.md
+++ b/docs/projects/milky-monster/connect.md
@@ -12,7 +12,7 @@ You will need a second @boardname@ for this part. By using the radio, we can con
 Download the code below to the @boardname@ that's on the Milky Monster and again to another "controller" @boardname@. Whenever button **A** is pressed, the Milky Monster will move one time.
 
 ```blocks
-radio.onReceivedNumber(({ receivedNumber }) => {
+radio.onReceivedNumber((receivedNumber) => {
     pins.servoWritePin(AnalogPin.P0, 0)
     basic.pause(500)
     pins.servoWritePin(AnalogPin.P0, 180)

--- a/docs/projects/red-light-green-light.md
+++ b/docs/projects/red-light-green-light.md
@@ -38,7 +38,7 @@ basic.forever(function () {
 
 ### Red light, green light
 
-Use the ``||radio:on button pressed||`` block to run code when button ``A`` and ``B`` are pressed.
+Use the ``||input:on button pressed||`` block to run code when button ``A`` and ``B`` are pressed.
 When ``A`` is pressed, the game goes into ``GREENLIGHT`` mode. When ``B`` is pressed, the game
 goes into ``REDLIGHT`` mode. We also use ``||basic:show icon||`` to display the current game state.
 


### PR DESCRIPTION
Make doc text match the parameter (variable) usage for the radio event blocks.

Closes #1966