### PR TITLE
Logo touch ref

### DIFF
--- a/docs/reference/input.md
+++ b/docs/reference/input.md
@@ -3,31 +3,36 @@
 Events and data from sensors
 
 ```cards
-input.onButtonPressed(Button.A, () => {
-    
-});
-input.onGesture(Gesture.Shake, () => {
-    
-});
-input.onPinPressed(TouchPin.P0, () => {
-    
-});
-input.buttonIsPressed(Button.A);
-input.isGesture(Gesture.Shake);
-input.compassHeading();
-input.pinIsPressed(TouchPin.P0);
-input.temperature();
-input.acceleration(Dimension.X);
-input.lightLevel();
-input.rotation(Rotation.Pitch);
-input.magneticForce(Dimension.X);
-input.runningTime();
-input.runningTimeMicros();
-input.setAccelerometerRange(AcceleratorRange.OneG);
+input.onButtonPressed(Button.A, function () {})
+input.onGesture(Gesture.Shake, function () {})
+input.onPinPressed(TouchPin.P0, function() {})
+input.onPinReleased(TouchPin.P0, function() {})
+input.onLogoPressed(function () {})
+input.onLogoReleased(function () {})
+input.buttonIsPressed(Button.A)
+input.pinIsPressed(TouchPin.P0)
+input.logoIsPressed()
+input.isGesture(Gesture.Shake)
+input.compassHeading()
+input.temperature()
+input.acceleration(Dimension.X)
+input.lightLevel()
+input.rotation(Rotation.Pitch)
+input.magneticForce(Dimension.X)
+input.runningTime()
+input.runningTimeMicros()
+input.setAccelerometerRange(AcceleratorRange.OneG)
 ```
 
 ## See also
 
-[onButtonPressed](/reference/input/on-button-pressed), [onGesture](/reference/input/on-gesture), [onPinPressed](/reference/input/on-pin-pressed), [buttonIsPressed](/reference/input/button-is-pressed), 
-[is gesture](/reference/input/is-gesture),
-[compassHeading](/reference/input/compass-heading), [pinIsPressed](/reference/input/pin-is-pressed), [temperature](/reference/input/temperature), [acceleration](/reference/input/acceleration), [lightLevel](/reference/input/light-level), [rotation](/reference/input/rotation), [magneticForce](/reference/input/magnetic-force), [runningTime](/reference/input/running-time), [setAccelerometerRange](/reference/input/set-accelerometer-range), [calibrate-compass](/reference/input/calibrate-compass)
+[onButtonPressed](/reference/input/on-button-pressed), [onGesture](/reference/input/on-gesture),
+[onPinPressed](/reference/input/on-pin-pressed), [onPinReleased](/reference/input/on-pin-released),
+[onLogoPressed](/reference/input/on-logo-pressed), [onLogoReleased](/reference/input/on-logo-released),
+[buttonIsPressed](/reference/input/button-is-pressed), [pinIsPressed](/reference/input/pin-is-pressed),
+[logoIsPressed](/reference/input/logo-is-pressed), [is gesture](/reference/input/is-gesture),
+[compassHeading](/reference/input/compass-heading), [temperature](/reference/input/temperature),
+[acceleration](/reference/input/acceleration), [lightLevel](/reference/input/light-level),
+[rotation](/reference/input/rotation), [magneticForce](/reference/input/magnetic-force),
+[runningTime](/reference/input/running-time), [setAccelerometerRange](/reference/input/set-accelerometer-range),
+[calibrate-compass](/reference/input/calibrate-compass)

--- a/docs/reference/input.md
+++ b/docs/reference/input.md
@@ -7,11 +7,8 @@ input.onButtonPressed(Button.A, function () {})
 input.onGesture(Gesture.Shake, function () {})
 input.onPinPressed(TouchPin.P0, function() {})
 input.onPinReleased(TouchPin.P0, function() {})
-input.onLogoPressed(function () {})
-input.onLogoReleased(function () {})
 input.buttonIsPressed(Button.A)
 input.pinIsPressed(TouchPin.P0)
-input.logoIsPressed()
 input.isGesture(Gesture.Shake)
 input.compassHeading()
 input.temperature()
@@ -28,9 +25,8 @@ input.setAccelerometerRange(AcceleratorRange.OneG)
 
 [onButtonPressed](/reference/input/on-button-pressed), [onGesture](/reference/input/on-gesture),
 [onPinPressed](/reference/input/on-pin-pressed), [onPinReleased](/reference/input/on-pin-released),
