### PR TITLE
Redo section in 'Remote' page of 'Data Anaylsis'

### DIFF
--- a/docs/device/data-analysis.md
+++ b/docs/device/data-analysis.md
@@ -8,9 +8,9 @@ The Data Viewer in the MakeCode editor allows you to stream and log data from yo
 
 These topics describe how to analyze your data using MakeCode with the @boardname@:
 
-* [Plotting with LEDs](./data-analysis/led-plotting)
-* [Viewing your data](./data-analysis/viewing)
-* [Writing data](./data-analysis/writing)
-* [Generating data](./data-analysis/generating)
-* [Analyze](./data-analysis/analyze)
-* [Remote data collection](./data-analysis/remote)
+* [Plotting with LEDs](/device/data-analysis/led-plotting)
+* [Viewing your data](/device/data-analysis/viewing)
+* [Writing data](/device/data-analysis/writing)
+* [Generating data](/device/data-analysis/generating)
+* [Analyze](/device/data-analysis/analyze)
+* [Remote data collection](/device/data-analysis/remote)

--- a/docs/device/data-analysis/remote.md
+++ b/docs/device/data-analysis/remote.md
@@ -126,22 +126,37 @@ The serial number, ``id``, is used as a _prefix_ for the ``name`` to identify wh
 
 ### Extended data recording
 
-If you're recording data to save on a computer for analysis or other uses outside of the MakeCode editor, you can use the ``||radio:radio write received packet to serial||`` block to format it for you. This function will format the data from the received packet into a [JSON](https://en.wikipedia.org/wiki/JSON) string and write it to the serial port, all in one operation. It's used just like this:
+If you're recording data to save on a computer for analysis or other uses outside of the MakeCode editor, you can create your own custom recording data format to log reported data. One way to do this is by forming a [JSON](https://en.wikipedia.org/wiki/JSON) string with the information related to the data *sample*.
+
+### ~ hint
+
+#### Data samples
+
+A data sample is a snapshot of some input value at a particular moment in time. A sample usually contains several pieces of information such as the value recorded, the time it was recorded, and a name to identify what the value is for.
+
+### ~
+
+As an example, if you know that the remote station is sending you a name-value pair for temperature data, you can report that data in a JSON string like this:
 
 ```blocks
-radio.onReceivedNumber(function (receivedNumber) {
-    radio.writeReceivedPacketToSerial();
-});
+radio.onReceivedValue(function (name, value) {
+    serial.writeString("{")
+    serial.writeString("\"t\":" + radio.receivedPacket(RadioPacketProperty.Time) + ",")
+    serial.writeString("\"s\":" + radio.receivedPacket(RadioPacketProperty.SerialNumber) + ",")
+    serial.writeString("\"n\":\"" + name + "\",")
+    serial.writeString("\"v\":" + value)
+    serial.writeLine("}")
+})
 ```
 
-The output to the serial port is a line of text with these name value pairs:
+The output to the serial port is a line of text with these name-value pairs:
 
 * **t** - time: the time when the packet was sent
 * **s** - serial: the serial number of the board that sent the packet (if enabled)
-* **n** - name: the name for the data value from the string part of the packet
-* **v** - value: the data from the number part of the packet
+* **n** - name: the name for the data value sent in the packet
+* **v** - value: the data value for the number sent in the packet
 
-It's sent in this format to the serial port:
+The JSON formatted in the received event is sent in this format to the serial port:
 
 ```json
 {"t":3504,"s":1951284846,"n":"temperature","v":19} 
@@ -154,8 +169,7 @@ It's sent in this format to the serial port:
 
 ## See also
 
-[radio](/reference/radio), [serial write value](/reference/serial/write-value),
-[write received packet to serial](/reference/radio/write-received-packet-to-serial)
+[radio](/reference/radio), [serial write value](/reference/serial/write-value)
 
 ```package
 radio

--- a/docs/reference/radio.md
+++ b/docs/reference/radio.md
@@ -16,7 +16,6 @@ radio.setGroup(0);
 ## Advanced
 
 ```cards
-radio.writeReceivedPacketToSerial();
 radio.setTransmitPower(7);
 radio.setTransmitSerialNumber(false);
 radio.raiseEvent(0, 0);
@@ -38,5 +37,4 @@ radio
 [set group](/reference/radio/set-group),
 [set transmit power](/reference/radio/set-transmit-power),
 [set transmit serial number](/reference/radio/set-transmit-serial-number),
-[write received packet to serial](/reference/radio/write-received-packet-to-serial),
 [raise event](/reference/radio/raise-event)

--- a/docs/reference/radio/write-received-packet-to-serial.md
+++ b/docs/reference/radio/write-received-packet-to-serial.md
@@ -9,6 +9,14 @@ radio.writeReceivedPacketToSerial();
 This should be called within a callback to
 [on data packet received](/reference/radio/on-data-packet-received).
 
+### ~ hint
+
+#### Deprecated
+
+This API has been deprecated! Use [serial write value](/reference/serial/write-value) instead.
+
+### ~
+
 ## Data received format
 
 The format for received data when these send functions are used:
@@ -18,6 +26,8 @@ The format for received data when these send functions are used:
 - [send string](/reference/radio/send-string): ```{t:MicrobitTimeAlive,s:SerialNumber,n:"Text"}```
 
 ### ~hint
+
+#### Default serial number
 
 The serial number value sent in the packet is set to `0` unless transmission of the serial number is enabled with ``||radio:radio set transmit serial number||``.
 


### PR DESCRIPTION
The example shown in the "Exteneded data recording" section of the "Remote" page uses the deprecated `radio.writeReceivedPacketToSerial()`. Redo the section to provide an alternate solution.

- [x] Switch from relative to full paths for [Data Analysis](https://makecode.microbit.org/device/data-analysis) links
- [x] Redo the "Extended Data Recording" section in [remote](https://makecode.microbit.org/device/data-analysis/remote) page to update for deprecated `radio.writeReceivedPacketToSerial()`
- [x] Remove `radio.writeReceivedPacketToSerial()` from Radio card page
- [x] Add deprecated note to the reference page for `radio.writeReceivedPacketToSerial()`

Closes #3452