### PR TITLE
emit radio broadcast message as bitmask

### DIFF
--- a/libs/radio-broadcast/radio-broadcast.ts
+++ b/libs/radio-broadcast/radio-broadcast.ts
@@ -5,6 +5,7 @@ namespace radio {
     //% blockHidden=1 shim=ENUM_GET
     //% blockId=radioMessageCode block="$msg" enumInitialMembers="message1"
     //% enumName=RadioMessage enumMemberName=msg enumPromptHint="e.g. Start, Stop, Jump..."
+    //% enumIsHash=1
     export function __message(msg: number): number {
         return msg;
     }


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/2391
TypeScript looks like this where the Enum value is a hash.

```
enum RadioMessage {
    message1 = 49434,
    foobar = 18366
}
radio.onReceivedMessage(RadioMessage.foobar, function () {
	
})
```