### PR TITLE
Set LED plot row/column ranges for 'Reaction Time'

### DIFF
--- a/docs/projects/reaction-time/code.md
+++ b/docs/projects/reaction-time/code.md
@@ -221,7 +221,7 @@ input.onPinPressed(TouchPin.P0, () => {
         running = true
         led.stopAnimation()
         basic.clearScreen()
-        led.plot(Math.randomRange(0, 5), Math.randomRange(0, 5))
+        led.plot(Math.randomRange(0, 4), Math.randomRange(0, 4))
     }
 })
 running = false
@@ -254,7 +254,7 @@ input.onPinPressed(TouchPin.P0, () => {
         running = true
         led.stopAnimation()
         basic.clearScreen()
-        led.plot(Math.randomRange(0, 5), Math.randomRange(0, 5))
+        led.plot(Math.randomRange(0, 4), Math.randomRange(0, 4))
     }
 })
 input.onPinPressed(TouchPin.P1, () => {


### PR DESCRIPTION
Change remaining LED plot blocks to the proper range in the 'Reaction Time' code examples.

RE: #2416