### PR TITLE
Turn on diffs for 'spy' tutorials

### DIFF
--- a/docs/projects/SUMMARY.md
+++ b/docs/projects/SUMMARY.md
@@ -60,7 +60,7 @@
   * [Mood Radio](/projects/mood-radio)
   * [Tele-potato](/projects/tele-potato)
   * [Fireflies](/projects/fireflies)
-  * [Hot or Cold](/hot-or-cold-multi)
+  * [Hot or Cold](/projects/hot-or-cold-multi)
   * [Red Light Green Light](/projects/red-light-green-light)
   * [Voting Machine](/projects/voting-machine)
   * [Rock Paper Scissors Teams](/projects/rps-teams)

--- a/docs/projects/spy/7-seconds.md
+++ b/docs/projects/spy/7-seconds.md
@@ -47,7 +47,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 4
+## Step 4 @resetDiff
 
 The player stops the timer by pressing button **B**. Add another event to run code when
 ``||input:button B is pressed||``.

--- a/docs/projects/spy/7-seconds.md
+++ b/docs/projects/spy/7-seconds.md
@@ -1,6 +1,7 @@
 # 7 seconds game
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 
@@ -30,7 +31,6 @@ variable.
 ```spy
 let start = 0
 input.onButtonPressed(Button.A, function () {
-    // @highlight
     start = input.runningTime()
 })
 ```
@@ -43,7 +43,6 @@ Show something on the screen so that the user knows that the timer has started..
 let start = 0
 input.onButtonPressed(Button.A, function () {
     start = input.runningTime()
-    // @highlight
     basic.showIcon(IconNames.Chessboard)
 })
 ```
@@ -67,7 +66,6 @@ store it in a new local variable (a variable only inside the event) called ``||v
 ```spy
 let start = 0
 input.onButtonPressed(Button.B, function () {
-    // @highlight
     let elapsed = input.runningTime() - start
 })
 ```
@@ -82,7 +80,6 @@ milliseconds.
 let start = 0
 input.onButtonPressed(Button.B, function () {
     let elapsed = input.runningTime() - start
-    // @highlight
     let score = Math.abs(elapsed - 7000)
 })
 ```
@@ -96,7 +93,6 @@ let start = 0
 input.onButtonPressed(Button.B, function () {
     let elapsed = input.runningTime() - start
     let score = Math.abs(elapsed - 7000)
-    // @highlight
     basic.showNumber(score)
 })
 ```

--- a/docs/projects/spy/coin-flipper.md
+++ b/docs/projects/spy/coin-flipper.md
@@ -1,6 +1,7 @@
 # Coin Flipper
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/compass.md
+++ b/docs/projects/spy/compass.md
@@ -1,5 +1,8 @@
 # Compass
 
+### @explicitHints true
+### @diffs true
+
 ## Introduction @unplugged
 
 This tutorial will show you how to program a script that displays which direction the @boardname@ is pointing. Let's get started!

--- a/docs/projects/spy/dice.md
+++ b/docs/projects/spy/dice.md
@@ -1,6 +1,7 @@
 # Dice
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/flashing-heart.md
+++ b/docs/projects/spy/flashing-heart.md
@@ -1,6 +1,7 @@
 # Flashing Heart
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/heads-guess.md
+++ b/docs/projects/spy/heads-guess.md
@@ -1,6 +1,7 @@
 # Heads Guess!
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 
@@ -45,7 +46,6 @@ Add code to pick a ``||math:random||`` ``||variables:index||``.
 let text_list: string[] = []
 let index = 0
 input.onGesture(Gesture.LogoUp, function () {
-    // @highlight
     index = randint(0, text_list.length - 1)
 })
 ```
@@ -60,7 +60,6 @@ let text_list: string[] = []
 let index = 0
 input.onGesture(Gesture.LogoUp, function () {
     index = randint(0, text_list.length - 1)
-    // @highlight
     basic.showString(text_list[index])
 })
 ```
@@ -82,7 +81,6 @@ Put in code to add points to the ``||game:score||``.
 
 ```spy
 input.onGesture(Gesture.ScreenDown, function () {
-    // @highlight
     game.addScore(1)
 })
 ```
@@ -104,7 +102,6 @@ For the pass gesture, add code to remove a ``||game:life||`` from the player.
 
 ```spy
 input.onGesture(Gesture.ScreenUp, function () {
-    // @highlight
     game.removeLife(1)
 })
 ```

--- a/docs/projects/spy/heads-guess.md
+++ b/docs/projects/spy/heads-guess.md
@@ -26,7 +26,7 @@ text_list = ["PUPPY", "CLOCK", "NIGHT"]
 game.startCountdown(30000)
 ```
 
