### PR TITLE
Bring in settings package from pxt-common-pkgs

### DIFF
--- a/libs/settings/_locales/settings-jsdoc-strings.json
+++ b/libs/settings/_locales/settings-jsdoc-strings.json
@@ -1,0 +1,16 @@
+{
+  "settings.clear": "Delete all non-system settings.",
+  "settings.deviceSecrets": "Secrets shared by any program on the device",
+  "settings.exists": "Check if a named setting exists.",
+  "settings.list": "Return a list of settings starting with a given prefix.",
+  "settings.programSecrets": "Program secrets",
+  "settings.readBuffer": "Read named setting as a buffer. Returns undefined when setting not found.",
+  "settings.readNumber": "Read named setting as a number.",
+  "settings.readNumberArray": "Read named setting as a number.",
+  "settings.readString": "Read named setting as a string.",
+  "settings.remove": "Remove named setting.",
+  "settings.writeBuffer": "Set named setting to a given buffer.",
+  "settings.writeNumber": "Set named settings to a given number.",
+  "settings.writeNumberArray": "Set named settings to a given array of numbers.",
+  "settings.writeString": "Set named settings to a given string."
+}

--- a/libs/settings/_locales/settings-strings.json
+++ b/libs/settings/_locales/settings-strings.json
@@ -1,0 +1,6 @@
+{
+  "settings.deviceSecrets|block": "device secrets",
+  "settings.programSecrets|block": "program secrets",
+  "settings|block": "settings",
+  "{id:category}Settings": "Settings"
+}

--- a/libs/settings/pxt.json
+++ b/libs/settings/pxt.json
@@ -1,0 +1,7 @@
+{
+    "hidden": true,
+    "disablesVariants": [
+        "mbdal"
+    ],
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/settings"
+}

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -12,7 +12,8 @@
         "libs/bluetooth",
         "libs/servo",
         "libs/radio-broadcast",
-        "libs/microphone"
+        "libs/microphone",
+        "libs/settings"
     ],
     "cloud": {
         "workspace": false,


### PR DESCRIPTION
Package is hidden and v2 only. It's required by jacdac.

In future we may want to back up the settings in the I2C flash on the KL27, as they now do not survive flashing.