### PR TITLE
Update 'Metal Detector' example

### DIFF
--- a/docs/reference/input/calibrate-compass.md
+++ b/docs/reference/input/calibrate-compass.md
@@ -30,4 +30,4 @@ input.onButtonPressed(Button.AB, () => {
 
 ## See also
 
-[compassHeading](/reference/input/compass-heading)
+[compass heading](/reference/input/compass-heading)

--- a/docs/reference/input/compass-heading.md
+++ b/docs/reference/input/compass-heading.md
@@ -56,10 +56,11 @@ basic.forever(() => {
 
 ## Calibration
 
-Every time you start to use the compass (for example, if you have just
-turned the @boardname@ on), the @boardname@ will start to [calibrateCompass](/reference/input/calibrate-compass)
-(adjust itself).  It will ask you to draw a circle by tilting the
-@boardname@.
+Every time you start to use the compass (for example, if you have just turned the @boardname@ on),
+the @boardname@ will start a [calibrate compass](/reference/input/calibrate-compass)
+(adjust itself).
+The [calibration step](https://support.microbit.org/support/solutions/articles/19000008874-calibrating-the-micro-bit-compass)
+will ask you to draw a fill pattern on the screen by tilting the @boardname@.
 
 If you are calibrating or using the compass near metal, it might
 confuse the @boardname@.
@@ -78,4 +79,4 @@ input.onButtonPressed(Button.AB, () => {
 
 ## See also
 
-[acceleration](/reference/input/acceleration), [calibrateCompass](/reference/input/calibrate-compass)
+[acceleration](/reference/input/acceleration), [calibrate compass](/reference/input/calibrate-compass)

--- a/docs/reference/input/magnetic-force.md
+++ b/docs/reference/input/magnetic-force.md
@@ -1,6 +1,6 @@
 # Magnetic Force
 
-Find the amount of magnetic force (the strength of a magnet) in the direction you say.
+Find the amount of magnetic force (the strength of a magnet) in one of the three directions.
 
 ```sig
 input.magneticForce(Dimension.X);
@@ -10,12 +10,14 @@ input.magneticForce(Dimension.X);
 
 The @boardname@ measures magnetic force with **microteslas**.
 
-## ~
+You are asked to [calibrate](https://support.microbit.org/support/solutions/articles/19000008874-calibrating-the-micro-bit-compass) the compass the first time run a program
+that uses the compass.
 
+## ~
 
 ## Parameters
 
-* ``dimension`` means which direction the @boardname@ should measure
+* **dimension**: this is the direction the @boardname@ should measure
   magnetic force in: either `Dimension.X` (the left-right direction),
   `Dimension.Y` (the forward/backward direction), or `Dimension.Z`
   (the up/down direction)
@@ -24,16 +26,14 @@ The @boardname@ measures magnetic force with **microteslas**.
 
 * a [number](/types/number) of microteslas that means the strength of the magnet
 
-## Example: metal detector
+## Example
 
-This program makes the center LED of the @boardname@ get brighter when
-the magnetic force is stronger, and dimmer when it is weaker.
+Create a metal detector my measuring the strength of magnetic force in the `X` direction.
+Display a bar graph to show the current level of magnetic force measured by the magnetometer.
 
 ```blocks
-led.plot(2, 2)
-basic.forever(() => {
-    let f = input.magneticForce(Dimension.X)
-    led.setBrightness(f / 2000)
+basic.forever(function() {
+    led.plotBarGraph(input.magneticForce(Dimension.X) / 2000, 0)
 })
 ```
 


### PR DESCRIPTION
Change the "Metal Detector" example in the "Magnetic Force" page to use plotting instead of modulating the brightness of a single LED.

Fixes #2555