### PR TITLE
Fix some typos in v0 docs

### DIFF
--- a/docs/projects/crashy-bird.md
+++ b/docs/projects/crashy-bird.md
@@ -46,7 +46,7 @@ let obstacles: game.LedSprite[] = []
 Now generate vertical obstacles consisting of 4 sprites and 1 random hole. 
 Create new variable called `emptyObstacleY`. Using ``||math:pick random||``, generate a random number from `0` to `4` and store it inside `emptyObstacleY`. 
 
-Using ``||loops:for||`` loop, iterate from `0` to `4`. For every coordinate not equal to `emptyObstacleY` create and add obstacle sprites to the endo fo the `obstacles` array.
+Using ``||loops:for||`` loop, iterate from `0` to `4`. For every coordinate not equal to `emptyObstacleY` create and add obstacle sprites to the end of the `obstacles` array.
 
 ```blocks
 let emptyObstacleY = 0

--- a/docs/projects/plant-watering/code.md
+++ b/docs/projects/plant-watering/code.md
@@ -2,7 +2,7 @@
 
 Let's add code so that when the soil moisture level is low, the servo waters the plant.
 
-From the **[soil moisture](/projects/soil-moisture)** project, we know that the moisture is low when the ``reading`` is roughly less than ``500``. We can use this number to add an ``if reading < 500`` in the code to decect a dry condition.
+From the **[soil moisture](/projects/soil-moisture)** project, we know that the moisture is low when the ``reading`` is roughly less than ``500``. We can use this number to add an ``if reading < 500`` in the code to detect a dry condition.
 
 ```block
 let reading = 0

--- a/docs/projects/plant-watering/code.md
+++ b/docs/projects/plant-watering/code.md
@@ -2,7 +2,9 @@
 
 Let's add code so that when the soil moisture level is low, the servo waters the plant.
 
-From the **[soil moisture](/projects/soil-moisture)** project, we know that the moisture is low when the ``reading`` is roughly less than ``500``. We can use this number to add an ``if reading < 500`` in the code to detect a dry condition.
+From the **[soil moisture](/projects/soil-moisture)** project, we know that the moisture is low when the
+``reading`` is roughly less than ``500``. We can use this number to add an ``if reading < 500`` in the
+code to detect a dry condition.
 
 ```block
 let reading = 0


### PR DESCRIPTION
Fix a couple of typos in the `v0` docs. Found by Crowdin translators.