### PR TITLE
Missing 'have' in micro chat step info

### DIFF
--- a/docs/projects/micro-chat.md
+++ b/docs/projects/micro-chat.md
@@ -51,7 +51,7 @@ radio.onReceivedString(function (receivedString) {
 
 ## Try it for real
 
-If you two @boardname@s, download the program to each one. Press button **A** on one and see if the other gets a message.
+If you have two @boardname@s, download the program to each one. Press button **A** on one and see if the other gets a message.
 
 ## Groups
 


### PR DESCRIPTION
Sentence in the "Try it for real" step is missing "have" when referring to micro:bits.

Fixes #3192