### PR TITLE
Adding interval to show image block

### DIFF
--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -83,9 +83,11 @@ void plotImage(Image i, int xOffset = 0) {
 /**
  * Shows an frame from the image at offset ``x offset``.
  * @param xOffset column index to start displaying the image
+ * @param interval time in milliseconds to pause after drawing
  */
 //% help=images/show-image weight=80 blockNamespace=images
-//% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset"
+//% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset ||and interval (ms) %interval"
+//% interval.defl=400
 //% blockGap=8 parts="ledmatrix" async
 void showImage(Image sprite, int xOffset, int interval = 400) {
     uBit.display.print(MicroBitImage(sprite->img), -xOffset, 0, 0, interval);

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -37,9 +37,11 @@ declare interface Image {
     /**
      * Shows an frame from the image at offset ``x offset``.
      * @param xOffset column index to start displaying the image
+     * @param interval time in milliseconds to pause after drawing
      */
     //% help=images/show-image weight=80 blockNamespace=images
-    //% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset"
+    //% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset ||and interval (ms) %interval"
+    //%
     //% blockGap=8 parts="ledmatrix" async interval.defl=400 shim=ImageMethods::showImage
     showImage(xOffset: int32, interval?: int32): void;
 


### PR DESCRIPTION
Adds optional interval to show image block. This parameter was already present in text and default value was 400ms.

![imageinterval](https://user-images.githubusercontent.com/6107272/95803584-59caaa00-0cb5-11eb-920c-35f3336574f0.gif)
