### PR TITLE
Remove loops from basic 'spy' tutorials

### DIFF
--- a/docs/projects/spy/flashing-heart.md
+++ b/docs/projects/spy/flashing-heart.md
@@ -11,58 +11,64 @@ Learn how to use the LEDs and make a flashing heart!
 
 ## Step 1 @fullscreen
 
-Put in a ``||basic:forever||`` event to repeat code.
+Make the screen ``||basic:show an icon||``  of a **Heart**.
 
 ```spy
-basic.forever(function() {
-
-})
+basic.showIcon(IconNames.Heart)
 ```
 
 ## Step 2
 
-Put ``||basic:show leds||`` in the ``||basic:forever||`` loop and draw a heart. An image is drawn
-by placing a `#` for the LED you want to turn on in the 5 rows by 5 columns of periods - `.`. These
-represent each LED on the display.
+After the icon is displayed, ``||basic:clear screen||`` and  ``||basic:pause||`` for `500` milliseconds.
 
 ```spy
-basic.forever(function() {
-    basic.showLeds(`
-        . # . # .
-        # # # # #
-        # # # # #
-        . # # # .
-        . . # . .`)
-})
+basic.showIcon(IconNames.Heart)
+basic.clearScreen()
+basic.pause(500)
 ```
 
 ## Step 3
 
-Put in one more ``||basic:show leds||``. You can either leave it blank or draw in a new image.
+Now, copy the code currently have and add it to the end. In the copied code, ``||basic:show an icon||`` of a **SmallHeart**. Your heart will flash from big to small.
 
 ```spy
-basic.forever(function() {
-    basic.showLeds(`
-        . # . # .
-        # # # # #
-        # # # # #
-        . # # # .
-        . . # . .`)
-    basic.showLeds(`
-        . . . . .
-        . . . . .
-        . . . . .
-        . . . . .
-        . . . . .`)
-})
+basic.showIcon(IconNames.Heart)
+basic.clearScreen()
+basic.pause(500)
+basic.showIcon(IconNames.SmallHeart)
+basic.clearScreen()
+basic.pause(500)
 ```
 
 ## Step 4
 
-Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
+Add one more ``||basic:show icon||`` at the end to display another **Heart**.
 
-![Heart shape in the LEDs](/static/mb/projects/flashing-heart/show-leds.gif)
+```spy
+basic.showIcon(IconNames.Heart)
+basic.clearScreen()
+basic.pause(500)
+basic.showIcon(IconNames.SmallHeart)
+basic.clearScreen()
+basic.pause(500)
+basic.showIcon(IconNames.Heart)
+```
 
 ## Step 5
+
+Do you want your heart to flash continuously? Remove the last ``||basic:show icon||`` and then put a ``||basic:forever||`` loop around your code.
+
+```spy
+basic.forever(function() {
+    basic.showIcon(IconNames.Heart)
+    basic.clearScreen()
+    basic.pause(500)
+    basic.showIcon(IconNames.SmallHeart)
+    basic.clearScreen()
+    basic.pause(500)
+})
+```
+
+## Step 6
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/spy/name-tag.md
+++ b/docs/projects/spy/name-tag.md
@@ -10,44 +10,49 @@ Tell everyone who you are. Show you name on the LEDs.
 
 ## Step 1
 
-Use the ``||basic:forever||`` loop to run some code continuously.
+On the screen, ``||basic:show a string||`` saying `"My name is: "`.
 
 ```spy
-basic.forever(function() {
-
-})
+basic.showString("My name is: ")
 ```
 
 ## Step 2
 
-Show your name using ``||basic:show string||`` inside the ``||basic:forever||`` loop. Set your
-name as the string value for ``||basic:show string||``.
+Let everyone know who you are and ``||basic:show a string||`` with your name.
 
 ```spy
