### PR TITLE
fix setAudioPin / add setSilenceLevel

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -523,6 +523,7 @@
   "music.setBuiltInSpeakerEnabled": "Turn the built-in speaker on or off.\nDisabling the speaker resets the sound pin to the default of P0.",
   "music.setBuiltInSpeakerEnabled|param|enabled": "whether the built-in speaker is enabled in addition to the sound pin",
   "music.setPlayTone": "Sets a custom playTone function for playing melodies",
+  "music.setSilenceLevel": "Defines an optional sample level to generate during periods of silence.",
   "music.setTempo": "Sets the tempo to the specified amount",
   "music.setTempo|param|bpm": "The new tempo in beats per minute, eg: 120",
   "music.setVolume": "Set the default output volume of the sound synthesizer.",

--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -67,7 +67,6 @@ void setBuiltInSpeakerEnabled(bool enabled) {
  * Defines an optional sample level to generate during periods of silence.
  **/
 //% group="micro:bit (V2)"
-//% parts=builtinspeaker
 //% help=music/set-silence-level
 //% level.min=0
 //% level.max=1024

--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -63,4 +63,23 @@ void setBuiltInSpeakerEnabled(bool enabled) {
 #endif
 }
 
+/**
+ * Defines an optional sample level to generate during periods of silence.
+ **/
+//% group="micro:bit (V2)"
+//% parts=builtinspeaker
+//% help=music/set-silence-level
+//% level.min=0
+//% level.max=1024
+//% level.defl=0
+//% weight=1
+void setSilenceLevel(int level) {
+#if MICROBIT_CODAL
+    uBit.audio.mixer.setSilenceLevel(level);
+#else
+    // this is an optimization
+    // ignore in V1
+#endif
+}
+
 }

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -637,6 +637,18 @@ declare namespace music {
     //% help=music/set-built-in-speaker-enabled
     //% enabled.shadow=toggleOnOff shim=music::setBuiltInSpeakerEnabled
     function setBuiltInSpeakerEnabled(enabled: boolean): void;
+
+    /**
+     * Defines an optional sample level to generate during periods of silence.
+     **/
+    //% group="micro:bit (V2)"
+    //% parts=builtinspeaker
+    //% help=music/set-silence-level
+    //% level.min=0
+    //% level.max=1024
+    //%
+    //% weight=1 level.defl=0 shim=music::setSilenceLevel
+    function setSilenceLevel(level?: int32): void;
 }
 declare namespace pins {
 

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -177,8 +177,10 @@ namespace pxsim.music {
     export function volume(): number {
         return pxsim.pins.analogPitchVolume();
     }
+}
 
-    export function setSoundPin(pinId: number) {
+namespace pxsim.pins {
+    export function setAudioPin(pinId: number) {
         pxsim.pins.analogSetPitchPin(pinId);
     }
 }

--- a/sim/state/music.ts
+++ b/sim/state/music.ts
@@ -3,8 +3,12 @@ namespace pxsim.music {
         const b = board();
         if (!b) return;
 
-        // TODO some redering about this
+        // TODO some rendering about this
         b.ensureHardwareVersion(2);
         b.speakerEnabled = !!enabled;
+    }
+
+    export function setSilenceLevel(level: number) { 
+        // ignore in v1,v2
     }
 }


### PR DESCRIPTION
- [x] fix shim of setAudioPin
- [x] added music.setSilenceLevel (no blocks). API added in codal-v2 0.2.23 to support some accessories.

![image](https://user-images.githubusercontent.com/4175913/101344988-3e09fd00-383b-11eb-88b8-ec699f14d53f.png)
