### PR TITLE
fixed typo in enum: touch->touched

### DIFF
--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -256,7 +256,7 @@
   "TouchButtonEvent.LongPressed|block": "long pressed",
   "TouchButtonEvent.Pressed|block": "pressed",
   "TouchButtonEvent.Released|block": "released",
-  "TouchButtonEvent.Touch|block": "touch",
+  "TouchButtonEvent.Touched|block": "touched",
   "TouchTarget.LOGO|block": "logo",
   "TouchTarget.P0|block": "P0",
   "TouchTarget.P1|block": "P1",

--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -570,8 +570,8 @@ declare namespace serial {
     declare const enum TouchButtonEvent {
     //% block=pressed
     Pressed = 3,  // MICROBIT_BUTTON_EVT_CLICK
-    //% block=touch
-    Touch = 1,  // MICROBIT_BUTTON_EVT_DOWN
+    //% block=touched
+    Touched = 1,  // MICROBIT_BUTTON_EVT_DOWN
     //% block=released
     Released = 2,  // MICROBIT_BUTTON_EVT_UP
     //% block="long pressed"

--- a/libs/core/logo.cpp
+++ b/libs/core/logo.cpp
@@ -6,8 +6,8 @@
 enum TouchButtonEvent {
     //% block=pressed
     Pressed = MICROBIT_BUTTON_EVT_CLICK,
-    //% block=touch
-    Touch = MICROBIT_BUTTON_EVT_DOWN,
+    //% block=touched
+    Touched = MICROBIT_BUTTON_EVT_DOWN,
     //% block=released
     Released = MICROBIT_BUTTON_EVT_UP,
     //% block="long pressed"


### PR DESCRIPTION
Rename "touch" to "touched" to match other enum members.