### PR TITLE
Remove '@fullscreen' from most tutorials

### DIFF
--- a/docs/projects/SUMMARY.md
+++ b/docs/projects/SUMMARY.md
@@ -21,7 +21,7 @@
   * [Rock Paper Scissors](/projects/rock-paper-scissors)
   * [Coin Flipper](/projects/coin-flipper)
   * [Hot Potato](/projects/hot-potato)
-  * [Heads Guess!](/projects/head-guess)
+  * [Heads Guess!](/projects/heads-guess)
   * [Reaction Time](/projects/reaction-time)
   * [Magic Button Trick](/projects/magic-button-trick)
   * [Snap the dot](/projects/snap-the-dot)

--- a/docs/projects/dice.md
+++ b/docs/projects/dice.md
@@ -7,7 +7,7 @@ Let's turn the @boardname@ into a dice!
 
 ![A microbit dice](/static/mb/projects/dice.png)
 
-## Step 1 @fullscreen
+## Step 1
 
 We need 3 pieces of code: one to detect a throw (shake), another to pick a random number, and then one to show the number.
 
@@ -19,7 +19,7 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
-## Step 2 @fullscreen
+## Step 2
 
 Get a ``||basic:show number||`` block and place it inside the ``||input:on shake||`` block to display a number.
 
@@ -29,7 +29,7 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
-## Step 3 @fullscreen
+## Step 3
 
 Put a ``||Math:pick random||`` block in the ``||basic:show number||`` block to pick a random number.
 
@@ -39,7 +39,7 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
-## Step 4 @fullscreen
+## Step 4
 
 A typical dice shows values from `1` to `6`. So, in ``||Math:pick random||``, don't forget to choose the right minimum and maximum values!
 

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -8,7 +8,7 @@ Learn how to use the LEDs and make a flashing heart!
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/sim.gif)
 
-## Step 1
+## Step 1 @fullscreen
 
 Place the ``||basic:show leds||`` block in the ``||basic:forever||`` block and draw a heart.
 

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -8,13 +8,13 @@ Learn how to use the LEDs and make a flashing heart!
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/sim.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Place the ``||basic:show leds||`` block in the ``||basic:forever||`` block and draw a heart.
 
 ![An animation that shows how to drag a block and paint a heart](/static/mb/projects/flashing-heart/showleds.gif)
 
-## Step 2 @fullscreen
+## Step 2
 
 Place another ``||basic:show leds||`` block. You can leave it blank and draw what you want.
 
@@ -35,12 +35,12 @@ basic.forever(function() {
 })
 ```
 
-## Step 3 @fullscreen
+## Step 3
 
 Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
 
-## Step 4 @fullscreen
+## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!

--- a/docs/projects/micro-chat.md
+++ b/docs/projects/micro-chat.md
@@ -6,7 +6,7 @@
 
 Use the **radio** to send and receive messages with other @boardname@.
 
-## Sending a message @fullscreen
+## Sending a message
 
 Use ``||input:on button pressed||`` to send a text message over radio with ``||radio:send string||``.
 Every @boardname@ nearby will receive this message.
@@ -17,7 +17,7 @@ input.onButtonPressed(Button.A, () => {
 });
 ```
 
-## Receiving a message @fullscreen
+## Receiving a message
 
 Add a ``||radio:on received string||`` block to run when a message is received. 
 
@@ -26,7 +26,7 @@ radio.onReceivedString(function (receivedString) {
 })
 ```
 
-## Displaying text @fullscreen
+## Displaying text
 
 Add a ``||basic:show string||`` to display the string on the screen. Pull the ``||variables:receivedString||`` out of ``||radio:on received string||`` and put it into ``||basic:show string||``.
 
@@ -36,7 +36,7 @@ radio.onReceivedString(function (receivedString) {
 })
 ```
 
-## Testing in the simulator @fullscreen
+## Testing in the simulator
 
 Press button **A** on the simulator, you will notice that a second @boardname@ appears (if your screen is too small, the simulator might decide not to show it). Try pressing **A** again and notice that the "Yo" message gets displayed on the other @boardname@.
 
