### PR TITLE
Removing old bitbot as we have a new bitbot package

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -37,10 +37,6 @@ Check out [microbit.org](http://microbit.org/resellers/) for more information on
   "url":"/pkg/4tronix/MiniBit",
   "cardType": "package"
 }, {
-  "name": "SRS BitBot",
-  "url":"/pkg/srs/pxt-bitbot",
-  "cardType": "package"
-}, {
   "name": "Sunfounder Sloth",
   "url":"/pkg/sunfounder/pxt-sloth",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -46,7 +46,6 @@
             "CoderDojoOlney/pxt-olney",
             "PaulDFoster/pxt-microbit-GY521",
             "chevyng/pxt-ucl-junkrobot",
-            "srs/pxt-bitbot",
             "sparkfun/pxt-gamer-bit",
             "sparkfun/pxt-moto-bit",
             "sparkfun/pxt-weather-bit",


### PR DESCRIPTION
Following is the request to remove old bitbot package.
-------------------------------------------
Hi Peli, 

Thank you for the intro Jonny.

So nice to meet you and get to know the great people of MakeCode at micro:bit Live!

I am the tall Norwegian talking with you about translation + our national project where kids get to program the robot Bit:bot from 4Tronix. We are introducing micro:bit + programming this robot for 120K school kids age 12 + coding clubs in our project named super:bit.

I just have a simple question for you for now:
•	When you search for the bit:bot library, two show up. One old one by someone unknown, and the one made by 4tronix (see attached image). This causes a lot of confusion in our educational programs.
•	Would it be possible to remove the old library?

PS: Hope we can meet in Norway some time, so you get to play on the micro:bit orchestra in our Makerspace. :-) Daniel made it for us 1 year ago. He has even made a video blog on how to make your own. :-)

Best,

Jon Haavie
