### PR TITLE
add tick event to offline-app.html

### DIFF
--- a/docs/offline-app.html
+++ b/docs/offline-app.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
 
 <head>
+    <!-- @include tickevent.html -->
     <!-- @include offline-app-head.html -->
 </head>
 


### PR DESCRIPTION
I noticed the tick didn't get fired when I downloaded the live site; window.pxtTickEvent wasn't getting defined there but was when served locally. Looks like we handle includes recursively locally

https://github.com/microsoft/pxt/blob/c9e8e5031b5c423309b779f633dc1cc451708c9b/cli/server.ts#L391

but non recursively in backend

https://github.com/microsoft/pxt-backend/blob/f51f4a90e937a82cebd06cd9af7d9902b3bccd7e/src/routing.ts#L192

which is a bit of a gotcha, so the import tickevent.html in offline-app-head.html wasn't working before :( 