@@ -49,11 +49,11 @@ radio.onReceivedString(function (receivedString) {
 })
 ```
 
-## Try it for real @fullscreen
+## Try it for real
 
 If you two @boardname@s, download the program to each one. Press button **A** on one and see if the other gets a message.
 
-## Groups @fullscreen
+## Groups
 
 Use the ``||radio:set group||`` block to assign a **group** number to your program. You will only receive messages from @boardname@s within the same group. Use this to avoid receiving messages from every @boardname@ that is transmitting.
 

--- a/docs/projects/multi-dice.md
+++ b/docs/projects/multi-dice.md
@@ -8,7 +8,7 @@ Build a multi-player dice game using the **radio**. The **radio** blocks let you
 
 In this game, you shake to "throw the dice" and send the result to the other @boardname@. If you receive a result of a dice throw equal or greater than yours, you lose.
 
-## Dice game @fullscreen
+## Dice game
 
 Let's start by rebuilding the **dice** game. If you are unsure about the details, try the **dice** tutorial again.
 
@@ -18,7 +18,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Dice variable @fullscreen
+## Dice variable
 
 We need to store the result of the dice cast in a variable. A **variable** is like a place in the memory of the @boardname@ where you save information, like numbers.
 
@@ -34,7 +34,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Send the dice @fullscreen
+## Send the dice
 
 Put in a ``||radio:send number||`` and a ``||dice||`` to send the value stored in the ``dice`` variable via radio.
 
@@ -47,7 +47,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Receive the dice @fullscreen
+## Receive the dice
 
 Go get an ``||radio:on received number||`` event block. This event runs when a radio message from another @boardname@ arrives. The ``receivedNumber`` value is the value of the dice in this game.
 
@@ -56,7 +56,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Check your cast @fullscreen
+## Check your cast
 
 Add a ``||logic:if||`` block to test if ``receivedNumber`` is greater or equal to ``dice``. 
 If is, you lost so display a sad face on the screen.
@@ -70,7 +70,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Test it! @fullscreen
+## Test it!
 
 Try pressing **SHAKE** in the simulator and see that a second @boardname@ appears. You can play the game on both virtual boards.
 

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -6,7 +6,7 @@ Tell everyone who you are. Show you name on the LEDs.
 
 ![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Place the ``||basic:show string||`` block in the ``||basic:forever||`` block to repeat it. Change the text to your name.
 
@@ -16,13 +16,13 @@ basic.forever(() => {
 });
 ```
 
