### PR TITLE
Adding python helpers

### DIFF
--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -17,6 +17,8 @@
         "core.cpp",
         "pxt-helpers.ts",
         "helpers.ts",
+        "pxt-python.d.ts",
+        "pxt-python-helpers.ts",
         "pinscompat.ts",
         "configkeys.h",
         "gc.cpp",


### PR DESCRIPTION
Needs to be in the pxt.json of the core library.