### PR TITLE
Remove the v2 extension.

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -1,7 +1,6 @@
 {
     "packages": {
         "approvedRepos": [
-            "microbit-foundation/pxt-microbit-v2-extension",
             "microsoft/pxt-neopixel",
             "microsoft/pxt-microturtle",
             "microsoft/pxt-sonar",


### PR DESCRIPTION
The extension is now incompatible with the equivalent blocks in
pxt-microbit. It only ever worked with /beta/ and these blocks
are now available there.

We'll archive the extension GitHub repository soon to avoid issues
being raised there.

Revert "Extensions: add micro:bit extension (#3445)"

This reverts commit 093448282d3e94396da759eb127322e4412b68e1.