### PR TITLE
Triple dot menu color for microbit

### DIFF
--- a/theme/style.less
+++ b/theme/style.less
@@ -25,9 +25,14 @@
     &:extend(.ui.purple.button all);
 }
 
-.ui.button.download-button:hover {
+.ui.button.download-button:hover,
+.ui.button.hw-button:hover {
     background-color: #00ED00;
     color: black;
+}
+
+.ui.button.hw-button {
+    background-color: darken(@purple, 10%);
 }
 
 .docs.inlinebutton.ui.button.download-button:hover {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2775

Specified in the target because we define the 'Download' button color separately in each target, using semantic classes instead of less variables.