### PR TITLE
Ability to specify baud rate

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -84,6 +84,7 @@
   "Buffer.shift|param|start": "start offset in buffer. Default is 0.",
   "Buffer.sizeOfNumberFormat": "Get the size in bytes of specified number format.",
   "Buffer.slice": "Return a copy of a fragment of a buffer.",
+  "Buffer.toArray": "Read contents of buffer as an array in specified format",
   "Buffer.toHex": "Convert a buffer to its hexadecimal representation.",
   "Buffer.toString": "Convert a buffer to string assuming UTF8 encoding",
   "Buffer.unpack": "Reads numbers from the buffer according to the format",

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -71,6 +71,8 @@
   "Delimiters.NewLine|block": "new line (\n)",
   "Delimiters.Pipe|block": "|",
   "Delimiters.SemiColon|block": ";",
+  "Delimiters.Space|block": "space",
+  "Delimiters.Tab|block": "tab (\t)",
   "Dimension.Strength|block": "strength",
   "Dimension.X|block": "x",
   "Dimension.Y|block": "y",

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -175,6 +175,23 @@ namespace serial {
     }
 
     /**
+    Set the baud rate of the serial port
+    */
+    //% weight=10
+    //% blockId=serial_setbaudrate block="serial|set baud rate %rate"
+    //% blockGap=8 inlineInputMode=inline
+    //% help=serial/set-baud-rate
+    //% group="Configuration" advanced=true
+    void setBaudRate(BaudRate rate) {
+#if MICROBIT_CODAL
+      uBit.serial.setBaud(rate);
+#else
+      uBit.serial.baud((int)rate);
+#endif
+    }
+
+
+    /**
     * Direct the serial input and output to use the USB connection.
     */
     //% weight=9 help=serial/redirect-to-usb

--- a/libs/core/serial.ts
+++ b/libs/core/serial.ts
@@ -13,6 +13,10 @@ const enum Delimiters {
     Hash = 35,
     //% block="carriage return (\r)"
     CarriageReturn = 13,
+    //% block="space"
+    Space = 32,
+    //% block="tab (\t)"
+    Tab = 9,
     //% block="|"
     Pipe = 124,
     //% block=";"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "typescript": "^3.7.5"
     },
     "dependencies": {
-        "pxt-common-packages": "6.22.13",
+        "pxt-common-packages": "6.23.1",
         "pxt-core": "5.37.66"
     }
 }

--- a/sim/state/serial.ts
+++ b/sim/state/serial.ts
@@ -78,4 +78,8 @@ namespace pxsim.serial {
             length = 64;
         return pins.createBuffer(length);
     }
+
+    export function setBaudRate(rate: number) {
+        // TODO
+    }
 }


### PR DESCRIPTION
Some extension need to set the USB pins for serial and set the baud rate. This is not possible today.