### PR TITLE
Simplify the Fahrenheit from Celsius computation.

### DIFF
--- a/docs/reference/input/temperature.md
+++ b/docs/reference/input/temperature.md
@@ -38,12 +38,12 @@ basic.forever(() => {
 This program measures the temperature using Fahrenheit degrees.
 Fahrenheit is a way of measuring temperature that is commonly used in the United States.
 To make a Celsius temperature into a Fahrenheit one, multiply the Celsius temperature by
-``18``, divide by ``10`` and add ``32``.
+``1.8`` and add ``32``.
 
 ```blocks
 basic.forever(() => {
     let c = input.temperature()
-    let f = (c * 18) / 10 + 32
+    let f = (1.8 * c) + 32
     basic.showNumber(f)
 })
 ```


### PR DESCRIPTION
As the micro:bit introduces floating point arithmetic for both the existing `f = 18 * c / 10 + 32` computation and the new `f = 1.8 * c + 32` computation, there isn't any benefit for the former. The latter has the benefit of being the formula familiar to most students (at least in the USA).