### PR TITLE
Modify the LED coordinates to be between 0 and 4.

### DIFF
--- a/docs/projects/reaction-time/code.md
+++ b/docs/projects/reaction-time/code.md
@@ -162,7 +162,7 @@ input.onPinPressed(TouchPin.P0, () => {
         running = true
         led.stopAnimation()
         basic.clearScreen()
-        led.plot(Math.randomRange(0, 5), Math.randomRange(0, 5))
+        led.plot(Math.randomRange(0, 4), Math.randomRange(0, 4))
     }
 })
 running = false


### PR DESCRIPTION
Without this change, there is a 11/36 chance no LED lights as [`Math.random(a,b)`](https://docs.python.org/2/library/random.html#random.uniform) (thus the `pick random` block) chooses a number in the (inclusive, closed) interval `[a, b]`.