### PR TITLE
display sensor data in debugger variable view

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "6.22.7",
-        "pxt-core": "5.37.27"
+        "pxt-core": "5.37.29"
     }
 }

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -16,6 +16,7 @@ namespace pxsim.input {
 
     export function isGesture(gesture: number): boolean {
         const b = accForGesture(gesture);
+        b.accelerometer.activate();
         return b.accelerometer.getGesture() == gesture;
     }
 
@@ -33,15 +34,15 @@ namespace pxsim.input {
                 acc.activate(AccelerometerFlag.Z);
                 return acc.getZ();
             default:
-                acc.activate();
-                return Math.floor(Math.sqrt(acc.instantaneousAccelerationSquared()));
+                acc.activate(AccelerometerFlag.Strength);
+                return acc.getStrength();
         }
     }
 
     export function rotation(kind: number): number {
         const b = board().accelerometerState;
+        b.accelerometer.activate();
         const acc = b.accelerometer;
-        acc.activate();
         const x = acc.getX(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
         const y = acc.getY(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
         const z = acc.getZ(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
@@ -117,8 +118,9 @@ namespace pxsim {
 
     export enum AccelerometerFlag {
         X = 1,
-        Y = 2,
-        Z = 4
+        Y = 1 << 1,
+        Z = 1 << 2,
+        Strength = 1 << 3
     }
 
     export class Accelerometer {
@@ -148,7 +150,7 @@ namespace pxsim {
                 this.isActive = true;
                 this.runtime.queueDisplayUpdate();
             }
-            if (flags)
+            if (!!flags)
                 this.flags |= flags;
         }
 
@@ -169,7 +171,25 @@ namespace pxsim {
             board().bus.queue(this.id, DAL.MICROBIT_ACCELEROMETER_EVT_DATA_UPDATE)
         }
 
-        public instantaneousAccelerationSquared() {
+        public getStrength() {
+            return Math.floor(Math.sqrt(this.instantaneousAccelerationSquared()));
+        }
+
+        updateEnvironmentGlobals() {
+            // update debugger
+            if (this.isActive) {
+                if (this.flags & AccelerometerFlag.X)
+                    this.runtime.environmentGlobals["acc.x"] = this.sample.x;
+                if (this.flags & AccelerometerFlag.Y)
+                    this.runtime.environmentGlobals["acc.y"] = this.sample.y;
+                if (this.flags & AccelerometerFlag.Z)
+                    this.runtime.environmentGlobals["acc.z"] = this.sample.z;
+                if (this.flags & AccelerometerFlag.Strength)
+                    this.runtime.environmentGlobals["acc.strength"] = Math.sqrt(this.instantaneousAccelerationSquared());
+            }
+        }
+
+        private instantaneousAccelerationSquared() {
             // Use pythagoras theorem to determine the combined force acting on the device.
             return this.sample.x * this.sample.x + this.sample.y * this.sample.y + this.sample.z * this.sample.z;
         }
@@ -294,7 +314,6 @@ namespace pxsim {
           * @endcode
           */
         public getX(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
-            this.activate();
             switch (system) {
                 case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
                     return -this.sample.x;
@@ -319,7 +338,6 @@ namespace pxsim {
           * @endcode
           */
         public getY(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
-            this.activate();
             switch (system) {
                 case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
                     return -this.sample.y;
@@ -344,7 +362,6 @@ namespace pxsim {
           * @endcode
           */
         public getZ(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
-            this.activate();
             switch (system) {
                 case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
                     return -this.sample.z;
@@ -365,7 +382,6 @@ namespace pxsim {
           * @endcode
           */
         public getPitch(): number {
-            this.activate();
             return Math.floor((360 * this.getPitchRadians()) / (2 * Math.PI));
         }
 
@@ -384,7 +400,6 @@ namespace pxsim {
           * @endcode
           */
         public getRoll(): number {
-            this.activate();
             return Math.floor((360 * this.getRollRadians()) / (2 * Math.PI));
         }
 

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -178,17 +178,17 @@ namespace pxsim {
             // update debugger
             if (this.isActive) {
                 if (this.flags & AccelerometerFlag.X)
-                    this.runtime.environmentGlobals["acc.x"] = this.sample.x;
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.x")] = this.sample.x;
                 if (this.flags & AccelerometerFlag.Y)
-                    this.runtime.environmentGlobals["acc.y"] = this.sample.y;
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.y")] = this.sample.y;
                 if (this.flags & AccelerometerFlag.Z)
-                    this.runtime.environmentGlobals["acc.z"] = this.sample.z;
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.z")] = this.sample.z;
                 if (this.flags & AccelerometerFlag.Strength)
-                    this.runtime.environmentGlobals["acc.strength"] = Math.sqrt(this.instantaneousAccelerationSquared());
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.strength")] = Math.sqrt(this.instantaneousAccelerationSquared());
                 if (this.flags & AccelerometerFlag.Pitch)
-                    this.runtime.environmentGlobals["acc.pitch"] = this.getPitch();
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.pitch")] = this.getPitch();
                 if (this.flags & AccelerometerFlag.Roll)
-                    this.runtime.environmentGlobals["acc.roll"] = this.getRoll();
+                    this.runtime.environmentGlobals[pxsim.localization.lf("acceleration.roll")] = this.getRoll();
             }
         }
 

--- a/sim/state/accelerometer.ts
+++ b/sim/state/accelerometer.ts
@@ -41,21 +41,18 @@ namespace pxsim.input {
 
     export function rotation(kind: number): number {
         const b = board().accelerometerState;
-        b.accelerometer.activate();
         const acc = b.accelerometer;
-        const x = acc.getX(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
-        const y = acc.getY(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
-        const z = acc.getZ(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
-
-        const roll = Math.atan2(y, z);
-        const pitch = Math.atan(-x / (y * Math.sin(roll) + z * Math.cos(roll)));
-
-        let r = 0;
         switch (kind) {
-            case 0: r = pitch; break;
-            case 1: r = roll; break;
+            case 0: {
+                acc.activate(AccelerometerFlag.Pitch);
+                return acc.getPitch(); 
+            }
+            case 1: {
+                acc.activate(AccelerometerFlag.Roll);
+                return acc.getRoll(); 
+            }
+            default: return 0;
         }
-        return Math.floor(r / Math.PI * 180);
     }
 
     export function setAccelerometerRange(range: number) {
@@ -120,7 +117,9 @@ namespace pxsim {
         X = 1,
         Y = 1 << 1,
         Z = 1 << 2,
-        Strength = 1 << 3
+        Strength = 1 << 3,
+        Pitch = 1 << 4,
+        Roll = 1 << 5
     }
 
     export class Accelerometer {
@@ -186,6 +185,10 @@ namespace pxsim {
                     this.runtime.environmentGlobals["acc.z"] = this.sample.z;
                 if (this.flags & AccelerometerFlag.Strength)
                     this.runtime.environmentGlobals["acc.strength"] = Math.sqrt(this.instantaneousAccelerationSquared());
+                if (this.flags & AccelerometerFlag.Pitch)
+                    this.runtime.environmentGlobals["acc.pitch"] = this.getPitch();
+                if (this.flags & AccelerometerFlag.Roll)
+                    this.runtime.environmentGlobals["acc.roll"] = this.getRoll();
             }
         }
 

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -507,7 +507,7 @@ path.sim-board {
                 });
                 this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130 }) as SVGTextElement;
                 if (this.props.runtime)
-                    this.props.runtime.environmentGlobals["temperature"] = state.thermometerState.temperature;
+                    this.props.runtime.environmentGlobals[pxsim.localization.lf("temperature")] = state.thermometerState.temperature;
                 this.updateTheme();
 
                 let pt = this.element.createSVGPoint();
@@ -585,7 +585,7 @@ path.sim-board {
                 svg.rotateElement(this.head, xc, yc, state.compassState.heading + 180);
                 this.headText.textContent = txt;
                 if (this.props.runtime)
-                    this.props.runtime.environmentGlobals["heading"] = state.compassState.heading;
+                    this.props.runtime.environmentGlobals[pxsim.localization.lf("heading")] = state.compassState.heading;
             }
         }
 
@@ -672,7 +672,7 @@ path.sim-board {
                     });
                 this.lightLevelText = svg.child(this.g, "text", { x: 85, y: cy + r - 5, text: '', class: 'sim-text' }) as SVGTextElement;
                 if (this.props.runtime)
-                    this.props.runtime.environmentGlobals["light"] = state.lightSensorState.lightLevel;
+                    this.props.runtime.environmentGlobals[pxsim.localization.lf("lightLevel")] = state.lightSensorState.lightLevel;
                 this.updateTheme();
 
                 accessibility.makeFocusable(this.lightLevelButton);

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -506,6 +506,8 @@ path.sim-board {
                     fill: `url(#${gid})`
                 });
                 this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130 }) as SVGTextElement;
+                if (this.props.runtime)
+                    this.props.runtime.environmentGlobals["temperature"] = state.thermometerState.temperature;
                 this.updateTheme();
 
                 let pt = this.element.createSVGPoint();
@@ -582,6 +584,8 @@ path.sim-board {
             if (txt != this.headText.textContent) {
                 svg.rotateElement(this.head, xc, yc, state.compassState.heading + 180);
                 this.headText.textContent = txt;
+                if (this.props.runtime)
+                    this.props.runtime.environmentGlobals["heading"] = state.compassState.heading;
             }
         }
 

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -707,6 +707,8 @@ path.sim-board {
             const af = 8 / 1023;
             const s = 1 - Math.min(0.1, Math.pow(Math.max(Math.abs(x), Math.abs(y)) / 1023, 2) / 35);
 
+            acc.updateEnvironmentGlobals();
+
             // fix top parent and apply style to it
             const el = this.findParentElement();
             el.style.transform = `perspective(30em) rotateX(${y * af}deg) rotateY(${x * af}deg) scale(${s}, ${s})`

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -412,7 +412,7 @@ path.sim-board {
             this.updateButtonAB();
             this.updateGestures();
 
-            if (!runtime || runtime.dead) U.addClass(this.element, "grayscale");
+            if (!this.props.runtime || this.props.runtime.dead) U.addClass(this.element, "grayscale");
             else U.removeClass(this.element, "grayscale");
         }
 
@@ -667,6 +667,8 @@ path.sim-board {
                         }
                     });
                 this.lightLevelText = svg.child(this.g, "text", { x: 85, y: cy + r - 5, text: '', class: 'sim-text' }) as SVGTextElement;
+                if (this.props.runtime)
+                    this.props.runtime.environmentGlobals["light"] = state.lightSensorState.lightLevel;
                 this.updateTheme();
 
                 accessibility.makeFocusable(this.lightLevelButton);


### PR DESCRIPTION
Inject the "hidden" environment state into the debugger view. A lot of state, like the accelerometer state, is currently not visible in the debugger -- unless the user uses a variable. We can make this better by injecting this state on demand.

![image](https://user-images.githubusercontent.com/4175913/79678444-80999f00-81b0-11ea-9f1a-ff27f97b342b.png)

TODO: 
- [x] style it up a bit better; finish wiring sensor
- [x] localize names

Requires https://github.com/microsoft/pxt/pull/6872