### PR TITLE
Remove outdated #ifdef

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -222,7 +222,6 @@ void sendSerial(const char *data, int len) {
     logwriten(data, len);
 }
 
-#ifdef PXT_GC
 ThreadContext *getThreadContext() {
     if (!currentFiber)
         return NULL;
@@ -273,6 +272,5 @@ void gcProcessStacks(int flags) {
     }
     xfree(fibers);
 }
-#endif
 
 } // namespace pxt


### PR DESCRIPTION
PXT_GC is always enabled now (and new PXT doesn't emit the #define)