### PR TITLE
bump to core 5.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "pxt-common-packages": "6.9.3",
-    "pxt-core": "5.14.3"
+    "pxt-core": "5.15.1"
   }
 }


### PR DESCRIPTION
This includes the web USB fix for microbit

Testable here: https://makecode.microbit.org/app/9d7553868827b644ff3ff75bb3d05968cf8b27c0-20fae79319