### PR TITLE
Add redirect to pins info to serial heading

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -124,7 +124,7 @@ You can attach an external device such as a motor to these and power it using th
 
 ## Serial Communication
 
-The micro:bit can send and receive data via [serial communication](/device/serial). The serial data can be transferred via USB, BLE or redirected to pins on the edge connector.
+The micro:bit can send and receive data via [serial communication](/device/serial). The serial data can be transferred via [USB](/reference/serial/redirect-to-usb), BLE or [redirected to pins](/reference/serial/redirect) on the edge connector.
 
 ## Bluetooth Low Energy (BLE) Antenna
 

--- a/docs/device.md
+++ b/docs/device.md
@@ -124,7 +124,7 @@ You can attach an external device such as a motor to these and power it using th
 
 ## Serial Communication
 
-The micro:bit can send and receive data via [serial communication](/device/serial). The serial data can be transferred via USB or BLE.
+The micro:bit can send and receive data via [serial communication](/device/serial). The serial data can be transferred via USB, BLE or redirected to pins on the edge connector.
 
 ## Bluetooth Low Energy (BLE) Antenna
 


### PR DESCRIPTION
In the documentation [`/device/serial`][0] there is no mention of serial redirection, but in [`reference/serial/redirect`][1] it is documented it is possible to redirect serial I/O to pins on the edge connector. Should I also add information about this in the `/device/serial` page? 

[0]: https://makecode.microbit.org/device/serial
[1]: https://makecode.microbit.org/reference/serial/redirect