### PR TITLE
pxt-microbit-next?

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cd ..
 ```
 6. Clone this repository.
 ```
-git clone https://github.com/microsoft/pxt-microbit-next
+git clone https://github.com/microsoft/pxt-microbit
 cd pxt-microbit
 ```
 7. Install the PXT command line (add `sudo` for Mac/Linux shells).


### PR DESCRIPTION
Since the repo https://github.com/microsoft/pxt-microbit-next doesn't exist, I am assuming that the word `next` is not meant to be here.