### PR TITLE
Muselab oled

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -70,12 +70,16 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "url":"/pkg/xinabox/pxt-OD01",
   "cardType": "package"
 }, {
-  "name": "ssd1306 OLED",
+  "name": "Tinkertanker ssd1306 OLED",
   "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
   "cardType": "package"
 }, {
-  "name": "ssd1306 OLED with reset pin",
+  "name": "Tinkertanker ssd1306 OLED with reset pin",
   "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
+  "cardType": "package"
+}, {
+  "name": "Muselab ssd1306 OLED",
+  "url":"/pkg/MUSELAB/pxt-oled-ssd1306",
   "cardType": "package"
 }, {
   "name": "I2C LCD 1602 Display",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -79,7 +79,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "cardType": "package"
 }, {
   "name": "Muselab ssd1306 OLED",
-  "url":"/pkg/MUSELAB/pxt-muselab-oled-v2",
+  "url":"/pkg/MUSELAB/pxt-oled-ssd1306",
   "cardType": "package"
 }, {
   "name": "I2C LCD 1602 Display",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -79,7 +79,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "cardType": "package"
 }, {
   "name": "Muselab ssd1306 OLED",
-  "url":"/pkg/MUSELAB/pxt-oled-ssd1306",
+  "url":"/pkg/MUSELAB/pxt-muselab-oled-v2",
   "cardType": "package"
 }, {
   "name": "I2C LCD 1602 Display",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -190,7 +190,8 @@
             "KitronikLtd/pxt-kitronik-smart-greenhouse",
             "hardwario/pxt-microbit-hardwario",
             "Schoumi/ssd1306-with-reset",
-            "keble6/pxt-DS3231"
+            "keble6/pxt-DS3231",
+            "MUSELAB/pxt-oled-ssd1306/"
         ],
         "preferredRepos": [
             "Microsoft/pxt-neopixel",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -192,7 +192,7 @@
             "Schoumi/ssd1306-with-reset",
             "keble6/pxt-DS3231",
             "microsoft/ExpressivePixelsMakeCode",
-            "MUSELAB/pxt-muselab-oled-v2"
+            "MUSELAB/pxt-oled-ssd1306"
         ],
         "preferredRepos": [
             "Microsoft/pxt-neopixel",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -191,7 +191,7 @@
             "hardwario/pxt-microbit-hardwario",
             "Schoumi/ssd1306-with-reset",
             "keble6/pxt-DS3231",
-            "MUSELAB/pxt-oled-ssd1306/"
+            "MUSELAB/pxt-muselab-oled-v2"
         ],
         "preferredRepos": [
             "Microsoft/pxt-neopixel",


### PR DESCRIPTION
https://github.com/microsoft/pxt-microbit/pull/3801/files had a legacy URL for the extension that only supported V2. This extension has the correct URL