### PR TITLE
Sets JustWorks to the actual config values

### DIFF
--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -92,9 +92,9 @@
                 "config": {
                     "microbit-dal": {
                         "bluetooth": {
-                            "open": null,
-                            "whitelist": null,
-                            "security_level": null
+                            "open": 0,
+                            "whitelist": 1,
+                            "security_level": "SECURITY_MODE_ENCRYPTION_NO_MITM"
                         }
                     }
                 }


### PR DESCRIPTION
Fixes the JustWorks pairing option. Sets the keys to the actual values needed so that the option can be detected correctly.


Needs to be merged in conjunction with https://github.com/microsoft/pxt/pull/5622.