### PR TITLE
Shrink the link in firmware version hint

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -9,7 +9,7 @@
 
 All the bits and pieces that make up the BBC micro:bit
 
-![](/static/mb/device-0.png)
+![micro:bit board layout](/static/mb/device-0.png)
 
 
 ## LED Screen and Status LED
@@ -43,18 +43,19 @@ https://www.youtube.com/watch?v=t_Qujjd_38o
 When you plug in your micro:bit via [USB](/device/usb), it should appear as  a ``MICROBIT`` drive. 
 
 If you accidentally hold down the reset button as you’re plugging in your micro:bit, 
-the micro:bit will appear as a MAINTENANCE drive instead of ``MICROBIT``. This is known as maintenance mode.
+the micro:bit will appear as a ``MAINTENANCE`` drive instead of ``MICROBIT``. This is known as maintenance mode.
 
 To continue programming your micro:bit YOU MUST unplug your USB and reconnect it. Check that the drive now shows as ``MICROBIT``.
 
 ## ~ hint
 
-Use with caution. If you click on the drive while it shows as ``MAINTENANCE``, 
+### Open the version file
+
+Use with caution!
+If you click on the drive while it shows the ``MAINTENANCE`` label, 
 you can see which version of firmware you have running on your micro:bit. 
 Firmware on your micro:bit should be up-to-date already. 
-You can find the version of firmware in the 'version.txt' file on the micro:bit. Further information on the firmware can be found here:
-
-https://developer.mbed.org/platforms/Microbit/#firmware
+You can find the version of firmware in the 'version.txt' file on the micro:bit. See the @boardname@ **[firmware](https://microbit.org/guide/firmware/)** page for more about checking your board's firmware version.
 
 ## ~
 

--- a/docs/reference/bluetooth/start-io-pin-service.md
+++ b/docs/reference/bluetooth/start-io-pin-service.md
@@ -33,7 +33,7 @@ For more advanced information on the @boardname@ Bluetooth IO pin service includ
 
 ## See also
 
-[About Bluetooth](/reference/bluetooth/about-bluetooth), [@boardname@ Bluetooth profile overview ](http://lancaster-university.github.io/microbit-docs/ble/profile/), [@boardname@ Bluetooth profile reference](http://lancaster-university.github.io/microbit-docs/resources/bluetooth/microbit-profile-V1.9-Level-2.pdf),  [Bluetooth on @boardname@ resources](http://bluetooth-mdw.blogspot.co.uk/p/bbc-microbit.html), [Bluetooth SIG](https://www.bluetooth.com)
+[About Bluetooth](/reference/bluetooth/about-bluetooth), [@boardname@ Bluetooth profile overview ](http://lancaster-university.github.io/microbit-docs/ble/profile/), [@boardname@ Bluetooth profile reference](http://lancaster-university.github.io/microbit-docs/resources/bluetooth/microbit-profile-V1.9-Level-2.pdf), [Bluetooth on @boardname@ resources](http://bluetooth-mdw.blogspot.co.uk/p/bbc-microbit.html), [Bluetooth SIG](https://www.bluetooth.com)
 
 ```package
 bluetooth


### PR DESCRIPTION
- [x] Use anchor text for the firmware link instead of literal URL.
- [x] Switch the mbed firmware link to the micro:bit.org page since the mbed page just directs to that one anyway.
- [x] Style up the hint a bit.
- [x] Fix a tiny translation quibble: https://crowdin.com/translate/kindscript/930/en-zhcn#39543:drl:1858:ff98sha

Fixes #786