### PR TITLE
fixing radio stack

### DIFF
--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -41,14 +41,18 @@ namespace radio {
     //% help=radio/received-packet
     Buffer readRawPacket() {
         if (radioEnable() != MICROBIT_OK) return mkBuffer(NULL, 0);
-        packet = uBit.radio.datagram.recv();
-        return mkBuffer(packet.getBytes(), packet.length());
+        uint8_t buf[32];
+        int size = uBit.radio.datagram.recv(buf, sizeof(buf));
+        if (size <= 0)
+            return mkBuffer(NULL, 0);
+        return mkBuffer(buf, size);
     }
 
     /**
      * Sends a raw packet through the radio
      */
     //% advanced=true
+    //% async
     void sendRawPacket(Buffer msg) {
         if (radioEnable() != MICROBIT_OK || NULL == msg) return;
         uBit.radio.datagram.send(msg->data, msg->length);

--- a/libs/radio/shims.d.ts
+++ b/libs/radio/shims.d.ts
@@ -24,7 +24,8 @@ declare namespace radio {
     /**
      * Sends a raw packet through the radio
      */
-    //% advanced=true shim=radio::sendRawPacket
+    //% advanced=true
+    //% async shim=radio::sendRawPacket
     function sendRawPacket(msg: Buffer): void;
 
     /**

--- a/sim/state/radio.ts
+++ b/sim/state/radio.ts
@@ -48,7 +48,7 @@ namespace pxsim {
                 rssi: -1,
                 serial: 0,
                 time: 0,
-                payload: { type: -1, groupId: 0 }
+                payload: { type: -1, groupId: 0, bufferData: new Uint8Array(0) }
             };
         }
     }
@@ -109,11 +109,13 @@ namespace pxsim.radio {
     }
 
     export function sendRawPacket(buf: RefBuffer) {
+        let cb = getResume();
         board().radioState.datagram.send({
             type: 0,
             groupId: board().radioState.groupId,
             bufferData: buf.data
         });
+        setTimeout(cb, 1);
     }
 
     export function readRawPacket() {


### PR DESCRIPTION
Fixing race condition between incoming packages and codal events.
Issue reported by cap credible.
```
const n = 10
radio.setGroup(11)
input.onButtonPressed(Button.A, function () {
    for(let i = 0; i < 10; ++i) {
        radio.sendNumber(i)
        led.toggle(Math.idiv(i, 5), i % 5)
    }
})

radio.onReceivedNumber(function (i: number) {
    led.toggle(Math.idiv(i, 5), i % 5)    
})
```