### PR TITLE
Updates for melody ref pages

### DIFF
--- a/docs/reference/music.md
+++ b/docs/reference/music.md
@@ -6,7 +6,7 @@ Generation of music tones through pin ``P0``.
 music.playTone(0, 0);
 music.ringTone(0);
 music.rest(0);
-music.beginMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once);
+music.startMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once);
 music.stopMelody(MelodyStopOptions.All);
 music.onEvent(MusicEvent.MelodyNotePlayed, () => {});
 music.beat(BeatFraction.Whole);
@@ -18,7 +18,7 @@ music.setTempo(120);
 ## See Also
 
 [playTone](/reference/music/play-tone), [ringTone](/reference/music/ring-tone), [rest](/reference/music/rest),
-[beginMelody](/reference/music/begin-melody), 
+[startMelody](/reference/music/start-melody), 
 [stopMelody](/reference/music/stop-melody),
 [onEvent](/reference/music/on-event),
-[beat](/reference/music/beat), [tempo](/reference/music/tempo), [changeTempoBy](/reference/music/change-tempo-by), [setTempo](/reference/music/set-tempo),
+[beat](/reference/music/beat), [tempo](/reference/music/tempo), [changeTempoBy](/reference/music/change-tempo-by), [setTempo](/reference/music/set-tempo)

