### PR TITLE
Correct badly rendered blocks in Bluetooth documentation

### DIFF
--- a/docs/reference/bluetooth/on-uart-data-received.md
+++ b/docs/reference/bluetooth/on-uart-data-received.md
@@ -15,7 +15,8 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {})
 Read values separated by `,`:
 
 ```blocks
-bluetooth.onUartDataReceived(serial.delimiters(Delimiters.Comma), () => {
+bluetooth.startUartService()
+bluetooth.onUartDataReceived(serial.delimiters(Delimiters.Comma), function () {
     basic.showString(serial.readUntil(serial.delimiters(Delimiters.Comma)))
 })
 ```

--- a/docs/reference/bluetooth/on-uart-data-received.md
+++ b/docs/reference/bluetooth/on-uart-data-received.md
@@ -1,23 +1,47 @@
 # Bluetooth On UART Data Received
 
-Registers an event to be fired when one of the delimiter is matched.
+Runs some code in an event when a delimiter is matched in the received data.
 
 ```sig
-bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {})
+bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), function() {})
 ```
 
 ## Parameters
 
-* `delimiters` is a [string](/types/string) containing any of the character to match
+* **delimiters**: a [string](/types/string) containing the delimiter characters to match in the received data.
+
+### ~ hint
+
+#### Delimiters
+
+Delimiters are characters in a received data string which divide the string into smaller strings to form separate data items.
+
+Although multiple delimiter characters can be set in the **delimiters** string, it is common to have received data separated using just one delimiter character, such as a comma:
+
+``"data1,data2,data3,data4"``
+
+So, you can specify a delimiter character using the ``||serial:serial delimiters||`` which create a single character delimiter string for you...
+
+```block
+bluetooth.onUartDataReceived(serial.delimiters(Delimiters.Comma), function () {
+})
+```
+Or, maybe...
+
+```block
+let delim = serial.delimiters(Delimiters.NewLine)
+basic.showString(bluetooth.uartReadUntil(delim))
+```
+
+### ~
 
 ## Example
 
-Read values separated by `,`:
+Read the data items separated by a comma (`,`):
 
 ```blocks
-bluetooth.startUartService()
 bluetooth.onUartDataReceived(serial.delimiters(Delimiters.Comma), function () {
-    basic.showString(serial.readUntil(serial.delimiters(Delimiters.Comma)))
+    basic.showString(bluetooth.uartReadUntil(serial.delimiters(Delimiters.Space)))
 })
 ```
 

--- a/docs/reference/bluetooth/on-uart-data-received.md
+++ b/docs/reference/bluetooth/on-uart-data-received.md
@@ -3,7 +3,7 @@
 Registers an event to be fired when one of the delimiter is matched.
 
 ```sig
-bluetooth.onUartDataReceived(",", () => {})
+bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {})
 ```
 
 ## Parameters

--- a/docs/reference/bluetooth/on-uart-data-received.md
+++ b/docs/reference/bluetooth/on-uart-data-received.md
@@ -20,3 +20,7 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.Comma), function () {
     basic.showString(serial.readUntil(serial.delimiters(Delimiters.Comma)))
 })
 ```
+
+```package
+bluetooth
+```


### PR DESCRIPTION
Correct badly rendered blocks in Bluetooth documentation for block "bluetooth on data received"
