### PR TITLE
Generalize 'MakeCode' instead of 'app' in UCP Science

### DIFF
--- a/docs/courses/ucp-science.md
+++ b/docs/courses/ucp-science.md
@@ -6,14 +6,6 @@ The **Science Experiments** lessons are geared for students in middle school and
  
 These lessons guide the student in hands-on, practical measurement activities along with using the micro:bit to control and record data for the experiments. Each lesson provides an overview of the activity, outlines expected results, explains the setup of the experiment, and the gives a coding activity to measure and collect the data.
 
-### ~hint
-
-**MakeCode app**
-
-To enable data collection in the experiments, the lessons require use of the **[Windows 10 MakeCode for micro:bit](https://www.microsoft.com/store/productId/9PJC7SV48LCX)** app instead of **[MakeCode](@homeurl@)** in the browser.
-
-### ~
-
 ## Lesson series
 
 ### ~hint

--- a/docs/courses/ucp-science/body-electrical/overview.md
+++ b/docs/courses/ucp-science/body-electrical/overview.md
@@ -16,7 +16,7 @@ Give students real world experience with coding, collecting data, analyzing data
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming (micro:bit using the Windows 10 MakeCode app) and download a program to a @boardname@.
+Students need to have a basic knowledge of how to code using block style programming and download a program to a @boardname@.
 
 ## Student Outcomes
 

--- a/docs/courses/ucp-science/body-electrical/setup-procedure.md
+++ b/docs/courses/ucp-science/body-electrical/setup-procedure.md
@@ -14,7 +14,7 @@
 
 ## Code and data collection
 
-This project will use to microbits to collect and record data using the MakeCode as described in the [Data Collection](/courses/ucp-science/data-collection/setup-procedure) lesson.
+This project will use to microbits to collect and record data using MakeCode as described in the [Data Collection](/courses/ucp-science/data-collection/setup-procedure) lesson.
 
 ## Option 2 — MakeCode and a USB connection
 

--- a/docs/courses/ucp-science/body-electrical/setup-procedure.md
+++ b/docs/courses/ucp-science/body-electrical/setup-procedure.md
@@ -14,15 +14,15 @@
 
 ## Code and data collection
 
-This project will use to microbits to collect and record data using the Windows 10 MakeCode app  as described in the [Data Collection](/courses/ucp-science/data-collection/setup-procedure) lesson.
+This project will use to microbits to collect and record data using the MakeCode as described in the [Data Collection](/courses/ucp-science/data-collection/setup-procedure) lesson.
 
-## Option 2 — Microbit Windows 10 MakeCode app and a USB connection
+## Option 2 — MakeCode and a USB connection
 
-The Windows 10 MakeCode app allows data to be directly read from the microbit when it is attached using USB cable. Data can be sent from the microbit to the Windows 10 MakeCode app  using serial data connection. The data collected over the serial connection can be graphed and the data can be downloaded. A limit of only about the last 20 seconds of data can be downloaded as a ``"data.csv"`` file. This allows the collection of data in real time. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique. 
+MakeCode allows data to be directly read from the microbit when it is attached using USB cable. Data can be sent from the microbit to the browser using serial data connection over WebUSB. The data collected over the serial connection can be graphed and the data can be downloaded. A limit of only about the last 20 seconds of data can be downloaded as a ``"data.csv"`` file. This allows the collection of data in real time. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique. 
 
 ### on Start event
 
-1. Code the first @boardname@ using Windows 10 MakeCode app for @boardname@.
+1. Code the first @boardname@ using MakeCode for @boardname@.
 2. Name the project, "Body Electricity Sender".
 3. The ``||basic:on start||`` event will display the title and function of the @boardname@ in all caps, ``"BODY ELECTRICAL"``.
 4. Set up a variable ``ekg`` or ``bodyElectricity`` and initialize its starting value to `0`.
@@ -30,7 +30,7 @@ The Windows 10 MakeCode app allows data to be directly read from the microbit wh
 ### forever event
 
 1. Set the ``ekg`` or ``bodyElectricity`` variable to get its value from the “analog read pin (0)”. This detects and electrical current that is sent through the body between the 2 taped wires connected to the body and the microbit. This is an analog reading that gets converted to a digital number between 0 - 1024.
-2. The next line uses a ``||basic:serial write value||`` (``"EKG"`` and the value stored in the ``ekg`` variable) to send the value back to the Windows 10 MakeCode app through the USB connection to the computer and @boardname@.
+2. The next line uses a ``||basic:serial write value||`` (``"EKG"`` and the value stored in the ``ekg`` variable) to send the value back to MakeCode through the USB connection to the computer and @boardname@.
 
 ```blocks 
 // Body Electricity
@@ -64,7 +64,7 @@ Do some more meaurements:
 
 Two @boardname@s can be used to collect and record data using the radio commands. One @boardname@ can be setup remotely and the other @boardname@ can be used to observe the data. The first @boardname@ can send the data it observes to the second @boardname@ for the observer to record. To set up 2 @boardname@s so they can communicate over the radio they need to be on the same radio group. For additional information look at the [Data Collection](/courses/ucp-science/data-collection/setup-procedure) lesson.
 
-By using 2 @boardname@ to collect the data on one and send it to the second @boardname@ which is connect to the Windows 10 MakeCode app using a USB cable the experiment can collect and record data remotely. This would allow the collection of body electrical data while a person is exercising or moving.
+By using 2 @boardname@ to collect the data on one and send it to the second @boardname@ which is connected to MakeCode using a USB cable, the experiment can collect and record data remotely. This would allow the collection of body electrical data while a person is exercising or moving.
 
 ### micro:bit radio sending code
 
@@ -89,7 +89,7 @@ basic.forever(() => {
 
 This receiver @boardname@ uses the “on start” event to set up the title on the @boardname@ when started, the radio group, and the ``bodyElectricity`` variable to collect and store the data received.
 
-The ``||radio:on received number||`` event reads the number value sent from the sending @boardname@. The number is then stored in the ``bodyElectricity`` variable. the electricity on pin **0** and stores it in the variable ``bodyElectricity``. The last line uses the serial write command to send the text `"Body Electricity"` label and the value of ``bodyElectricity`` variable back to the Windows 10 MakeCode app. The data is sampled and send from 10 to 20 times per second.
+The ``||radio:on received number||`` event reads the number value sent from the sending @boardname@. The number is then stored in the ``bodyElectricity`` variable. the electricity on pin **0** and stores it in the variable ``bodyElectricity``. The last line uses the serial write command to send the text `"Body Electricity"` label and the value of ``bodyElectricity`` variable back to MakeCode. The data is sampled and send from 10 to 20 times per second.
  
 ```blocks
 // Body Electricity Receiver

--- a/docs/courses/ucp-science/data-collection/overview.md
+++ b/docs/courses/ucp-science/data-collection/overview.md
@@ -50,7 +50,6 @@ Students will:
 ## Materials Needed
 
 * A @boardname@ with a longer USB cable
-* [Windows 10 MakeCode for micro:bit app](https://www.microsoft.com/store/productId/9PJC7SV48LCX)
 * 2 @boardname@s with batteries connected
 * A longer USB @boardname@ cable
 * Spreadsheet program for data analysis

--- a/docs/courses/ucp-science/data-collection/setup-procedure.md
+++ b/docs/courses/ucp-science/data-collection/setup-procedure.md
@@ -2,7 +2,7 @@
 
 ## micro:bit setup and coding concepts
 
-This document describes different methods using micro:bits to collect and record data for science experiments. There are several ways to collect data from an experiment. The simplest is having the data display on the LED screen and manually record the data on a paper. Data can also be collected using the Window’s 10 MakeCode app. The third way is using 2 micro:bits with one observing the data and then radioing the results to a second micro:bit so it can allow the remote collection of data.
+This document describes different methods using micro:bits to collect and record data for science experiments. There are several ways to collect data from an experiment. The simplest is having the data display on the LED screen and manually record the data on a paper. Data can also be collected using MakeCode. The third way is using 2 micro:bits with one observing the data and then radioing the results to a second micro:bit so it can allow the remote collection of data.
 
 ### ~ hint
 
@@ -33,15 +33,12 @@ led.plotBarGraph(
     input.temperature(), 0
     )
 ```
+### Option 2 - MakeCode and a USB connection
 
-### Option 2 - micro:bit Windows 10 MakeCode app and a USB connection
+MakeCode allows data to be directly read from the micro:bit when it is attached using USB cable. Data can be sent from the micro:bit to the browser using serial data connection over WebUSB. The data collected over the serial connection can be graphed and the data can be downloaded. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique.
 
-The Windows 10 MakeCode app allows data to be directly read from the micro:bit when it is attached using USB cable. Data can be sent from the micro:bit to the Windows 10 MakeCode app  using serial data connection. The data collected over the serial connection can be graphed and the data can be downloaded. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique. 
-
-You can download the [Windows 10 MakeCode](https://www.microsoft.com/store/apps/9PJC7SV48LCX) app.
-
-With the program downloaded from the MakeCode app to the micro:bit and the USB cable left connected, the
-``||led:plot bar graph||`` will automatically upload the data to the app.
+With the program downloaded from MakeCode to the micro:bit and the USB cable left connected, the
+``||led:plot bar graph||`` will automatically upload the data to MakeCode.
 
 ```blocks
 led.plotBarGraph(
@@ -102,7 +99,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 ### Radio receiver code with serial write
 
-This code is the same as above but one additional line of code is added to write to the word `"Celisus"` and the temperature to the MakeCode app to the USB serial connection. This is the same as described peviously in [Option 2](#option-2-micro-bit-windows-10-makecode-app-and-a-usb-connection).
+This code is the same as above but one additional line of code is added to write to the word `"Celisus"` and the temperature to MakeCode to the USB serial connection. This is the same as described peviously in [Option 2](#option-2-makecode-and-a-usb-connection).
 
 
 ```blocks
@@ -144,7 +141,7 @@ basic.forever(() => {
 
 ### "Receiver" micro:bit code
 
-Using the Windows 10 MakeCode app, setup and code the second micro:bit. This micro:bit will remain connected to the computer through the USB cable and the Windows 10 MakeCode app to monitor the data being received.
+Using the MakeCode, setup and code the second micro:bit. This micro:bit will remain connected to the computer through the USB cable to MakeCode and monitor the data being received.
 
 Name the project, "Gravity Receiver". The ``||basic:on start||`` event will display the title and function of the micro:bit in all caps, `"GRAVITY RECEIVER"`. Add comments to the ``||basic:on start||`` event like before: Name the project, creator, and date created. Set up a radio group using the ``||radio:radio set group||`` block. Both micro:bits need the same radio group.
 
@@ -155,7 +152,7 @@ radio.setGroup(99)
 
 The ``||radio:on received number||`` event will constantly monitor radio signals from the radio group.
 When a value is received from the group it is stored in the ``gravity`` variable.
-The ``||serial:serial write value||`` sends 2 pieces of data back to the MakeCode app through the USB cable. First it sends a label `"gravity"` and then the value received as gravity from the ``||input:acceleration||`` method from the first micro:bit.
+The ``||serial:serial write value||`` sends 2 pieces of data back to MakeCode through the USB cable. First it sends a label `"gravity"` and then the value received as gravity from the ``||input:acceleration||`` method from the first micro:bit.
 
 ```blocks
 basic.showString("GRAVITY RECEIVER")
@@ -167,7 +164,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 ### Monitoring, downloading, and analyzing the data
 
-With the micro:bit code downloaded from the MakeCode app to the micro:bit and the USB cable connected it will start receiving data from the first micro:bit. Under the simulator in the app a purple outlined button shows up **Show data Device**.
+With the micro:bit code downloaded from MakeCode to the micro:bit and the USB cable connected it will start receiving data from the first micro:bit. Under the simulator in the MakeCode a purple outlined button shows up **Show data Device**.
 
 ![Show data device button](/static/courses/ucp-science/data-collection/show-data-device.jpg)
 

--- a/docs/courses/ucp-science/electricity/overview.md
+++ b/docs/courses/ucp-science/electricity/overview.md
@@ -15,7 +15,7 @@ Give students real world experience with coding, collecting data, analyzing data
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming (micro:bit using the Windows 10 MakeCode app) and download a program to a @boardname@.
+Students need to have a basic knowledge of how to code using block style programming and download a program to a @boardname@.
 
 ## Student Outcomes
 

--- a/docs/courses/ucp-science/gravity/overview.md
+++ b/docs/courses/ucp-science/gravity/overview.md
@@ -18,7 +18,7 @@ Give students real world experience with coding, collecting data, analyzing data
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming (@boardname@ using the [Windows 10 MakeCode app](https://www.microsoft.com/store/productId/9PJC7SV48LCX)) and download a program to a @boardname@.
+Students need to have a basic knowledge of how to code using block style programming and download a program to a @boardname@ using MakeCode.
 
 ## Student Outcomes
 
@@ -36,7 +36,6 @@ Students will:
 ![Two micro:bit showing 0 and 6](/static/courses/ucp-science/gravity/06.png)
 
 * A longer USB @boardname@ cable
-* [MakeCode for micro:bit Windows App](https://www.microsoft.com/store/productId/9PJC7SV48LCX)
 * Spreadsheet for data analysis
 * Padding for one @boardname@ for gravity testing
 

--- a/docs/courses/ucp-science/gravity/setup-procedure.md
+++ b/docs/courses/ucp-science/gravity/setup-procedure.md
@@ -9,7 +9,7 @@
 
 ## Code
 
-This project will use to @boardname@s to collect and record data using the Windows 10 MakeCode app as described in [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure).
+This project will use to @boardname@s to collect and record data using MakeCode as described in [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure).
 
 ### Sender @boardname@ code
 
@@ -39,8 +39,8 @@ basic.forever(() => {
 
 ### Receiver @boardname@ code
 
-1. Using the [Windows 10 MakeCode app](https://www.microsoft.com/store/productId/9PJC7SV48LCX) setup and code the second @boardname@.
-2. This @boardname@ will remain connected to the computer through the USB cable and the Windows 10 MakeCode app to monitor the data being received.
+1. Using MakeCode setup and code the second @boardname@.
+2. This @boardname@ will remain connected to the computer through the USB cable and MakeCode to monitor the data being received.
 3. Name the project, “Gravity Receiver”.
 4. The ``||basic:on start||`` event will display the title and function of the @boardname@ in all caps, `"GRAVITY RECEIVER"`.
 6. Set up a radio group using the ``||radio:radio set group||``. Both @boardname@s need the same radio group.
@@ -54,7 +54,7 @@ radio.setGroup(99)
 
 7. The ``||radio:on received number||`` event will constantly monitor radio signals from the radio group.
 8. When a value is received from the group it is stored in the ``gravity`` variable.
-9. The ``||serial:serial write Value||`` sends 2 pieces of data back to the MakeCode app through the USB cable. First it sends a label `"gravity"` and then the value received as gravity from the acceleration method from the first @boardname@. 
+9. The ``||serial:serial write Value||`` sends 2 pieces of data back to MakeCode through the USB cable. First it sends a label `"gravity"` and then the value received as gravity from the acceleration method from the first @boardname@. 
 10. Add a ``||led:toggle||`` to indicate that it's receiving data. Change ``x`` to `1` so that another LED blinks.
 
 ```blocks
@@ -68,8 +68,8 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 ## Monitoring the data
 
-1. With the @boardname@ code downloaded from the MakeCode app to the @boardname@ and the USB cable connected it will start receiving data from the first @boardname@.
-2. Under the simulator in the app a purple outlined button shows up “Show data Device”.
+1. With the @boardname@ code downloaded from MakeCode to the @boardname@ and the USB cable connected it will start receiving data from the first @boardname@.
+2. Under the simulator in MakeCode a purple outlined button shows up "Show data Device".
  
 3. By clicking on the **Show data Device** button a window opens up to the right showing values and graph of the gravity data being received (the dips in the graph are 3 tosses of the @boardname@ in the air).
  
@@ -85,7 +85,7 @@ Additional analysis and graphing can be done in a spreadsheet.
 
 ## Data Collection
 
-There are several ways to collect data from an experiment. The simplest is having the data display on the LED screen and manually record the data on a paper. Data can also be collected using the Window’s 10 MakeCode app. The third way is using 2 @boardname@s with one observing the data and then radioing the results to a second @boardname@ can allow the remote collection of data. 
+There are several ways to collect data from an experiment. The simplest is having the data display on the LED screen and manually record the data on a paper. Data can also be collected using MakeCode. The third way is using 2 @boardname@s with one observing the data and then radioing the results to a second @boardname@ can allow the remote collection of data. 
 
 For additional information on data collection, see the [Data Collection](/courses/ucp-science/data-collection) lesson.
 
@@ -93,13 +93,13 @@ For additional information on data collection, see the [Data Collection](/course
 
 ### Sound Wave Sensor
 
-Sound causes vibrations which can be detected with the Microbit accelerator. Connect 2 @boardname@s using radio signals (see [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure)). The “Gravity Sender” @boardname@ can be placed on or near a speaker. It will send a signal to the “Gravity Receiver” @boardname@ which can be connected to the Windows 10 MakeCode app. When the “Gravity Receiver” @boardname@ receives a gravity number it is sent to the monitoring data collection using the method ``serial.writeValue("gravity", gravity)``. The sound can be observed in the **Show data Device**. 
+Sound causes vibrations which can be detected with the Microbit accelerator. Connect 2 @boardname@s using radio signals (see [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure)). The “Gravity Sender” @boardname@ can be placed on or near a speaker. It will send a signal to the “Gravity Receiver” @boardname@ which can be connected to MakeCode. When the “Gravity Receiver” @boardname@ receives a gravity number it is sent to the monitoring data collection using the method ``serial.writeValue("gravity", gravity)``. The sound can be observed in the **Show data Device**. 
 
 ![Sound vibrations](/static/courses/ucp-science/gravity/soundvibrations.png)
 
 ### Earthquake Detector
 
-Earthquakes cause vibrations which can be detected with the Microbit accelerator. By placing the "Gravity Sender" @boardname@ on a flat surface and having it “feel” minor changes in acceleration it can detect earthquakes or other vibrations in the earth. Connect 2 @boardname@s using radio signals (see [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure)). The “Gravity Sender” @boardname@ can be placed on or near a speaker. It will send a signal to the “Gravity Receiver” @boardname@ which can be connected to the Windows 10 MakeCode app. When the “Gravity Receiver” @boardname@ receives a gravity number it is sent to the monitoring data collection using the method ``serial.writeValue("gravity", gravity)``. The movement of the object connected to the Earth can be observed in the **Show data Device**. Using a conditional statement that detects changes in the received gravity could be implemented to play “music” sound as an alarm when changes in movement are detected.
+Earthquakes cause vibrations which can be detected with the Microbit accelerator. By placing the "Gravity Sender" @boardname@ on a flat surface and having it “feel” minor changes in acceleration it can detect earthquakes or other vibrations in the earth. Connect 2 @boardname@s using radio signals (see [Data Collection - Option 3](/courses/ucp-science/data-collection/setup-procedure)). The “Gravity Sender” @boardname@ can be placed on or near a speaker. It will send a signal to the “Gravity Receiver” @boardname@ which can be connected to MakeCode. When the “Gravity Receiver” @boardname@ receives a gravity number it is sent to the monitoring data collection using the method ``serial.writeValue("gravity", gravity)``. The movement of the object connected to the Earth can be observed in the **Show data Device**. Using a conditional statement that detects changes in the received gravity could be implemented to play “music” sound as an alarm when changes in movement are detected.
 
 ![Earthquake vibrations](/static/courses/ucp-science/gravity/earthquake.png)
 

--- a/docs/courses/ucp-science/rocket-acceleration/overview.md
+++ b/docs/courses/ucp-science/rocket-acceleration/overview.md
@@ -20,7 +20,7 @@ Give students real world experience with coding, collecting data, analyzing data
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming (@boardname@ using the Windows 10 MakeCode app) and download a program to a @boardname@.
+Students need to have a basic knowledge of how to code using block style programming and download a program to a @boardname@.
 
 ## Student Outcomes
 

--- a/docs/courses/ucp-science/rocket-acceleration/setup-procedure.md
+++ b/docs/courses/ucp-science/rocket-acceleration/setup-procedure.md
@@ -3,7 +3,7 @@
 ## Setup
 
 1. Plan and design the experiments.
-2. Use the radio and the [MakeCode app][makecode-app] for the data collection method. 
+2. Use the radio and MakeCode for the data collection method. 
 3. Plan and design data collection documents.
 4. Program the @boardname@s.
 5. Experiment with different data collection scenarios.
@@ -11,17 +11,17 @@
 
 ## Code and Data Collection
 
-This project will explore 2 different methods of data collection. The first uses a single @boardname@ with the [Windows 10 MakeCode app][makecode-app] to record the data over a serial connection. The second uses the radio on the @boardname@ in the nose cone to transmit the acceleration values back to another @boardname@ connected to the computer to collect and record data using the Windows 10 MakeCode app.
+This project will explore 2 different methods of data collection. The first uses a single @boardname@ with MakeCode to record the data over a serial connection. The second uses the radio on the @boardname@ in the nose cone to transmit the acceleration values back to another @boardname@ connected to the computer to collect and record data using MakeCode.
 
-### Option 1: Windows 10 MakeCode app and a USB connection
+### Option 1: MakeCode and a USB connection
 
-The [Windows 10 MakeCode app][makecode-app] allows data to be directly read from the @boardname@ when it is attached using USB cable. Data can be sent from the @boardname@ to the Windows 10 MakeCode app using a serial data connection. The data collected over the serial connection can be graphed and the data can be downloaded. The data can be downloaded as a _data.csv_ file. This allows the collection of data in real time. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique.
+MakeCode allows data to be directly read from the @boardname@ when it is attached using USB cable. Data can be sent from the @boardname@ to the browser using a serial data connection. The data collected over the serial connection can be graphed and the data can be downloaded. The data can be downloaded as a _data.csv_ file. This allows the collection of data in real time. This file can be opened in a spreadsheet for further analysis. Many different kinds of experiments can be performed using this data logging technique.
 
 ### Option 2: Remote collecting unit sending to receiving unit over radio
 
 Two @boardname@s can be used to collect and record data using the radio commands. One @boardname@ can be setup remotely and the other @boardname@ can be used to observe the data. The first @boardname@ can send the data it observes to the second @boardname@ for the observer to record. Setup 2 @boardname@s so they can communicate over the radio they need to be on the same radio group. For additional information see the [Data Collection](/courses/ucp-science/data-collection) lesson.
 
-Use 2 @boardname@s to collect the data on one and send it to another that is connect to the Windows 10 MakeCode app using a USB cable the experiment to collect and record data remotely. This allows the collection of acceleration data at a distance.
+Use 2 @boardname@s to collect the data on one and send it to another that is connect to MakeCode using a USB cable the experiment to collect and record data remotely. This allows the collection of acceleration data at a distance.
 
 ## Coding the Radios Method
 
@@ -29,7 +29,7 @@ Use 2 @boardname@s to collect the data on one and send it to another that is con
 
 The sender @boardname@ uses the ``||basic:on start||`` event to set up the title on the  @boardname@ when started and the radio group.
 
-1. Code the first @boardname@ using Windows 10 MakeCode app.
+1. Code the first @boardname@ using MakeCode.
 2. Name the project, “Rocket Launch Sender”.
 3. The ``||basic:on start||`` event will display the title and function of the @boardname@ in all caps, “ACCEL Z”.
 4. Add comments to the ``||basic:on start||`` event: name of the project, creator, and date created.
@@ -58,12 +58,12 @@ basic.forever(() => {
 
 This receiver @boardname@ uses the ``||basic:on start||`` event to set up the title on the  @boardname@ when started, the radio group.
 
-1. Code the first @boardname@ using Windows 10 MakeCode app for  @boardname@s.
+1. Code the first @boardname@ using MakeCode for @boardname@s.
 2. Name the project, "Rocket Launch Receiver".
 3. The ``||basic:on start||`` event will display the title and function of the  @boardname@ in all caps, "ACCEL Z RECEIVER".
 4. Add comments to the ``||basic:on start||`` event: Name the project, creator, and date created.
 5. Set up a radio group by giving it a number or channel to work on. (Group 10 is used in this example.)
-6. A ``||serial:serial write line||`` is used to send the text ``"Acceleration"``. This opens up the serial port in the Windows 10 MakeCode app so the purple **Show Data Device** button shows up below the simulator in the MakeCode app. Clicking this button allows the observation and downloading of the collected data.
+6. A ``||serial:serial write line||`` is used to send the text ``"Acceleration"``. This opens up the serial port in MakeCode so the purple **Show Data Device** button shows up below the simulator in MakeCode. Clicking this button allows the observation and downloading of the collected data.
 
 ```blocks
 basic.showString("ACCEL Z RECEIVER")
@@ -71,7 +71,7 @@ radio.setGroup(10)
 serial.writeLine("Acceleration")
 ```
 
-The ``||radio:on received number||`` event reads the number value from the sending @boardname@. The number is then stored in the variable ``receivedNumber``. The last line uses the serial write command to send the text ``"z"`` label and the value of ``receivedNumber`` variable back to the Windows 10 MakeCode app. The data is sampled and send from 10 to 20 times per second.
+The ``||radio:on received number||`` event reads the number value from the sending @boardname@. The number is then stored in the variable ``receivedNumber``. The last line uses the serial write command to send the text ``"z"`` label and the value of ``receivedNumber`` variable back to MakeCode. The data is sampled and send from 10 to 20 times per second.
 
 ```blocks
 // onRadio receive & write z value to serial
@@ -82,7 +82,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 ## Data Analysis
 
-Sample Graphed data in the Windows MakeCode app:
+Sample Graphed data in MakeCode:
 
 ![Graphed data in data viewer](/static/courses/ucp-science/rocket-acceleration/graphed-data.jpg)
 
@@ -124,5 +124,3 @@ radio
 | | | |
 |-|-|-|
 | Adapted from "[Rocket Acceleration z Radios](https://drive.google.com/open?id=1IyhCPdYQevKh3kHNgukSxlgdvZIKuzmIBjLSRnFS36o)" by [C Lyman](http://utahcoding.org) | | [![CC BY-NC-SA](https://licensebuttons.net/l/by-nc-sa/4.0/80x15.png)](https://creativecommons.org/licenses/by-nc-sa/4.0/) |
-
-[makecode-app]: https://www.microsoft.com/store/productId/9PJC7SV48LCX

--- a/docs/courses/ucp-science/soil-moisture/overview.md
+++ b/docs/courses/ucp-science/soil-moisture/overview.md
@@ -14,7 +14,7 @@ Give students real world experience with coding, collecting data, analyzing data
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming (micro:bit using the Windows 10 MakeCode app) and download a program to a micro:bit.
+Students need to have a basic knowledge of how to code using block style programming and download a program to a micro:bit using MakeCode.
 
 ## Student Outcomes
 

--- a/docs/courses/ucp-science/temperature/overview.md
+++ b/docs/courses/ucp-science/temperature/overview.md
@@ -26,7 +26,7 @@ Give students real world experience with coding, collecting temperature data, an
 
 ## Prior Knowledge
 
-Students need to have a basic knowledge of how to code using block style programming ([Microbit using the Windows 10 MakeCode app](https://www.microsoft.com/store/productId/9PJC7SV48LCX))) and download a program to a microbit. 
+Students need to have a basic knowledge of how to code using block style programming and download a program to a micro:bit using MakeCode. 
 
 ## Student Outcomes
 
@@ -41,7 +41,6 @@ Students will:
 
 * 2 microbits with batteries connected
 * A longer USB microbit cable
-* [MakeCode for @boardname@ Windows 10 app](https://www.microsoft.com/store/productId/9PJC7SV48LCX))
 * Spreadsheet for data analysis and a word processor for reporting the findings
 
 <br/>

--- a/docs/courses/ucp-science/temperature/setup-procedure.md
+++ b/docs/courses/ucp-science/temperature/setup-procedure.md
@@ -65,13 +65,11 @@ basic.forever(() => {
 
 **Variation:** Instead of using a ``||basic:forever||`` loop, the **A** and **B** buttons could be programmed to display the temperature in either Celsius or Fahrenheit.
 
-### Temperature project 2 - @boardname@ Windows 10 MakeCode app and a USB connection
+### Temperature project 2 - MakeCode and a USB connection
 
-The Windows 10 MakeCode app allows data to directly read serial data from your @boardname@ for data logging and other fun experiments. This allow the collection of data in real time which can be downloaded in a CSV file for additional analysis in a spreadsheet.
+MakeCode allows data to directly read serial data from your @boardname@ for data logging and other fun experiments. This allow the collection of data in real time which can be downloaded in a CSV file for additional analysis in a spreadsheet.
 
-**Get the app:** The Windows 10 MakeCode app can be downloaded here: https://www.microsoft.com/store/apps/9PJC7SV48LCX 
-
-With the program downloaded from the MakeCode app to the @boardname@ and the USB cable left connected and using the ``||serial:serial write value||`` block from the ``|serial:Serial||`` toolbox in the **Advanced** tool section.
+With the program downloaded from MakeCode to the @boardname@ and the USB cable left connected and using the ``||serial:serial write value||`` block from the ``|serial:Serial||`` toolbox in the **Advanced** tool section.
 
 ```blocks
 basic.forever(() => {

--- a/docs/device/data-analysis/remote.md
+++ b/docs/device/data-analysis/remote.md
@@ -6,7 +6,8 @@ If you have more than one @boardname@ you can setup one of them to receive data 
 
 ## Receiver @boardname@
 
-Connect the @boardname@ to a computer with a USB cable. The data received over radio is sent to the computer with this connection using writes to the serial port. If you have the [Windows 10 MakeCode](https://www.microsoft.com/store/apps/9PJC7SV48LCX) app, you can view the received data with the [Data Viewer](./viewing) in the editor. Otherwise, you need a _serial terminal_ app or some other program that can read from the computer's serial port.
+Connect the @boardname@ to a computer with a USB cable. The data received over radio is sent to the computer with this connection using writes to the serial port.
+You can view the received data with the [Data Viewer](./viewing) in the MakeCode editor (you can also receive and view data with the [Windows 10 MakeCode](https://www.microsoft.com/store/apps/9PJC7SV48LCX) app). Otherwise, you need a _serial terminal_ app or some other program that can read from the computer's serial port.
 
 The receiving @boardname@ sets a radio group number on which to listen for incoming messages.
 


### PR DESCRIPTION
De-emphasizing the use of "Windows 10 MakeCode app" to just "MakeCode" in the UCP Science lessons. Since WebUSB is in place, the use of the app is no longer required. The app is left as an option in the setup pages where it is mentioned.

Closes #3388