### PR TITLE
Enabling hebrew & bulgarian

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -476,6 +476,7 @@
         "availableLocales": [
             "en",
             "ar",
+            "bg",
             "cs",
             "da",
             "de",
@@ -483,6 +484,7 @@
             "es-ES",
             "fi",
             "fr",
+            "he",
             "hu",
             "is",
             "it",


### PR DESCRIPTION
Both translated around 90% for core strings.