### PR TITLE
more accessible red buttons

### DIFF
--- a/theme/site/elements/button.overrides
+++ b/theme/site/elements/button.overrides
@@ -1,3 +1,10 @@
 /*******************************
          Site Overrides
 *******************************/
+
+.ui.red.button {
+    background: darken(@red, 20%);
+    &:hover, &:focus {
+        background: darken(@red, 30%);
+    }
+}

--- a/theme/site/elements/button.overrides
+++ b/theme/site/elements/button.overrides
@@ -1,10 +1,3 @@
 /*******************************
          Site Overrides
 *******************************/
-
-.ui.red.button {
-    background: darken(@red, 20%);
-    &:hover, &:focus {
-        background: darken(@red, 30%);
-    }
-}

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -11,7 +11,7 @@
 
 @teal: #3891A6;
 @blue: #3454D1;
-@red: #EF767A;
+@red: #E41B21;
 @pink: #F46197;
 @yellow: #FDE74C;
 @grey: #95a5a6;


### PR DESCRIPTION
fix microsoft/pxt-microbit#2292; pulled out of https://github.com/microsoft/pxt/pull/5968 as the other targets didn't actually need to darken this button as much, just microbit

![66072296-a360b080-e509-11e9-9b58-91cbda9ee44c](https://user-images.githubusercontent.com/5615930/66159444-d88a0300-e5dc-11e9-9762-e2634ef374b3.gif)