-basic.forever(function() {
-    // @highlight
-    basic.showString("MICRO")
-})
+basic.showString("My name is: ")
+basic.showString("Sarah!")
 ```
 
 ## Step 3
 
-Look at the simulator and make sure it shows your name on the screen.
+Tell everyone what your age is. Add a ``||basic:show string||`` for `"My age is "` and then ``||basic:show a number||` for your age.
 
-![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
+```spy
+basic.showString("My name is: ")
+basic.showString("Sarah!")
+basic.showString("My age is: ")
+basic.showNumber(9)
+```
 
 ## Step 4
+
+Look at the simulator and make sure it shows your name and age on the screen.
+
+## Step 5
 
 Place more ``||basic:show strings||`` to create a longer message.
 
 ```spy
-basic.forever(function() {
-    basic.showString("MICRO")
-    // @highlight
-    basic.showString("BIT")
-})
+basic.showString("My name is: ")
+basic.showString("Sarah!")
+basic.showString("My age is: ")
+basic.showNumber(9)
+basic.showString("Favorite color: ")
+basic.showString("Blue")
 ```
 
-## Step 5
+## Step 6
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/spy/smiley-buttons.md
+++ b/docs/projects/spy/smiley-buttons.md
@@ -20,61 +20,34 @@ input.onButtonPressed(Button.A, function() {
 
 ## Step 2
 
-Place ``||basic:show leds||`` inside ``||input:on button pressed||`` to display a **:)** image on
-the screen. An image is drawn by placing a `#` for the LED you want to turn on in the 5 rows by 5
-columns of periods - `.`. These represent each LED on the screen.
+Use ``||basic:show icon||`` to display a **Happy** face on the screen.
 
 Press the **A** button in the simulator to see the smiley.
 
 ```spy
 input.onButtonPressed(Button.A, function() { 
-    basic.showLeds(`
-        # # . # #
-        # # . # #
-        . . . . .
-        # . . . #
-        . # # # .`
-        )
+    basic.showIcon(IconNames.Happy)
 })
 ```
 
 ## Step 3
 
-Use another ``||input:on button pressed||`` with ``||basic:show leds||`` inside to display a **:(** when
-button **B** is pressed.
+Use another ``||input:on button pressed||`` with a ``||basic:show icon||`` inside to display a **Sad** face when button **B** is pressed.
 
 ```spy
 input.onButtonPressed(Button.B, function() { 
-    basic.showLeds(`
-        # # . # #
-        # # . # #
-        . . . . .
-        . # # # .
-        # . . . #`
-        )
+    basic.showIcon(IconNames.Sad)
 })
 ```
 
 ## Step 4
 
-Add a secret mode that happens when **A** and **B** are pressed together. For this case, use ``||basic:show leds||`` multiple times to create an animation.
+Add a secret mode that happens when **A** and **B** are pressed together. For this case, use ``||basic:show icon||`` multiple times to create an animation.
 
 ```spy
 input.onButtonPressed(Button.AB, function() {
-    basic.showLeds(`
-        . . . . .
-        # . # . .
-        . . . . .
-        # . . . #
-        . # # # .
-        `)
-    basic.showLeds(`
-        . . . . .
-        . . # . #
-        . . . . .
-        # . . . #
-        . # # # .
-        `)    
+    basic.showIcon(IconNames.Silly)
+    basic.showIcon(IconNames.Suprised)
 })
 ```
 

--- a/docs/projects/spy/smiley-buttons.md
+++ b/docs/projects/spy/smiley-buttons.md
@@ -47,7 +47,7 @@ Add a secret mode that happens when **A** and **B** are pressed together. For th
 ```spy
 input.onButtonPressed(Button.AB, function() {
     basic.showIcon(IconNames.Silly)
-    basic.showIcon(IconNames.Suprised)
+    basic.showIcon(IconNames.Surprised)
 })
 ```
 


### PR DESCRIPTION
Remove the requirement of forming loop structures from the basic 'spy' tutorials. This is to make them a bit easier to type in (at least for the simplest ones).

Closes #3118 