### PR TITLE
Update ref category page for serial

### DIFF
--- a/docs/reference/serial.md
+++ b/docs/reference/serial.md
@@ -19,10 +19,8 @@ serial.onDataReceived(",", () => {})
 ```cards
 serial.redirect(SerialPin.P0, SerialPin.P0, BaudRate.BaudRate115200);
 serial.redirectToUSB();
-serial.writeBuffer(pins.createBuffer(0));
+serial.writeBuffer(serial.readBuffer(64));
 serial.readBuffer(64);
-serial.setRxBufferSize(64);
-serial.setTxBufferSize(64);
 ```
 
 ## See Also
@@ -31,7 +29,5 @@ serial.setTxBufferSize(64);
 [writeString](/reference/serial/write-string), 
 [writeNumbers](/reference/serial/write-numbers), [readUntil](/reference/serial/read-until), [readLine](/reference/serial/read-line),
 [readString](/reference/serial/read-string), [onDataReceived](/reference/serial/on-data-received),
-[redirect](/reference/serial/redirect), [writeBuffer](/reference/serial/write-buffer), [readBuffer](/reference/serial/read-buffer),
-[redirectToUSB](/reference/serial/redirect-to-usb),
-[set rx buffer size](/reference/serial/set-rx-buffer-size),
-[set tx buffer size](/reference/serial/set-tx-buffer-size)
+[redirect](/reference/serial/redirect), [redirectToUSB](/reference/serial/redirect-to-usb),
+[writeBuffer](/reference/serial/write-buffer), [readBuffer](/reference/serial/read-buffer)

--- a/docs/reference/serial/read-buffer.md
+++ b/docs/reference/serial/read-buffer.md
@@ -26,7 +26,7 @@ The need to pause for more data is set by the @boardname@ **[serial mode](https:
 
 Read character data from the serial port one row at a time. Write the rows to an LED display connected to the I2C pins.
 
-```blocks
+```typescript
 let rowData: Buffer = null;
 for (let i = 0; i < 24; i++) {
     rowData = serial.readBuffer(80);

--- a/docs/reference/serial/write-buffer.md
+++ b/docs/reference/serial/write-buffer.md
@@ -16,7 +16,7 @@ You place your data characters into an existing buffer. All of the data, the len
 
 Read some characters of data from a device connected to the I2C pins. Write the data to the serial port.
 
-```blocks
+```typescript
 pins.i2cWriteNumber(132, NumberFormat.UInt8LE, 0);
 let i2cBuffer = pins.i2cReadBuffer(132, 16, false);
 serial.writeBuffer(i2cBuffer);

--- a/docs/reference/serial/write-buffer.md
+++ b/docs/reference/serial/write-buffer.md
@@ -3,7 +3,7 @@
 Write a buffer to the [serial](/device/serial) port.
 
 ```sig
-serial.writeBuffer(pins.createBuffer(0));
+serial.writeBuffer(serial.readBuffer(64))
 ```
 
 You place your data characters into an existing buffer. All of the data, the length of the buffer, is written to the serial port.


### PR DESCRIPTION
Remove the TX and RX buffer size APIs and update the sig usage for serial ref docs.

Fixes #2101.