-## Step 2 @fullscreen
+## Step 2
 
 Look at the simulator and make sure it shows your name on the screen.
 
 ![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
 
-## Step 3 @fullscreen
+## Step 3
 
 Place more ``||basic:show string||`` blocks to create your own story.
 
@@ -33,6 +33,6 @@ basic.forever(() => {
 })
 ```
 
-## Step 4 @unplugged
+## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch your name scroll!

--- a/docs/projects/smiley-buttons.md
+++ b/docs/projects/smiley-buttons.md
@@ -7,7 +7,7 @@ Code the buttons on the @boardname@ to show that it's happy or sad.
 
 ![Pressing the A and B buttons](/static/mb/projects/smiley-buttons/sim.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Place a ``||input:on button pressed||`` block to run code when button **A** is pressed.
 
@@ -16,7 +16,7 @@ input.onButtonPressed(Button.A, () => {
 });
 ```
 
-## Step 2 @fullscreen
+## Step 2
 
 Place a ``||basic:show leds||`` block inside ``||input:on button pressed||`` to display a smiley on the screen. Press the **A** button in the simulator to see the smiley.
 
@@ -32,7 +32,7 @@ input.onButtonPressed(Button.A, () => {
 });
 ```
 
-## Step 3 @fullscreen
+## Step 3
 
 Add ``||input:on button pressed||`` and ``||basic:show leds||`` blocks to display a frowny when button **B** is pressed.
 
@@ -48,7 +48,7 @@ input.onButtonPressed(Button.B, () => {
 });
 ```
 
-## Step 4 @fullscreen
+## Step 4
 
 Add a secret mode that happens when **A** and **B** are pressed together. For this case, add multiple ``||basic:show leds||`` blocks to create an animation.
 

--- a/docs/projects/snap-the-dot.md
+++ b/docs/projects/snap-the-dot.md
@@ -6,14 +6,14 @@ Snap the dot is a game of skill where the player has to press **A** exactly when
 
 This tutorial shows how to use the game engine.
 
-## Make a sprite variable @fullscreen
+## Make a sprite variable
 
 Create a new variable called `sprite`. Drag a ``||variables:set sprite to||`` into the ``||basic:on start||`` on the workspace. 
 
 ```blocks
 let sprite = 0
 ```
-## Create a sprite @fullscreen
+## Create a sprite
 
 Pull out a ``||game:create sprite||`` block and put it in ``||variables:set sprite to||`` replacing the `0`. A sprite is a single pixel that can move on the screen. It has an ``x`` and ``y`` position along with a direction of motion.
 
@@ -21,7 +21,7 @@ Pull out a ``||game:create sprite||`` block and put it in ``||variables:set spri
 let sprite = game.createSprite(2, 2)
 ```
 
-## Move the dot @fullscreen
+## Move the dot
 
 The sprite starts in the center facing right. Put a ``||game:move||`` block into the ``||basic:forever||`` to make it move. Notice how it moves to the right but does not bounce back.
 
@@ -32,7 +32,7 @@ basic.forever(function () {
 })
 ```
 
-## Bounce @fullscreen
+## Bounce
 
 Grab a ``||game:if on edge, bounce||`` block to make the sprite bounce on the side of the screen. Also, add a ``||basic:pause||`` block to slow down the sprite.
 
@@ -49,7 +49,7 @@ basic.forever(function () {
 
 Use the simulator to find the best speed. If you have a @boardname@, press ``|Download|`` to try it out on the device.
 
-## Button handling @fullscreen
+## Button handling
 
 When **A** is pressed, we test if the sprite is in the center or not.
 

--- a/docs/projects/spy/dice.md
+++ b/docs/projects/spy/dice.md
@@ -9,7 +9,7 @@ We need 3 pieces of code: one to detect a throw (shake), another to pick a rando
 
 ![A @boardname@ dice](/static/mb/projects/dice.png)
 
-## Step 1 @fullscreen
+## Step 1
 
 Add an event to run code when a ``||input:shake||`` is detected.
 

--- a/docs/projects/spy/flashing-heart.md
+++ b/docs/projects/spy/flashing-heart.md
@@ -7,9 +7,18 @@ Learn how to use the LEDs and make a flashing heart!
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/sim.gif)
 
-## Step 1
+## Step 1 @fullscreen
 
-Put a ``||basic:show leds||`` in the ``||basic:forever||`` block and draw a heart.
+Put a ``||basic:forever||`` event to repeat code.
+
+```spy
+basic.forever(function() {
+})
+```
+
+## Step 2
+
+Put ``||basic:show leds||`` in the ``||basic:forever||`` and draw a heart.
 
 ```spy
 basic.forever(function() {
@@ -22,7 +31,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 2
+## Step 3
 
 Place in another ``||basic:show leds||``. You can leave it blank and draw what you want.
 
@@ -43,12 +52,12 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## Step 4
 
 Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
 
-## Step 4
+## Step 5
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/spy/flashing-heart.md
+++ b/docs/projects/spy/flashing-heart.md
@@ -7,7 +7,7 @@ Learn how to use the LEDs and make a flashing heart!
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/sim.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Put a ``||basic:show leds||`` in the ``||basic:forever||`` block and draw a heart.
 
@@ -22,7 +22,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 2 @fullscreen
+## Step 2
 
 Place in another ``||basic:show leds||``. You can leave it blank and draw what you want.
 
@@ -43,12 +43,12 @@ basic.forever(function() {
 })
 ```
 
-## Step 3 @fullscreen
+## Step 3
 
 Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
 
-## Step 4 @fullscreen
+## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/spy/love-meter.md
+++ b/docs/projects/spy/love-meter.md
@@ -6,7 +6,7 @@ Make a **LOVE METER** machine, how sweet! The @boardname@ is feeling the love, t
 
 ![Love meter banner message](/static/mb/projects/love-meter/love-meter.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Add an event to run code when ``||input:on pin 0 is pressed||``. Use ``P0`` from the list of pin inputs.
 

--- a/docs/projects/spy/micro-chat.md
+++ b/docs/projects/spy/micro-chat.md
@@ -6,7 +6,7 @@
 
 Use the **radio** to send and receive messages with other @boardname@.
 
-## Handle buttons @fullscreen
+## Handle buttons
 
 Add an event to run code when ``||input:button A is pressed||``.
 
@@ -15,7 +15,7 @@ input.onButtonPressed(Button.A, function() {
 });
 ```
 
-## Sending a message @fullscreen
+## Sending a message
 
 Add code to ``||radio:send a string||`` over ``||radio:radio||`` when ``||input:button A is pressed||``. 
 Every @boardname@ nearby will receive this message.
@@ -47,7 +47,7 @@ radio.onReceivedString(function (receivedString) {
 })
 ```
 
-## Testing in the simulator @fullscreen
+## Testing in the simulator
 
 Press button **A** on the simulator, you will notice that a second @boardname@ appears (if your screen is too small, the simulator might decide not to show it). Try pressing **A** again and notice that the "Yo" message gets displayed on the other @boardname@.
 

--- a/docs/projects/spy/name-tag.md
+++ b/docs/projects/spy/name-tag.md
@@ -6,7 +6,7 @@ Tell everyone who you are. Show you name on the LEDs.
 
 ![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Add an event to repeat code ``||basic:forever||``.
 
@@ -26,7 +26,7 @@ basic.forever(function() {
 });
 ```
 
-## Step 3 @fullscreen
+## Step 3
 
 Look at the simulator and make sure it shows your name on the screen.
 
@@ -44,6 +44,6 @@ basic.forever(function() {
 })
 ```
 
-## Step 5 @fullscreen
+## Step 5
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/spy/smiley-buttons.md
+++ b/docs/projects/spy/smiley-buttons.md
@@ -7,7 +7,7 @@ Code the buttons on the @boardname@ to show that it's happy or sad.
 
 ![Pressing the A and B buttons](/static/mb/projects/smiley-buttons/sim.gif)
 
-## Step 1 @fullscreen
+## Step 1
 
 Put in an ``||input:on button pressed||`` event to run code when button **A** is pressed.
 
@@ -75,6 +75,6 @@ input.onButtonPressed(Button.AB, function() {
 
 Click ``|Download|`` to transfer your code to your @boardname@ (if you have one). Try buttons **A**, **B** and then **A** and **B** together.
 
-## Step 6 @fullscreen
+## Step 6
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/turtle-square.md
+++ b/docs/projects/turtle-square.md
@@ -4,7 +4,7 @@
 
 Imagine that there's a virtual turtle, as small as an LED, that you can control with commands. In this tutorial, you will learn to use the turtle and draw a square.
 
-## Moving the turtle @fullscreen
+## Moving the turtle
 
 The turtle starts in the center of the screen heading upward. Place a ``||turtle:forward||`` block to make it move up.
 
@@ -12,7 +12,7 @@ The turtle starts in the center of the screen heading upward. Place a ``||turtle
 turtle.forward(1)
 ```
 
-## Turning and moving @fullscreen
+## Turning and moving
 
 Place a ``||turtle:turnRight||`` to turn the turtle and place another ``||turtle:forward||`` block to make it move again.
 


### PR DESCRIPTION
Drop the `@fullscreen` attribute from most (all except for 'RPS') tutorials.

RE: #2084