### PR TITLE
fill in trademarks section for electron app

### DIFF
--- a/docfiles/offline-app-trademarks.html
+++ b/docfiles/offline-app-trademarks.html
@@ -1,0 +1,2 @@
+Micro:bit and micro:bit logo are trademarks and/ or copyrights of the Micro:bit
+Educational Foundation. &copy; Micro:bit Educational Foundation. All rights reserved.


### PR DESCRIPTION
Had this sitting around on my laptop. The new format / this file won't be used until next release (unless we wanna port it). This is the copyright info that gets added into the built page from https://github.com/microsoft/pxt/pull/7398