### PR TITLE
No sim GIFs in tutorial steps

### DIFF
--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -39,8 +39,6 @@ basic.forever(function() {
 
 Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
 
-![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
-
 ## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -20,8 +20,6 @@ basic.forever(() => {
 
 Look at the simulator and make sure it shows your name on the screen.
 
-![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
-
 ## Step 3
 
 Place more ``||basic:show string||`` blocks to create your own story.


### PR DESCRIPTION
Remove the GIFs of simulator examples in steps other than the unplugged intro.

Here are some others with sim GIFs. Remove also?

* https://makecode.microbit.org/projects/rock-paper-scissors

Closes #3119