### PR TITLE
add flag for android app to disable blob object download

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -563,6 +563,9 @@
         "androidapp": {
             "compile": {
                 "webUSB": false
+            },
+            "appTheme": {
+                "disableBlobObjectDownload": true
             }
         }
     },


### PR DESCRIPTION
Along with https://github.com/microsoft/pxt/pull/7616 fixes https://github.com/microsoft/pxt-microbit/issues/3674