### PR TITLE
Render selected text instead of image in gesture handler

### DIFF
--- a/fieldeditors/field_gestures.ts
+++ b/fieldeditors/field_gestures.ts
@@ -17,7 +17,7 @@ export class FieldGestures extends pxtblockly.FieldImages implements Blockly.Fie
         this.width_ = parseInt(options.width) || 350;
         this.addLabel_ = true;
 
-        this.setText = Blockly.FieldDropdown.prototype.setText;
+        this.renderSelectedImage_ = Blockly.FieldDropdown.prototype.renderSelectedText_;
         this.updateSize_ = (Blockly.Field as any).prototype.updateSize_;
     }
 


### PR DESCRIPTION
Fix for image dropdown rendering in the gesture field (https://github.com/microsoft/pxt-microbit/issues/2678)