### PR TITLE
don't show accelerometer data when sound level is visible

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -885,8 +885,10 @@ path.sim-board {
             el.style.perspectiveOrigin = "50% 50% 50%";
             el.style.perspective = "30em";
 
-            // don't display acc data when AB is on
-            if (state.buttonPairState.usesButtonAB) {
+            // don't display acc data when AB is on, v2 is on or soundLevel is on
+            if (state.buttonPairState.usesButtonAB
+                || this.v2Circle
+                || this.soundLevel) {
                 if (this.accTextX) this.accTextX.textContent = "";
                 if (this.accTextY) this.accTextY.textContent = "";
                 if (this.accTextZ) this.accTextZ.textContent = "";


### PR DESCRIPTION
Don't show acceleration data if sound level is visible. No space in current design.

![image](https://user-images.githubusercontent.com/4175913/99230223-5ca64680-27ef-11eb-90a7-8a4f2d6ff0d8.png)
