### PR TITLE
Image literal rows fix

### DIFF
--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -83,7 +83,7 @@ void showImage(Image sprite, int xOffset, int interval = 400) {
 //% parts="ledmatrix"
 void plotFrame(Image i, int xOffset) {
     // TODO showImage() used in original implementation
-    plotImage(i, xOffset * 5);
+    plotImage(i, xOffset * i->img->height);
 }
 
 /**
@@ -178,6 +178,6 @@ bool pixel(Image i, int x, int y) {
 //% weight=70 help=images/show-frame
 //% parts="ledmatrix"
 void showFrame(Image i, int frame, int interval = 400) {
-    showImage(i, frame * 5, interval);
+    showImage(i, frame * i->img->height, interval);
 }
 } // namespace ImageMethods

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -86,7 +86,7 @@ namespace pxsim {
     }
 
     export function createImageFromBuffer(data: number[]): Image {
-        return new Image(data.length / 5, data);
+        return new Image((data.length / 5) | 0, data);
     }
 
     export function createImageFromString(text: string): Image {

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -32,21 +32,21 @@ namespace pxsim {
             console.debug(`Image id:${this.id} size:${this.width}x${this.height}`)
         }
         public get(x: number, y: number): number {
-            x = x >> 0;
-            y = y >> 0;
-            if (x < 0 || x >= this.width || y < 0 || y >= 5) return 0;
+            x = x | 0;
+            y = y | 0;
+            if (x < 0 || x >= this.width || y < 0 || y >= this.height) return 0;
             return this.data[y * this.width + x];
         }
         public set(x: number, y: number, v: number) {
-            x = x >> 0;
-            y = y >> 0;
-            if (x < 0 || x >= this.width || y < 0 || y >= 5) return;
+            x = x | 0;
+            y = y | 0;
+            if (x < 0 || x >= this.width || y < 0 || y >= this.height) return;
             this.data[y * this.width + x] = Math.max(0, Math.min(255, v));
         }
         public copyTo(xSrcIndex: number, length: number, target: Image, xTargetIndex: number): void {
-            xSrcIndex = xSrcIndex >> 0;
-            length = length >> 0;
-            xTargetIndex = xTargetIndex >> 0;
+            xSrcIndex = xSrcIndex | 0;
+            length = length | 0;
+            xTargetIndex = xTargetIndex | 0;
             for (let x = 0; x < length; x++) {
                 for (let y = 0; y < this.height; y++) {
                     let value = this.get(xSrcIndex + x, y);
@@ -55,7 +55,7 @@ namespace pxsim {
             }
         }
         public shiftLeft(cols: number) {
-            cols = cols >> 0;
+            cols = cols | 0;
             for (let x = 0; x < this.width; ++x)
                 for (let y = 0; y < this.height; ++y)
                     this.set(x, y, x < this.width - cols ? this.get(x + cols, y) : 0);

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -19,16 +19,17 @@ namespace pxsim {
     }
 
     export class Image extends RefObject {
-        public static height: number = 5;
+        public height: number;
         public width: number;
         public data: number[];
         constructor(width: number, data: number[]) {
             super();
             this.width = width;
             this.data = data;
+            this.height = (this.data.length / this.width) | 0;
         }
         public print() {
-            console.debug(`Image id:${this.id} size:${this.width}x${Image.height}`)
+            console.debug(`Image id:${this.id} size:${this.width}x${this.height}`)
         }
         public get(x: number, y: number): number {
             x = x >> 0;
@@ -47,7 +48,7 @@ namespace pxsim {
             length = length >> 0;
             xTargetIndex = xTargetIndex >> 0;
             for (let x = 0; x < length; x++) {
-                for (let y = 0; y < 5; y++) {
+                for (let y = 0; y < this.height; y++) {
                     let value = this.get(xSrcIndex + x, y);
                     target.set(xTargetIndex + x, y, value);
                 }
@@ -56,14 +57,14 @@ namespace pxsim {
         public shiftLeft(cols: number) {
             cols = cols >> 0;
             for (let x = 0; x < this.width; ++x)
-                for (let y = 0; y < 5; ++y)
+                for (let y = 0; y < this.height; ++y)
                     this.set(x, y, x < this.width - cols ? this.get(x + cols, y) : 0);
         }
 
         public shiftRight(cols: number) {
             cols = cols >> 0;
             for (let x = this.width - 1; x >= 0; --x)
-                for (let y = 0; y < 5; ++y)
+                for (let y = 0; y < this.height; ++y)
                     this.set(x, y, x >= cols ? this.get(x - cols, y) : 0);
         }
 

--- a/sim/state/ledmatrix.ts
+++ b/sim/state/ledmatrix.ts
@@ -178,7 +178,7 @@ namespace pxsim.ImageMethods {
 
     export function height(leds: Image): number {
         pxtrt.nullCheck(leds)
-        return Image.height;
+        return leds.height;
     }
 
     export function width(leds: Image): number {
@@ -187,11 +187,11 @@ namespace pxsim.ImageMethods {
     }
 
     export function plotFrame(leds: Image, frame: number) {
-        ImageMethods.plotImage(leds, frame * Image.height);
+        ImageMethods.plotImage(leds, frame * leds.height);
     }
 
     export function showFrame(leds: Image, frame: number, interval: number) {
-        ImageMethods.showImage(leds, frame * Image.height, interval);
+        ImageMethods.showImage(leds, frame * leds.height, interval);
     }
 
     export function pixel(leds: Image, x: number, y: number): number {


### PR DESCRIPTION
Better support for number of rows != 5 and "imageLiteralRows". The "trick" is to use a shim to send the image to ``images::createImage`` and implement the simulator code in STS.

Test:
```
namespace custom {
    /**
     */
    //% block="foo"
    //% imageLiteral=1
    //% imageLiteralColumns=17
    //% imageLiteralRows=7
    //% shim=images::createImage
    export function foo(i: string): Image {
        const im = <Image><any>i;
        return im
    }
}

let im = custom.foo(`
    # . . . . . . . . . . # # . . . .
    . # . . . . . . . . # . . # . . .
    . . # # . . . . . # . . . # . . .
    . . . # . . . . # . . . . . # . .
    . . . . # . . . # . . . . . # . .
    . . . . # # . . . . . . . . . # .
    . . . . . # # # . . . . . . . . #
    `)
im.scrollImage(1, 200)
```