### PR TITLE
Decrease size of GC heap to allow more DAL allocs

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -28,8 +28,8 @@ MicroBitEvent lastEvent;
 void platform_init() {
     microbit_seed_random();    
     seedRandom(microbit_random(0x7fffffff));
-    if (device_heap_size(1))
-        gcPreAllocateBlock(device_heap_size(1) - 4);
+    if (device_heap_size(1) > NON_GC_HEAP_RESERVATION + 4)
+        gcPreAllocateBlock(device_heap_size(1) - NON_GC_HEAP_RESERVATION);
 }
 
 void platform_init();

--- a/libs/core/pxtcore.h
+++ b/libs/core/pxtcore.h
@@ -16,11 +16,8 @@ void debuglog(const char *format, ...);
 
 #define GC_MAX_ALLOC_SIZE 9000
 
-#if CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
 #define GC_BLOCK_SIZE 256
-#else
-#define GC_BLOCK_SIZE 1000
-#endif
+#define NON_GC_HEAP_RESERVATION 1024
 
 #define DMESG NOLOG
 


### PR DESCRIPTION
This PR:
 * decreases the size of initial GC heap to 256 from 1024
 * leaves 1024 bytes from the second chunk of heap for microbit-dal allocations (in particular fibers and their stacks)

fixes https://github.com/microsoft/pxt-microbit/issues/2245
