### PR TITLE
Move neopixel sendBuffer primitive into core

### DIFF
--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -559,7 +559,6 @@ declare namespace led {
     //% block=1200
     BaudRate1200 = 1200,
     }
-
 declare namespace serial {
 }
 

--- a/libs/core/light.cpp
+++ b/libs/core/light.cpp
@@ -17,7 +17,7 @@ __attribute__((noinline)) static void neopixel_send_buffer(DevicePin &pin, const
 
 namespace light {
 //%
-void sendNeopixelBuffer(Buffer buf, int pin) {
+void sendWS2812Buffer(Buffer buf, int pin) {
     if (!buf || !buf->length)
         return;
     neopixel_send_buffer(*pxt::getPin(pin), buf->data, buf->length);

--- a/libs/core/light.cpp
+++ b/libs/core/light.cpp
@@ -17,7 +17,7 @@ __attribute__((noinline)) static void neopixel_send_buffer(DevicePin &pin, const
 
 namespace light {
 //%
-void sendNeopixelBuffer(int pin, Buffer buf) {
+void sendNeopixelBuffer(Buffer buf, int pin) {
     if (!buf || !buf->length)
         return;
     neopixel_send_buffer(*pxt::getPin(pin), buf->data, buf->length);

--- a/libs/core/light.cpp
+++ b/libs/core/light.cpp
@@ -1,0 +1,26 @@
+#include "pxt.h"
+
+#if MICROBIT_CODAL
+#include "neopixel.h"
+#else
+extern "C" void neopixel_send_buffer_core(DevicePin *pin, const uint8_t *ptr, int numBytes);
+__attribute__((noinline)) static void neopixel_send_buffer(DevicePin &pin, const uint8_t *ptr,
+                                                           int numBytes) {
+
+    // setup pin as digital
+    pin.setDigitalValue(0);
+    __disable_irq();
+    neopixel_send_buffer_core(&pin, ptr, numBytes);
+    __enable_irq();
+}
+#endif
+
+namespace light {
+//%
+void sendNeopixelBuffer(int pin, Buffer buf) {
+    if (!buf || !buf->length)
+        return;
+    neopixel_send_buffer(*pxt::getPin(pin), buf->data, buf->length);
+}
+
+} // namespace light

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -39,6 +39,8 @@ static inline ImageData *imageBytes(ImageLiteral_ lit) {
 #define Button MButton
 #endif
 
+typedef MicroBitPin DevicePin;
+
 typedef RefMImage *Image;
 
 extern MicroBit uBit;

--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -50,6 +50,8 @@
         "trig.cpp",
         "fixed.ts",
         "templates.ts",
+        "sendbuffer.s",
+        "light.cpp",
         "parts/speaker.svg",
         "parts/headphone.svg"
     ],

--- a/libs/core/sendbuffer.s
+++ b/libs/core/sendbuffer.s
@@ -1,0 +1,48 @@
+.syntax unified
+.section .text.neopixel_send_buffer_core
+.global neopixel_send_buffer_core
+
+neopixel_send_buffer_core:
+    push {r4,r5,r6,r7,lr}
+    
+    mov r4, r1 // ptr
+    mov r5, r2 // len
+    
+    ldr r0, [r0, #8] // get mbed DigitalOut from MicroBitPin
+    ldr r1, [r0, #4] // r1-mask for this pin
+    ldr r2, [r0, #16] // r2-clraddr
+    ldr r3, [r0, #12] // r3-setaddr
+    
+    b .start
+    
+.nextbit:               //            C0
+    str r1, [r3, #0]    // pin := hi  C2
+    tst r6, r0          //            C3
+    bne .islate         //            C4
+    str r1, [r2, #0]    // pin := lo  C6
+.islate:
+    lsrs r6, r6, #1     // r6 >>= 1   C7
+    bne .justbit        //            C8
+    
+    // not just a bit - need new byte
+    adds r4, #1         // r4++       C9
+    subs r5, #1         // r5--       C10
+    bcc .stop           // if (r5<0) goto .stop  C11
+.start:
+    movs r6, #0x80      // reset mask C12
+    nop                 //            C13
+
+.common:               //             C13
+    str r1, [r2, #0]   // pin := lo   C15
+    // always re-load byte - it just fits with the cycles better this way
+    ldrb r0, [r4, #0]  // r0 := *r4   C17
+    b .nextbit         //             C20
+
+.justbit: // C10
+    // no nops, branch taken is already 3 cycles
+    b .common // C13
+
+.stop:    
+    str r1, [r2, #0]   // pin := lo
+
+    pop {r4,r5,r6,r7,pc}

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -45,7 +45,7 @@
         "gc": true,
         "imageRefTag": 9,
         "shimRenames": {
-            "sendBufferAsm": "light::sendNeopixelBuffer"
+            "sendBufferAsm": "light::sendWS2812Buffer"
         },
         "patches": {
             "0.0.0 - 1.0.0": [

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -44,6 +44,9 @@
         "utf8": false,
         "gc": true,
         "imageRefTag": 9,
+        "shimRenames": {
+            "sendBufferAsm": "light::sendNeopixelBuffer"
+        },
         "patches": {
             "0.0.0 - 1.0.0": [
                 {

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -242,7 +242,7 @@ namespace pxsim.bluetooth {
 }
 
 namespace pxsim.light {
-    export function sendNeopixelBuffer(buffer: RefBuffer, pin: number) {
+    export function sendWS2812Buffer(buffer: RefBuffer, pin: number) {
         pxsim.sendBufferAsm(buffer, pin)
     }
 }

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -241,3 +241,8 @@ namespace pxsim.bluetooth {
     export function setTransmitPower(power: number) { }
 }
 
+namespace pxsim.light {
+    export function sendNeopixelBuffer(buffer: RefBuffer, pin: number) {
+        pxsim.sendBufferAsm(buffer, pin)
+    }
+}


### PR DESCRIPTION
Tested as this:

```typescript
//% shim=light::sendNeopixelBuffer
function send(pin: DigitalPin, buf: Buffer): void {}
```
