### PR TITLE
Remove basic.more subcategory

### DIFF
--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -54,7 +54,6 @@ namespace basic {
     //% help=basic/clear-screen weight=79
     //% blockId=device_clear_display block="clear screen"
     //% parts="ledmatrix"
-    //% advanced=true
     void clearScreen() {
       uBit.display.image.clear();
     }

--- a/libs/core/icons.ts
+++ b/libs/core/icons.ts
@@ -197,7 +197,6 @@ namespace basic {
     //% blockId=basic_show_arrow
     //% block="show arrow %i=device_arrow"
     //% parts="ledmatrix"
-    //% advanced=true
     //% help=basic/show-arrow
     export function showArrow(direction: number, interval = 600) {
         let res = images.arrowImage(direction)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3210

Removes the advanced = true tags for the two blocks in the basic:more subcategory