### PR TITLE
Fill in reference pages for microphone

### DIFF
--- a/docs/reference/input/on-sound.md
+++ b/docs/reference/input/on-sound.md
@@ -1,0 +1,37 @@
+# on Sound
+
+Run some code when the microphone hears a sound.
+
+```sig
+input.onSound(function () {})
+```
+
+The microphone will detect sounds that are quiet or loud. You can have the microphone detect
+a sound at a certain level and run some code in and event when it hears the sound. There are
+two sound ranges you can detect for: `loud` or `quiet`.
+
+## Parameters
+
+* **sound**: the type of sound to detect: `loud` or `quiet`.
+* **handler**: the code to run when a sound is heard.
+
+## Example
+
+Show an icon animation when the microphone detects a sound.
+
+```blocks
+input.onSound(DetectedSound.Loud, function () {
+    basic.showIcon(IconNames.Square)
+    basic.showIcon(IconNames.SmallSquare)
+    basic.showIcon(IconNames.SmallDiamond)
+    basic.clearScreen()
+})
+```
+
+# See also #seealso
+
+[sound level](/reference/input/sound-level), [set sound threshold](/reference/input/sound-level)
+
+```package
+microphone
+```

--- a/docs/reference/input/set-sound-threshold.md
+++ b/docs/reference/input/set-sound-threshold.md
@@ -1,0 +1,40 @@
+# set Sound Threshold
+
+Tell how loud it should be for your board to detect a loud sound.
+
+```sig
+input.setSoundThreshold(SoundThreshold.Loud, 0)
+```
+
+When the microphone hears a sound, it sets a number for how loud the sound was at that moment.
+This number is the sound level and has a value from `0` (low sound) to `255` (loud sound). You can use
+a sound level number as a _threshold_ (just the right amount of sound) to make the
+[on sound](/reference/input/on-sound) event happen. To set a threshold, you choose the type of sound
+to detect, `loud` or `quiet`, and then the sound level for that type.
+
+## Parameters
+
+* **sound**: the type of sound to dectect: `loud` or `quiet`.
+* **threshold**: the sound level [number](/types/number) which makes a sound event happen.
+
+## Example #example
+
+Show an icon animation when the microphone detects a sound louder than a sound level of `200`.
+
+```blocks
+input.setSoundThreshold(SoundThreshold.Loud, 200)
+input.onSound(DetectedSound.Loud, function () {
+    basic.showIcon(IconNames.Square)
+    basic.showIcon(IconNames.SmallSquare)
+    basic.showIcon(IconNames.SmallDiamond)
+    basic.clearScreen()
+})
+```
+
+# See also #seealso
+
+[on sound](/reference/input/on-sound), [sound level](/reference/input/sound-level)
+
+```package
+microphone
+```

--- a/docs/reference/input/sound-level.md
+++ b/docs/reference/input/sound-level.md
@@ -1,0 +1,33 @@
+# sound Level
+
+Find out what the the level of sound heard by microphone is.
+
+```sig
+input.soundLevel()
+```
+
+## Returns
+
+* a ``number`` between `0` (low sound) and `255` (loud sound) which tells how loud the sounds are that the microphone hears.
+
+## Example
+
+Show a checkerboard icon while the sound level is greater than `100`.
+
+```blocks
+basic.forever(function () {
+    if (input.soundLevel() > 100) {
+        basic.showIcon(IconNames.Chessboard)
+    } else {
+        basic.clearScreen()
+    }
+})
+```
+
+## See also
+
+[on sound](/reference/input/on-sound), [set sound threshold](/reference/input/sound-level)
+
+```package
+microphone
+```

--- a/libs/microphone/microphone.cpp
+++ b/libs/microphone/microphone.cpp
@@ -73,6 +73,7 @@ int soundLevel() {
 /**
 * Sets the threshold for a sound type.
 */
+//% help=input/set-sound-threshold
 //% blockId=input_set_sound_threshold block="set %sound sound threshold to %value"
 //% parts="microphone"
 //% threshold.min=0 threshold.max=255 threshold.defl=128

--- a/libs/microphone/shims.d.ts
+++ b/libs/microphone/shims.d.ts
@@ -24,6 +24,7 @@ declare namespace input {
     /**
      * Sets the threshold for a sound type.
      */
+    //% help=input/set-sound-threshold
     //% blockId=input_set_sound_threshold block="set %sound sound threshold to %value"
     //% parts="microphone"
     //% threshold.min=0 threshold.max=255


### PR DESCRIPTION
Put in reference pages for logo press.

- [x] Page for `onSound`
- [x] Page for `soundLevel`
- [x] Page for `setSoundThreshold`
- [ ] Include in `input` card page (wait until v2 release)
- [x] Add help path for `setSoundThreshold`

