### PR TITLE
Update write-received-packet-to-serial.md

### DIFF
--- a/docs/reference/radio/write-received-packet-to-serial.md
+++ b/docs/reference/radio/write-received-packet-to-serial.md
@@ -30,22 +30,26 @@ the second @boardname@), this program sends temperature data to the
 serial port.
 
 ```blocks
-input.onButtonPressed(Button.A, () => {
-    radio.sendNumber(input.temperature());
-    radio.sendValue("temperature", input.temperature());
-    radio.sendString("It's warm now");
-
-
-});
+input.onButtonPressed(Button.A, function () {
+    radio.sendNumber(input.temperature())
+    radio.sendValue("temp", input.temperature())
+    radio.sendString("It's warm now")
+})
 radio.onReceivedNumber(function (receivedNumber) {
-    radio.writeReceivedPacketToSerial();
-});
+    radio.writeReceivedPacketToSerial()
+})
+radio.onReceivedValue(function (name, value) {
+    radio.writeReceivedPacketToSerial()
+})
+radio.onReceivedString(function (receivedString) {
+    radio.writeReceivedPacketToSerial()
+})
 ```
 Sample output to serial when ``A`` button pressed:
 
 ```json
 {"t":323,"s":0,"v":27}
-{"t":325,"s":0,"n":"temperature","v":27}
+{"t":325,"s":0,"n":"temp","v":27}
 {"t":326,"s":0,"n":"It's warm now"}
 ```
 


### PR DESCRIPTION
A support ticket pointed out issues that they'd encountered when trying to follow this document:

- `sendValue` only supports an 8 character string. This is documented in the `sendValue` docs but a longer string had been used here
- Only `radio.onReceivedNumber` is used so the sample output is not consistent with the users experience. I've changed it so that all packets are handled