### PR TITLE
Fix remove life animation causing microbit stuck

### DIFF
--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -210,7 +210,8 @@ namespace game {
     //% blockId=game_remove_life block="remove life %life" blockGap=8
     export function removeLife(life: number): void {
         setLife(_life - life);
-        if (!_paused)
+        if (!_paused && !_backgroundAnimation) {
+            _backgroundAnimation = true;
             control.inBackground(() => {
                 led.stopAnimation();
                 basic.showAnimation(`1 0 0 0 1 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0
@@ -218,7 +219,9 @@ namespace game {
 0 0 1 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
 0 1 0 1 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0
 1 0 0 0 1 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0`, 40);
+                _backgroundAnimation = false;
             });
+        }
     }
 
     /**


### PR DESCRIPTION
On the real microbit board, if the program execute other game blocks while the remove life animation is playing, it would cause strange behavior or even make the game stuck. 

This pull request make `removeLife()` to lock the `_backgroundAnimation`, thus, it should behave correctly as `addScore()`.