### PR TITLE
Update gesture field for new Blockly renderer

### DIFF
--- a/fieldeditors/field_gestures.ts
+++ b/fieldeditors/field_gestures.ts
@@ -19,7 +19,6 @@ export class FieldGestures extends pxtblockly.FieldImages implements Blockly.Fie
 
         this.setText = Blockly.FieldDropdown.prototype.setText;
         this.updateSize_ = (Blockly.Field as any).prototype.updateSize_;
-        this.updateTextNode_ = Blockly.Field.prototype.updateTextNode_;
     }
 
     trimOptions_() {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "6.21.9",
-        "pxt-core": "5.35.25"
+        "pxt-core": "5.36.1"
     }
 }


### PR DESCRIPTION
Requires pxt-core bump once https://github.com/microsoft/pxt/pull/6697 is merged in