### PR TITLE
Use gcPreAllocateBlock() to fix #2177, #2215

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -18,14 +18,18 @@ extern "C" void target_reset() {
     microbit_reset();
 }
 
+uint32_t device_heap_size(uint8_t heap_index); // defined in microbit-dal
+
 namespace pxt {
 
 MicroBit uBit;
 MicroBitEvent lastEvent;
 
 void platform_init() {
-    microbit_seed_random();
+    microbit_seed_random();    
     seedRandom(microbit_random(0x7fffffff));
+    if (device_heap_size(1))
+        gcPreAllocateBlock(device_heap_size(1) - 4);
 }
 
 void platform_init();

--- a/libs/core/pxtcore.h
+++ b/libs/core/pxtcore.h
@@ -14,6 +14,8 @@ void debuglog(const char *format, ...);
 #define xmalloc malloc
 #define xfree free
 
+#define GC_MAX_ALLOC_SIZE 9000
+
 #if CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
 #define GC_BLOCK_SIZE 256
 #else

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "6.9.3",
+    "pxt-common-packages": "6.12.6",
     "pxt-core": "5.15.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/web-bluetooth": "0.0.4"
   },
   "dependencies": {
-    "pxt-common-packages": "6.12.6",
+    "pxt-common-packages": "6.9.4",
     "pxt-core": "5.15.10"
   }
 }


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt-common-packages/pull/866

This allocates additional 8k of memory in one segment on non-BLE builds

Needs testing with BLE enabled.

fixes #2177, #2215