--- a/docs/reference/music/making-melodies.md
+++ b/docs/reference/music/making-melodies.md
@@ -8,7 +8,9 @@ A _note_ is a tone that is recognized as part of music. A note has a name like '
 
 On your @boardname@, a note is played on the speaker by sending a signal to it with a certain _frequency_ called [Hertz](http://wikipedia.org/Hertz). Frequency is how fast something vibrates during one second. If you ring a bell that was made to play an '**A**' note, the bell will vibrate at 440 Hertz (440 times per second). So, notes are just certain frequencies that have special names.
 
-## ~ hint
+### ~ hint
+
+#### Listen to music with headphones
 
 Watch this video to see how speakers and headphones make sound when connected to your @boardname@.
 
@@ -32,6 +34,14 @@ Some of these other notes look like:
 
 When a small amount music or even a song is written down it is called [sheet music](https://wikipedia.org/wiki/Sheet_music).
 
+### ~ hint
+
+#### Note names in different languages
+
+Many languages other than English use different names for some or all of the musical notes. MakeCode uses English for names in code.
+
+### ~
+
 ## Sounds and music in code
 
 Of course, we can't use written music in our code. We can make music another way. The way to do it is to put names of notes in [strings](/types/string). We make our notes using letters, symbols, and numbers. The notes of a melody are put together in an array like:
@@ -51,13 +61,13 @@ What you see here is not some alien language but a bunch of notes with their dur
 You might notice that the sound string has an ``'R:1'`` in it. The '**R**` means _rest_ and to rest for one beat. A rest is a pause, or a time of silence, in the sound.
 
 
-#### ~ hint
+### ~ hint
 
-**Duration**
+#### Duration
 
 The amount of time a note is played (duration) is measured as _beats_. The standard number _beats per minute_ (bpm) in music is 120 bpm which is one-half of a second of time. A _whole_ note lasts for 4 beats and a _quarter_ note takes just one beat.
 
-#### ~
+### ~
 
 ## Example
 

--- a/docs/reference/music/making-melodies.md
+++ b/docs/reference/music/making-melodies.md
@@ -6,7 +6,7 @@ Composing some sound, or maybe some music, is done by putting tones to together,
 
 A _note_ is a tone that is recognized as part of music. A note has a name like '**C**'. A note is played for an amount of time called its _duration_. 
 
-On your @boardname@, a note is played on the speaker by sending a signal to a it with a certain _frequency_ called [Hertz](http://wikipedia.org/Hertz). Frequency is how fast something vibrates during one second. If you ring a bell that was made to play an '**A**' note, the bell will vibrate at 440 Hertz (440 times per second). So, notes are just certain frequencies that have special names.
+On your @boardname@, a note is played on the speaker by sending a signal to it with a certain _frequency_ called [Hertz](http://wikipedia.org/Hertz). Frequency is how fast something vibrates during one second. If you ring a bell that was made to play an '**A**' note, the bell will vibrate at 440 Hertz (440 times per second). So, notes are just certain frequencies that have special names.
 
 ## ~ hint
 
@@ -24,7 +24,7 @@ Basic notes have names that use one of the first nine letters of the alphabet. T
 
 ``|A|``, ``|B|``, ``|C|``, ``|D|``, ``|E|``, ``|F|``, ``|G|``
 
-Ther are other notes named like the basic notes but have extra parts to the name called _sharp_ and _flat_. These other notes are just a bit different from the basic notes and have frequencies a little higher or lower than the basic note. This makes music a little more complicated but much more interesting!
+There are other notes named like the basic notes but have extra parts to the name called _sharp_ and _flat_. These other notes are just a bit different from the basic notes and have frequencies a little higher or lower than the basic note. This makes music a little more complicated but much more interesting!
 
 Some of these other notes look like:
 

--- a/docs/reference/music/start-melody.md
+++ b/docs/reference/music/start-melody.md
@@ -1,0 +1,64 @@
+# start Melody
+
+Start playing a musical melody through pin ``P0`` of the @boardname@.
+
+```sig
+music.startMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once)
+```
+
+## ~ hint
+
+**Simulator**: This function only works on the @boardname@ and in some browsers.
+
+## ~
+
+There are built-in melodies that you can choose from the ``||start melody||`` block. These are already composed for you and are easy to use by just selecting the one you want. If you want to play your own melody, you can [compose](/reference/music/making-melodies) one and use it instead of one of the built-in ones.
+
+Melodies are a sequence of notes, each played for some small amount time, one after the other. The notes in a melody are held in an [array](/types/array) of [strings](/types/string). Each string in the array is a note of the melody. You make a melody by assembling the notes along with the _duration_ that the note plays for. The melody is [formed](/reference/music/making-melodies) like this:
+
+``NOTE[octave][:duration] eg: ['g5:1']``
+
+```block
+music.startMelody(['g4:1', 'c5', 'e', 'g:2', 'e:1', 'g:3'], MelodyOptions.Once)
+```
+
+Melodies are played either in the _foreground_ or _background_. This allows more than one melody to be active at once. If a melody is set to play in the background, it can be interrupeted, or paused, temporarily while a melody set for the foreground is played. If the foreground melody is not set to play ``forever``, then the background melody resumes when the foreground melody is finished.
+
+You can set options for how you want the melody to play. You can ask that the melody plays just one time, ``once``, or have it keep repeating, ``forever``. With these options the melody will play in the foreground either once or continue to repeat. Of course, if you set ``forever``, any melody that was started in background will never play unless you [stop](/reference/music/stop-melody) the foreground melody. To make a background melody, set the option to ``once in background`` or ``forever in background``.
+
+## Parameters
+
+* **melody**: A built-in melody or an [array](/types/array) representation of a [melody](reference/music/making-melodies) you wish to play.
+* **options**: the play option for the melody:
+>* ``once``: play the melody in the foreground one time
+>* ``forever``: play the melody in the foreground and keep repeating it
+>* ``once in background``: play the melody in the background one time
+>* ``forever in background``: play the melody in the background and keep repeating it
+
+## Examples
+
+### Play the "Entertainer"
+
+This example plays the ``Entertainer`` built-in melody.
+
+```blocks
+music.startMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once)
+```
+
+### Play a composed melody forever
+
+Play a made-up melody in the background forever.
+
+```blocks
+music.startMelody(['g4:1', 'c5', 'e', 'g:2', 'e:1', 'g:3'], MelodyOptions.ForeverInBackground)
+```
+
+## See also
+
+[stop melody](/reference/music/stop-melody), [play tone](/reference/music/play-tone),
+[rest](/reference/music/rest), [ring tone](/reference/music/ring-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
+
+[Making Melodies](/reference/music/making-melodies)
+


### PR DESCRIPTION
- [x] Fix the typos found by [@smooke](https://crowdin.com/profile/smooke) in the 'Making Melodies' page via Crowdin.
- [x] Patch in the 'start-melody' ref page
- [x] Add a comment about note names in English