### PR TITLE
deprecate onShake

### DIFF
--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -25,6 +25,7 @@ namespace input {
      * Attaches code to run when the device is shaken.
      * @param body TODO
      */
+    //% deprecated=true
     //% help=input/on-shake
     export function onShake(body: () => void): void {
         onGesture(Gesture.Shake, body);


### PR DESCRIPTION
We prefer onGesture now I believe. Need confirmation: @abchatra or @riknoll 

Fixes: @https://github.com/microsoft/pxt-microbit/issues/2839

onShake no longer appears in intellisense:
<img width="511" alt="Screen Shot 2020-04-30 at 7 19 03 PM" src="https://user-images.githubusercontent.com/6453828/80776573-8af45b00-8b17-11ea-960e-001077a25852.png">

