### PR TITLE
Show rounded rope value in 'Tug of LED'

### DIFF
--- a/docs/projects/spy/tug-of-led.md
+++ b/docs/projects/spy/tug-of-led.md
@@ -55,6 +55,18 @@ input.onButtonPressed(Button.B, function () {
 
 ## Step 5
 
+Because a button press moves the rope by **0.1** in either direction, plot the ``||math:rounded||`` value of ``||variables:rope||`` instead.
+
+```spy
+let rope = 2
+basic.forever(function() {
+    basic.clearScreen()
+    led.plot(Math.round(rope), 2)
+})
+```
+
+## Step 6
+
 Back in the ``||basic:forever||``, add code to test ``||logic:if||`` the ``||variables:rope||`` is negative
 then ``||basic:show||``**A WINS** on the screen.
 
@@ -70,7 +82,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 6
+## Step 7
 
 Add an ``||logic:else if||`` condition to test ``||logic:if||`` the ``||variables:rope||`` is greater than `4`
 then ``||basic:show||``**B WINS** on the screen.
@@ -89,6 +101,6 @@ basic.forever(function() {
 })
 ```
 
-## Step 7
+## Step 8
 
 Find a friend and start button smashing!

--- a/docs/projects/spy/tug-of-led.md
+++ b/docs/projects/spy/tug-of-led.md
@@ -55,7 +55,7 @@ input.onButtonPressed(Button.B, function () {
 
 ## Step 5
 
-Because a button press moves the rope by **0.1** in either direction, plot the ``||math:rounded||`` value of ``||variables:rope||`` instead.
+Because a button press pulls the rope by **0.1** in either direction, plot the ``||math:rounded||`` value of ``||variables:rope||`` to the nearest LED.
 
 ```spy
 let rope = 2


### PR DESCRIPTION
Add a step to 'Tug of LED' tutorial to show the rounded value of `rope` instead of the default truncated.

Fixes #3025