-## Step 3
+## Step 3 @resetDiff
 
 Add an event to run code when a ``||input:gesture||`` points the @boardname@ ``||input:logo up||``.
 This is the gesture to get a new word.

--- a/docs/projects/spy/hot-potato.md
+++ b/docs/projects/spy/hot-potato.md
@@ -1,6 +1,7 @@
 # Hot Potato
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 
@@ -28,7 +29,6 @@ is caught holding the potato.
 ```spy
 let timer = 0
 input.onButtonPressed(Button.A, function () {
-    // @highlight
     timer = randint(5, 15)
 })
 ```
@@ -41,7 +41,6 @@ Add code to ``||basic:show an icon||`` to indicate that the game has started.
 let timer = 0
 input.onButtonPressed(Button.A, function () {
     timer = randint(5, 15)
-    // @highlight
     basic.showIcon(IconNames.Chessboard)
 })
 ```
@@ -57,7 +56,6 @@ let timer = 0
 input.onButtonPressed(Button.A, function () {
     timer = randint(5, 15)
     basic.showIcon(IconNames.Chessboard)
-    // @highlight
     while (timer > 0) {
     }
 })
@@ -74,9 +72,7 @@ input.onButtonPressed(Button.A, function () {
     timer = randint(5, 15)
     basic.showIcon(IconNames.Chessboard)
     while (timer > 0) {
-        // @highlight
         timer += -1
-        // @highlight
         basic.pause(1000)
     }
 })
@@ -95,7 +91,6 @@ input.onButtonPressed(Button.A, function () {
         timer += -1
         basic.pause(1000)
     }
-    // @highlight
     basic.showIcon(IconNames.Skull)
 })
 ```

--- a/docs/projects/spy/level.md
+++ b/docs/projects/spy/level.md
@@ -1,6 +1,7 @@
 # Level
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 
@@ -16,7 +17,6 @@ in the ``||basic:forever||`` loop.
 
 ```spy
 basic.forever(function() {
-    // @highlight
     let x = input.acceleration(Dimension.X)
 })
 ```
@@ -28,7 +28,6 @@ Make another variable ``||variables:y||`` and store the ``||input:acceleration y
 ```spy
 basic.forever(function() {
     let x = input.acceleration(Dimension.X)
-    // @highlight
     let y = input.acceleration(Dimension.Y)
 })
 ```
