### PR TITLE
Additional step in 'Snap the Dot' for sprite var

### DIFF
--- a/docs/projects/snap-the-dot.md
+++ b/docs/projects/snap-the-dot.md
@@ -6,13 +6,19 @@ Snap the dot is a game of skill where the player has to press **A** exactly when
 
 This tutorial shows how to use the game engine.
 
-## Create a sprite @fullscreen
+## Make a sprite variable @fullscreen
 
-Drag a ``||game:create sprite||`` block onto the workspace. A sprite is a single pixel that can move on the screen. It has an ``x`` and ``y`` position along with a direction of motion.
+Create a new variable called `sprite`. Drag a ``||variables:set sprite to||`` into the ``||basic:on start||`` on the workspace. 
 
 ```blocks
-let sprite: game.LedSprite = null
-sprite = game.createSprite(2, 2)
+let sprite = 0
+```
+## Create a sprite @fullscreen
+
+Pull out a ``||game:create sprite||`` block and put it in ``||variables:set sprite to||`` replacing the `0`. A sprite is a single pixel that can move on the screen. It has an ``x`` and ``y`` position along with a direction of motion.
+
+```blocks
+let sprite = game.createSprite(2, 2)
 ```
 
 ## Move the dot @fullscreen
@@ -20,8 +26,7 @@ sprite = game.createSprite(2, 2)
 The sprite starts in the center facing right. Put a ``||game:move||`` block into the ``||basic:forever||`` to make it move. Notice how it moves to the right but does not bounce back.
 
 ```blocks
-let sprite: game.LedSprite = null
-sprite = game.createSprite(2, 2)
+let sprite = game.createSprite(2, 2)
 basic.forever(function () {
     sprite.move(1)
 })
@@ -32,8 +37,7 @@ basic.forever(function () {
 Grab a ``||game:if on edge, bounce||`` block to make the sprite bounce on the side of the screen. Also, add a ``||basic:pause||`` block to slow down the sprite.
 
 ```blocks
-let sprite: game.LedSprite = null
-sprite = game.createSprite(2, 2)
+let sprite = game.createSprite(2, 2)
 basic.forever(function () {
     sprite.move(1)
     sprite.ifOnEdgeBounce()
@@ -52,13 +56,12 @@ When **A** is pressed, we test if the sprite is in the center or not.
 Use a ``||input:on button pressed||`` block to handle the **A** button. Put in a ``||logic:if||`` block and test if ``||game:x||`` is equal to `2`.
 
 ```blocks
-let sprite: game.LedSprite = null
+let sprite = game.createSprite(2, 2)
 input.onButtonPressed(Button.A, function () {
     if (sprite.get(LedSpriteProperty.X) == 2) {
     } else {
     }
 })
-sprite = game.createSprite(2, 2)
 basic.forever(function () {
     sprite.move(1)
     basic.pause(100)
@@ -71,7 +74,7 @@ basic.forever(function () {
 Finally, pull out an ``||game:add score||`` and a ``||game:game over||`` block to handle both success (sprite in the center) and failure (sprite not in the center).
 
 ```blocks
-let sprite: game.LedSprite = null
+let sprite = sprite = game.createSprite(2, 2)
 input.onButtonPressed(Button.A, function () {
     if (sprite.get(LedSpriteProperty.X) == 2) {
         game.addScore(1)
@@ -79,7 +82,6 @@ input.onButtonPressed(Button.A, function () {
         game.gameOver()
     }
 })
-sprite = game.createSprite(2, 2)
 basic.forever(function () {
     sprite.move(1)
     basic.pause(100)

--- a/docs/projects/snap-the-dot.md
+++ b/docs/projects/snap-the-dot.md
@@ -74,7 +74,7 @@ basic.forever(function () {
 Finally, pull out an ``||game:add score||`` and a ``||game:game over||`` block to handle both success (sprite in the center) and failure (sprite not in the center).
 
 ```blocks
-let sprite = sprite = game.createSprite(2, 2)
+let sprite = game.createSprite(2, 2)
 input.onButtonPressed(Button.A, function () {
     if (sprite.get(LedSpriteProperty.X) == 2) {
         game.addScore(1)


### PR DESCRIPTION
Add a step to explain creation of a `sprite` variable.

Closes #2644.

Note: There is no default instance for `sprite` on the `game.createSprite()` block.

![image](https://user-images.githubusercontent.com/27789908/77243547-7e9bea80-6bc8-11ea-9b33-2ef268dcfef4.png)

