### PR TITLE
make hc mode sim color have higher contrast

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -259,7 +259,7 @@ path.sim-board {
             theme.ledOn = "#0000bb";
             theme.display = "#ffffff";
             theme.pin = "#D4AF37";
-            theme.accent = "#273EE2";
+            theme.accent = "#FFD43A";
         }
         return theme;
     }


### PR DESCRIPTION
make hc mode simulator have a more accessible color:

![Screen Shot 2019-08-29 at 1 37 55 PM](https://user-images.githubusercontent.com/5615930/63974740-4c773f80-ca62-11e9-8654-fada11b1bafc.png)

fixes https://github.com/microsoft/pxt-microbit/issues/800

Also noticed a bug where the high contrast theme doesn't apply until simulator is restarted when high contrast is toggled; will fix that separately.