@@ -43,7 +42,6 @@ basic.forever(function() {
     let x = input.acceleration(Dimension.X)
     let y = input.acceleration(Dimension.Y)
     if (Math.abs(x) > 32) {
-        // @highlight
         basic.showIcon(IconNames.Sad)        
     } else {
 
@@ -63,7 +61,6 @@ basic.forever(function() {
     if (Math.abs(x) > 32) {
         basic.showIcon(IconNames.Sad)        
     } else if (Math.abs(y) > 32) {
-        // @highlight
         basic.showIcon(IconNames.Angry)        
     } else {
 
@@ -84,7 +81,6 @@ basic.forever(function() {
     } else if (Math.abs(y) > 32) {
         basic.showIcon(IconNames.Angry)        
     } else {
-        // @highlight
         basic.showIcon(IconNames.Happy)        
     }
 })

--- a/docs/projects/spy/love-meter.md
+++ b/docs/projects/spy/love-meter.md
@@ -1,6 +1,7 @@
 # Love Meter
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/micro-chat.md
+++ b/docs/projects/spy/micro-chat.md
@@ -24,7 +24,6 @@ Every @boardname@ nearby will receive this message.
 
 ```spy
 input.onButtonPressed(Button.A, function() {
-    // @highlight
     radio.sendString(":)")
 })
 ```
@@ -44,7 +43,6 @@ Inside the event, add code to ``||basic:show||`` the ``||variables:receivedStrin
 
 ```spy
 radio.onReceivedString(function (receivedString) {
-    // @highlight
     basic.showString(receivedString)
 })
 ```

--- a/docs/projects/spy/micro-chat.md
+++ b/docs/projects/spy/micro-chat.md
@@ -28,7 +28,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Receiving a message
+## Receiving a message @resetDiff
 
 Put in another event to run code when a ``||radio:string is received||`` over ``||radio:radio||``. 
 
@@ -55,7 +55,7 @@ Press button **A** on the simulator, you will notice that a second @boardname@ a
 
 If you two @boardname@s, download the program to each one. Press button **A** on one and see if the other gets a message.
 
-## Groups
+## Groups @resetDiff
 
 Add code to ``||radio:set the group||`` number of your program. You will only receive messages from @boardname@s within the same group. Use this to avoid receiving messages from every @boardname@ that is transmitting.
 

--- a/docs/projects/spy/name-tag.md
+++ b/docs/projects/spy/name-tag.md
@@ -1,6 +1,7 @@
 # Name Tag
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/rock-paper-scissors.md
+++ b/docs/projects/spy/rock-paper-scissors.md
@@ -1,6 +1,7 @@
 # Rock Paper Scissors
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/smiley-buttons.md
+++ b/docs/projects/spy/smiley-buttons.md
@@ -31,7 +31,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 3
+## Step 3 @resetDiff
 
 Use another ``||input:on button pressed||`` with a ``||basic:show icon||`` inside to display a **Sad** face when button **B** is pressed.
 
@@ -41,7 +41,7 @@ input.onButtonPressed(Button.B, function() {
 })
 ```
 
-## Step 4
+## Step 4 @resetDiff
 
 Add a secret mode that happens when **A** and **B** are pressed together. For this case, use ``||basic:show icon||`` multiple times to create an animation.
 

--- a/docs/projects/spy/smiley-buttons.md
+++ b/docs/projects/spy/smiley-buttons.md
@@ -1,6 +1,7 @@
 # Smiley Buttons
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/snap-the-dot.md
+++ b/docs/projects/spy/snap-the-dot.md
@@ -1,6 +1,7 @@
 # Snap the Dot
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/stopwatch.md
+++ b/docs/projects/spy/stopwatch.md
@@ -30,7 +30,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## Step 3 @resetDiff
 
 Add another event to run code when ``||input:button B is pressed||``.
 

--- a/docs/projects/spy/stopwatch.md
+++ b/docs/projects/spy/stopwatch.md
@@ -1,6 +1,7 @@
 # Stopwatch
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 

--- a/docs/projects/spy/tug-of-led.md
+++ b/docs/projects/spy/tug-of-led.md
@@ -1,6 +1,7 @@
 # Tug-Of-LED
 
 ### @explicitHints true
+### @diffs true
 
 ## Introduction @unplugged
 
@@ -75,7 +76,6 @@ let rope = 2
 basic.forever(function() {
     basic.clearScreen()
     led.plot(Math.round(rope), 2)
-    // @highlight
     if (rope < 0) {
         basic.showString("A WINS")
     }
@@ -95,7 +95,6 @@ basic.forever(function() {
     if (rope < 0) {
         basic.showString("A WINS")
     } else if (rope > 4) {
-        // @highlight
         basic.showString("B WINS")
     }
 })

--- a/docs/projects/spy/tug-of-led.md
+++ b/docs/projects/spy/tug-of-led.md
@@ -31,7 +31,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## Step 3 @resetDiff
 
 Add an event for ``||input:button A pressed||`` to change the ``||variables:rope||`` value by **-0.1**.
 The @boardname@ will automatically round the ``||variables:rope||`` value to the nearest LED coordinate.
@@ -43,7 +43,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 4
+## Step 4 @resetDiff
 
 Add an event on ``||input:button B pressed||`` to change the ``||variables:rope||`` value by **0.1**.
 
@@ -54,7 +54,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 5
+## Step 5 @resetDiff
 
 Because a button press pulls the rope by **0.1** in either direction, plot the ``||math:rounded||`` value of ``||variables:rope||`` to the nearest LED.
 
@@ -62,6 +62,7 @@ Because a button press pulls the rope by **0.1** in either direction, plot the `
 let rope = 2
 basic.forever(function() {
     basic.clearScreen()
+    // @highlight
     led.plot(Math.round(rope), 2)
 })
 ```


### PR DESCRIPTION
Turn on diffs for the 'spy' tutorials. Individual highlights are removed due to enabling of diffs.

Closes #3264 

**Comment**: This will now highlight the entire block of code in a later step when new code is shown that is separate from the rest of the project. Is that acceptable/desired too?

![image](https://user-images.githubusercontent.com/27789908/85173505-3d978e80-b228-11ea-8e44-083acfba5c61.png)
