### PR TITLE
Add a reference page for music.volume()

### DIFF
--- a/docs/reference/music.md
+++ b/docs/reference/music.md
@@ -3,22 +3,25 @@
 Generation of music tones through pin ``P0``.
 
 ```cards
-music.playTone(0, 0);
-music.ringTone(0);
-music.rest(0);
-music.startMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once);
-music.stopMelody(MelodyStopOptions.All);
-music.onEvent(MusicEvent.MelodyNotePlayed, () => {});
-music.beat(BeatFraction.Whole);
-music.tempo();
-music.changeTempoBy(20);
-music.setTempo(120);
+music.playTone(0, 0)
+music.ringTone(0)
+music.rest(0)
+music.startMelody(music.builtInMelody(Melodies.Entertainer), MelodyOptions.Once)
+music.stopMelody(MelodyStopOptions.All)
+music.onEvent(MusicEvent.MelodyNotePlayed, () => {})
+music.beat(BeatFraction.Whole)
+music.tempo()
+music.changeTempoBy(20)
+music.setTempo(120)
+music.setVolume(0)
+music.volume()
 ```
 
 ## See Also
 
-[playTone](/reference/music/play-tone), [ringTone](/reference/music/ring-tone), [rest](/reference/music/rest),
-[startMelody](/reference/music/start-melody), 
-[stopMelody](/reference/music/stop-melody),
-[onEvent](/reference/music/on-event),
-[beat](/reference/music/beat), [tempo](/reference/music/tempo), [changeTempoBy](/reference/music/change-tempo-by), [setTempo](/reference/music/set-tempo)
+[playTone](/reference/music/play-tone), [ringTone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [startMelody](/reference/music/start-melody),
+[stopMelody](/reference/music/stop-melody), [onEvent](/reference/music/on-event),
+[beat](/reference/music/beat), [tempo](/reference/music/tempo),
+[changeTempoBy](/reference/music/change-tempo-by), [setTempo](/reference/music/set-tempo),
+[setVolume](/reference/music/set-volume), [volume](/reference/music/volume)

--- a/docs/reference/music/set-volume.md
+++ b/docs/reference/music/set-volume.md
@@ -6,10 +6,13 @@ Set the volume for the sound synthesizer.
 music.setVolume(128)
 ```
 
-## #simnote
-#### ~hint
-**Simulator**: ``||music:set volume||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~hint
+
+#### Simulator
+
+``||music:set volume||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 
@@ -22,6 +25,10 @@ Set the synthesizer volume to something quieter.
 ```blocks
 music.setVolume(50)
 ```
+
+## See also
+
+[set volume](/reference/music/volume)
 
 ```package
 music

--- a/docs/reference/music/set-volume.md
+++ b/docs/reference/music/set-volume.md
@@ -28,7 +28,7 @@ music.setVolume(50)
 
 ## See also
 
-[set volume](/reference/music/volume)
+[volume](/reference/music/volume)
 
 ```package
 music

--- a/docs/reference/music/volume.md
+++ b/docs/reference/music/volume.md
@@ -1,0 +1,27 @@
+# volume
+
+Get the current volume level of the sound synthesizer.
+
+```sig
+music.volume()
+```
+
+### ~hint
+
+#### Simulator
+
+Using ``||music:volume||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
+
+## Returns
+
+* a [number](/types/number) that is the current volume level of output from the sound synthesizer. The value can be between `0` for silent and `255` for the loudest sound.
+
+## See also
+
+[set volume](/reference/music/set-volume)
+
+```package
+music
+```


### PR DESCRIPTION
A reference page for ``music.volume()``.

RE: #3298