### PR TITLE
hide pin p19/p20

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -546,6 +546,8 @@
   "serial.setRxBufferSize|param|size": "length of the rx buffer in bytes, eg: 32",
   "serial.setTxBufferSize": "Sets the size of the TX buffer in bytes",
   "serial.setTxBufferSize|param|size": "length of the tx buffer in bytes, eg: 32",
+  "serial.setWriteLinePadding": "Sets the padding length for lines sent with \"write line\".",
+  "serial.setWriteLinePadding|param|length": "the number of bytes alignment, eg: 0",
   "serial.writeBuffer": "Send a buffer through serial connection",
   "serial.writeLine": "Print a line of text to the serial port",
   "serial.writeNumber": "Print a numeric value to the serial port",

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -367,6 +367,7 @@
   "serial.redirect|block": "serial|redirect to|TX %tx|RX %rx|at baud rate %rate",
   "serial.setRxBufferSize|block": "serial set rx buffer size to $size",
   "serial.setTxBufferSize|block": "serial set tx buffer size to $size",
+  "serial.setWriteLinePadding|block": "serial set write line padding to $length",
   "serial.writeBuffer|block": "serial|write buffer %buffer=serial_readbuffer",
   "serial.writeLine|block": "serial|write line %text",
   "serial.writeNumbers|block": "serial|write numbers %values",

--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -445,7 +445,9 @@ declare namespace led {
     P14 = 21,  // MICROBIT_ID_IO_P14
     P15 = 22,  // MICROBIT_ID_IO_P15
     P16 = 23,  // MICROBIT_ID_IO_P16
+    //% blockHidden=1
     P19 = 24,  // MICROBIT_ID_IO_P19
+    //% blockHidden=1
     P20 = 25,  // MICROBIT_ID_IO_P20
     }
 
@@ -480,8 +482,10 @@ declare namespace led {
     //% block="P16 (write only)"
     P16 = 23,  // MICROBIT_ID_IO_P16
     //% block="P19 (write only)"
+    //% blockHidden=1
     P19 = 24,  // MICROBIT_ID_IO_P19
     //% block="P20 (write only)"
+    //% blockHidden=1
     P20 = 25,  // MICROBIT_ID_IO_P20
     }
 

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -18,7 +18,9 @@ enum class DigitalPin {
     P14 = MICROBIT_ID_IO_P14,
     P15 = MICROBIT_ID_IO_P15,
     P16 = MICROBIT_ID_IO_P16,
+    //% blockHidden=1
     P19 = MICROBIT_ID_IO_P19,
+    //% blockHidden=1
     P20 = MICROBIT_ID_IO_P20,
 };
 
@@ -52,8 +54,10 @@ enum class AnalogPin {
     //% block="P16 (write only)"
     P16 = MICROBIT_ID_IO_P16,
     //% block="P19 (write only)"
+    //% blockHidden=1
     P19 = MICROBIT_ID_IO_P19,
     //% block="P20 (write only)"
+    //% blockHidden=1
     P20 = MICROBIT_ID_IO_P20
 };
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/2253

![image](https://user-images.githubusercontent.com/4175913/61381845-84cf0f80-a860-11e9-9c7a-9f40a9e6fe2d.png)
