### PR TITLE
Set serial help paths for blocks

### DIFF
--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -194,7 +194,7 @@ namespace serial {
     * Sets the size of the RX buffer in bytes
     * @param size length of the rx buffer in bytes, eg: 32
     */
-    //% help=reference/serial/set-rx-buffer-size
+    //% help=serial/set-rx-buffer-size
     //% blockId=serialSetRxBufferSize block="serial set rx buffer size to $size"
     //% advanced=true
     void setRxBufferSize(uint8_t size) {
@@ -205,7 +205,7 @@ namespace serial {
     * Sets the size of the TX buffer in bytes
     * @param size length of the tx buffer in bytes, eg: 32
     */
-    //% help=reference/serial/set-tx-buffer-size
+    //% help=serial/set-tx-buffer-size
     //% blockId=serialSetTxBufferSize block="serial set tx buffer size to $size"
     //% advanced=true
     void setTxBufferSize(uint8_t size) {

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -869,7 +869,7 @@ declare namespace serial {
      * Sets the size of the RX buffer in bytes
      * @param size length of the rx buffer in bytes, eg: 32
      */
-    //% help=reference/serial/set-rx-buffer-size
+    //% help=serial/set-rx-buffer-size
     //% blockId=serialSetRxBufferSize block="serial set rx buffer size to $size"
     //% advanced=true shim=serial::setRxBufferSize
     function setRxBufferSize(size: uint8): void;
@@ -878,7 +878,7 @@ declare namespace serial {
      * Sets the size of the TX buffer in bytes
      * @param size length of the tx buffer in bytes, eg: 32
      */
-    //% help=reference/serial/set-tx-buffer-size
+    //% help=serial/set-tx-buffer-size
     //% blockId=serialSetTxBufferSize block="serial set tx buffer size to $size"
     //% advanced=true shim=serial::setTxBufferSize
     function setTxBufferSize(size: uint8): void;


### PR DESCRIPTION
Set correct help paths for **setRxBufferSize** and **setTxBufferSize** blocks.

RE: #2144