### PR TITLE
move beta to v

### DIFF
--- a/docs/beta-ref.json
+++ b/docs/beta-ref.json
@@ -1,3 +1,3 @@
 {
-    "appref": "v3.0"
+    "appref": "v"
 }


### PR DESCRIPTION
Unbind /beta so that it goes to ``v3.1``. ``/stable`` is still pointing to ``v3.0`` and should be used for micro:bit servicing.