### PR TITLE
add option to disable BLE event service

### DIFF
--- a/libs/bluetooth/pxt.json
+++ b/libs/bluetooth/pxt.json
@@ -28,7 +28,18 @@
                 "stack_size": 1280,
                 "gatt_table_size": "0x700"
             }
-        }
-    },
-    "installedVersion": "vzlhfd"
+        },
+        "userConfigs": [
+            {
+                "description": "Disable Bluetooth Event Service",
+                "config": {
+                    "microbit-dal": {
+                        "bluetooth": {
+                            "event_service": 0
+                        }
+                    }
+                }
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/3715

Add project configuration to disable the BLE Event service. No behavior change unless the user explicitely decides to toggle this value.

![image](https://user-images.githubusercontent.com/4175913/99361964-b64a5780-2867-11eb-8ced-d5f1a577cffc.png)

* in the editor, click on ``Project Settings`` in the gearwheel and toggle "Disable Event Service"