-[onLogoPressed](/reference/input/on-logo-pressed), [onLogoReleased](/reference/input/on-logo-released),
 [buttonIsPressed](/reference/input/button-is-pressed), [pinIsPressed](/reference/input/pin-is-pressed),
-[logoIsPressed](/reference/input/logo-is-pressed), [is gesture](/reference/input/is-gesture),
+[is gesture](/reference/input/is-gesture),
 [compassHeading](/reference/input/compass-heading), [temperature](/reference/input/temperature),
 [acceleration](/reference/input/acceleration), [lightLevel](/reference/input/light-level),
 [rotation](/reference/input/rotation), [magneticForce](/reference/input/magnetic-force),

--- a/docs/reference/input/logo-is-pressed.md
+++ b/docs/reference/input/logo-is-pressed.md
@@ -1,0 +1,33 @@
+# logo Is Pressed
+
+Check if the @boardname@ logo is currently being pressed.
+
+```sig
+input.logoIsPressed()
+```
+
+The logo on the @boardname@ works just like a touch pin. You can check the whether or not the logo is currently being pressed. You use the [boolean](/types/boolean) value for the status of the logo press to make a logical decision in your program.
+
+## Returns
+
+* a [boolean](types/boolean) value that is `true` if the logo is pressed, `false` if the logo is not pressed.
+
+## Example
+
+Show an icon on the LEDs while the logo is pressed.
+
+```blocks
+basic.forever(function () {
+    if (input.logoIsPressed()) {
+        basic.showIcon(IconNames.Diamond)
+    } else {
+        basic.clearScreen()
+    }
+})
+```
+
+## See also
+
+[on logo pressed](/reference/input/on-logo-pressed),
+[on logo released](/reference/input/is-pin-released),
+[pin is pressed](/referene/inpu/pin-is-pressed)

--- a/docs/reference/input/on-logo-pressed.md
+++ b/docs/reference/input/on-logo-pressed.md
@@ -1,0 +1,25 @@
+# on Logo Pressed
+
+Run some code in your program when the @boardname@ logo is pressed.
+
+```sig
+input.onLogoPressed(function () {})
+```
+
+The logo on the @boardname@ works just like a touch pin. The logo will detect your touch. You can have code inside an event that will run when the logo is pressed.
+
+## Example
+
+Show a message on the LEDs when the @boardname@ logo is pressed.
+
+```blocks
+input.onLogoPressed(function () {
+    basic.showString("I was pressed!")
+})
+```
+
+## See also
+
+[on logo released](/reference/input/on-logo-released),
+[logo is pressed](/reference/input/logo-is-pressed),
+[on pin pressed](/reference/input/on-logo-released)

--- a/docs/reference/input/on-logo-released.md
+++ b/docs/reference/input/on-logo-released.md
@@ -1,0 +1,25 @@
+# on Logo Released
+
+Run code when the @boardname@ logo is pressed.
+
+```sig
+input.onLogoReleased(function () {})
+```
+
+The logo on the @boardname@ works just like a touch pin. The logo will detect your touch. You can have code inside an event that will run when you stop pressing on the logo.
+
+## Example
+
+Show a message on the LEDs when the @boardname@ logo is released.
+
+```blocks
+input.onLogoReleased(function () {
+    basic.showString("I was released!")
+})
+```
+
+## See also
+
+[on logo pressed](/reference/input/on-logo-pressed),
+[logo is pressed](/reference/input/logo-is-pressed),
+[on pin released](/reference/input/on-pin-released)

--- a/libs/core/logo.cpp
+++ b/libs/core/logo.cpp
@@ -44,7 +44,7 @@ namespace input {
     //% blockGap=8
     //% group="micro:bit v2"
     //% parts="logotouch"
-    //% help="input/is-logo-pressed"
+    //% help="input/logo-is-pressed"
     bool logoIsPressed() {
 #if MICROBIT_CODAL
         return uBit.io.logo.isTouched();

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -1159,7 +1159,7 @@ declare namespace input {
     //% blockGap=8
     //% group="micro:bit v2"
     //% parts="logotouch"
-    //% help="input/is-logo-pressed" shim=input::logoIsPressed
+    //% help="input/logo-is-pressed" shim=input::logoIsPressed
     function logoIsPressed(): boolean;
 }
 declare namespace pins {


### PR DESCRIPTION
Put in reference pages for logo press.

- [x] Page for `onLogoPressed`
- [x] Page for `onLogoReleased`
- [x] Page for `logoIsPressed`
- [ ] Include in `input` card page (wait until v2 release)
- [x] Fix help path for `logoIsPressed`

Comment:

`onLogoPressed` triggers on release instead of on press in the sim. Haven't checked on hardware.

RE: #3461