### PR TITLE
Revert readRawPacket() to use PacketBuffer

### DIFF
--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -41,11 +41,8 @@ namespace radio {
     //% help=radio/received-packet
     Buffer readRawPacket() {
         if (radioEnable() != MICROBIT_OK) return mkBuffer(NULL, 0);
-        uint8_t buf[32];
-        int size = uBit.radio.datagram.recv(buf, sizeof(buf));
-        if (size <= 0)
-            return mkBuffer(NULL, 0);
-        return mkBuffer(buf, size);
+        packet = uBit.radio.datagram.recv();
+        return mkBuffer(packet.getBytes(), packet.length());
     }
 
     /**


### PR DESCRIPTION
This PR should fix #2471 by reverting `readRawPacket()` to the one before #2461. I think the use of `PacketBuffer` is not related to race condition issue that is fixed via #2461. Please feel free to reject this PR if I am wrong :)