### PR TITLE
Allow globals in reclaimed bluetooth memory

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -28,6 +28,9 @@ MicroBitEvent lastEvent;
 void platform_init() {
     microbit_seed_random();    
     seedRandom(microbit_random(0x7fffffff));
+}
+
+void initMicrobitGC() {
     if (device_heap_size(1) > NON_GC_HEAP_RESERVATION + 4)
         gcPreAllocateBlock(device_heap_size(1) - NON_GC_HEAP_RESERVATION);
 }

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -54,11 +54,21 @@ static inline int max_(int a, int b) {
         return b;
 }
 
+void initMicrobitGC();
+
 } // namespace pxt
 
 using namespace pxt;
 
 #define DEVICE_EVT_ANY 0
+
+#undef PXT_MAIN
+#define PXT_MAIN                                                                                   \
+    int main() {                                                                                   \
+        pxt::initMicrobitGC();                                                                     \
+        pxt::start();                                                                              \
+        return 0;                                                                                  \
+    }
 
 #endif
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2398