### PR TITLE
don't calibrate when reading field strength

### DIFF
--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -348,7 +348,7 @@ namespace input {
     //% parts="compass"
     //% advanced=true
     int magneticForce(Dimension dimension) {
-      if (!uBit.compass.isCalibrated())
+      if (dimension != Dimension::Strength && !uBit.compass.isCalibrated())
         uBit.compass.calibrate();
 
       switch (dimension) {


### PR DESCRIPTION
When measuring the magnetic field strength, don't calibrate.
- [ ] test on hardware