### PR TITLE
Adding dbprefix for v3

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -508,7 +508,8 @@
         },
         "browserDbPrefixes": {
             "1": "v1",
-            "2": "v2"
+            "2": "v2",
+            "3": "v3"
         },
         "editorVersionPaths": {
             "0": "v0"


### PR DESCRIPTION
Only updating dbprefix.
Verified that we don't need editorVersionPaths. It is only necessary for v0 as it didn't have right versions backed in. https://github.com/microsoft/pxt/blob/1285b123332ecbb9e923c28a7870d58e644da709/webapp/src/app.tsx#L316
