### PR TITLE
always shake when button is pressed

### DIFF
--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -267,7 +267,7 @@ namespace pxsim {
                 ++this.sigma;
             }
 
-            if (this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
+            if (this.currentGesture !== this.lastGesture && this.sigma >= DAL.MICROBIT_ACCELEROMETER_GESTURE_DAMPING) {
                 this.enqueueCurrentGesture();
             }
         }
@@ -278,10 +278,8 @@ namespace pxsim {
         }
 
         private enqueueCurrentGesture() {
-            if (this.currentGesture != this.lastGesture) {
-                this.lastGesture = this.currentGesture;
-                board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
-            }
+            this.lastGesture = this.currentGesture;
+            board().bus.queue(DAL.MICROBIT_ID_GESTURE, this.lastGesture);
         }
 
         /**


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2147
re https://github.com/microsoft/pxt-microbit/issues/820

I had actually fixed this in https://github.com/microsoft/pxt-microbit/pull/1983 but changed it to retain the behavior as it seemed like an intentional change (to match the behavior when you try to continuously shake it otherwise).

this makes it so when you press shake it always shakes, instead of waiting for you to start a different gesture like it normally would.

![2019-06-07 15 08 22](https://user-images.githubusercontent.com/5615930/59136032-2a27c700-8936-11e9-882b-e46d473cf25e.gif)
