### PR TITLE
Gallery page for blocks

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -374,4 +374,4 @@
     * [WebUSB](/device/usb/webusb)
         * [WebUSB Troubleshoot](/device/usb/webusb/troubleshoot)
     * [Flashing via HID (CMSIS-DAP)](/hidflash)
-
+* [Blocks Gallery](/block-gallery)

--- a/docs/block-gallery.md
+++ b/docs/block-gallery.md
@@ -1,0 +1,63 @@
+# Blocks Gallery
+
+Listing of the blocks and their images for @boardname@.
+
+## Basic
+
+```apis
+basic
+```
+
+## Input
+
+```apis
+input
+```
+
+## Music
+
+```apis
+music
+```
+
+## Led
+
+```apis
+led
+```
+
+## Radio
+
+```apis
+radio
+```
+
+## Game
+
+```apis
+game
+```
+
+## Images
+
+```apis
+images
+```
+
+## Pins
+
+```apis
+pins
+```
+
+## Serial
+
+```apis
+serial
+```
+
+## Control
+
+```apis
+control
+```


### PR DESCRIPTION
A page with API lists to show all the rendered blocks. 

**Note**: Image copy still requires screen caps or snippers. Also, built-ins don't render with this.

RE: https://github.com/microsoft/pxt-minecraft/issues/1902