### PR TITLE
Add MICROBIT_DAL_PXT to detect pxt in codal

### DIFF
--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -98,7 +98,8 @@
     "yotta": {
         "config": {
             "microbit-dal": {
-                "fiber_user_data": 1
+                "fiber_user_data": 1,
+                "pxt": 1
             }
         },
         "optionalConfig": {


### PR DESCRIPTION
This let's one say #ifdef MICROBIT_DAL_PXT in codal (apparently needed for some compat APIs for extensions)

@abchatra good to port this one