### PR TITLE
Correct links and indentation in extensions.md docs file

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -33,11 +33,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "cardType": "link"
 }, {
     "name": "LEDs and lights",
-    "url": "/extensions#iot",
+    "url": "/extensions#leds-and-lights",
     "cardType": "link"
 }, {
     "name": "Machine learning",
-    "url": "/extensions#kits",
+    "url": "/extensions#machine-learning",
     "cardType": "link"
 }, {
     "name": "Robotics",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -70,25 +70,25 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url": "/pkg/KitronikLtd/pxt-kitronik-viewtext32",
     "cardType": "package"
 }, {
-  "name": "XinaBox OD01 Display",
-  "url":"/pkg/xinabox/pxt-OD01",
-  "cardType": "package"
+    "name": "XinaBox OD01 Display",
+    "url":"/pkg/xinabox/pxt-OD01",
+    "cardType": "package"
 }, {
-  "name": "Tinkertanker ssd1306 OLED",
-  "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
-  "cardType": "package"
+    "name": "Tinkertanker ssd1306 OLED",
+    "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
+    "cardType": "package"
 }, {
-  "name": "Tinkertanker ssd1306 OLED with reset pin",
-  "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
-  "cardType": "package"
+    "name": "Tinkertanker ssd1306 OLED with reset pin",
+    "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
+    "cardType": "package"
 }, {
-  "name": "Muselab ssd1306 OLED",
-  "url":"/pkg/MUSELAB/pxt-muselab-oled-v2",
-  "cardType": "package"
+    "name": "Muselab ssd1306 OLED",
+    "url":"/pkg/MUSELAB/pxt-muselab-oled-v2",
+    "cardType": "package"
 }, {
-  "name": "I2C LCD 1602 Display",
-  "url": "/pkg/1010Technologies/pxt-makerbit-ir-lcd1602",
-  "cardType": "package"
+    "name": "I2C LCD 1602 Display",
+    "url": "/pkg/1010Technologies/pxt-makerbit-ir-lcd1602",
+    "cardType": "package"
 }]
 ```
 
@@ -96,21 +96,21 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Kitronik Stop:Bit",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-stopbit",
-  "cardType": "package"
+    "name": "Kitronik Stop:Bit",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-stopbit",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Access:Bit",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-accessbit",
-  "cardType": "package"
+    "name": "Kitronik Access:Bit",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-accessbit",
+    "cardType": "package"
 }, {
-  "name": "PCA9685 LED controller",
-  "url":"/pkg/jdarling/pxt-pca9685",
-  "cardType": "package"
+    "name": "PCA9685 LED controller",
+    "url":"/pkg/jdarling/pxt-pca9685",
+    "cardType": "package"
 }, {
-  "name": "Coolguy expansion board",
-  "url":"/pkg/CoolGuy-official/pxt-coolguy",
-  "cardType": "package"
+    "name": "Coolguy expansion board",
+    "url":"/pkg/CoolGuy-official/pxt-coolguy",
+    "cardType": "package"
 }]
 ```
 
@@ -118,37 +118,37 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Elecfreaks magic wand",
-  "url":"/pkg/elecfreaks/pxt-magicwand",
-  "cardType": "package"
+    "name": "Elecfreaks magic wand",
+    "url":"/pkg/elecfreaks/pxt-magicwand",
+    "cardType": "package"
 }, {
-  "name": "Kitronik :GAME ZIP64",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-zip-64",
-  "cardType": "package"
+    "name": "Kitronik :GAME ZIP64",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-zip-64",
+    "cardType": "package"
 }, {
-  "name": "Kitronik :GAME Controller",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-game-controller",
-  "cardType": "package"
+    "name": "Kitronik :GAME Controller",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-game-controller",
+    "cardType": "package"
 }, {
-  "name": "Sparkfun Gamer:bit",
-  "url":"/pkg/sparkfun/pxt-gamer-bit",
-  "cardType": "package"
+    "name": "Sparkfun Gamer:bit",
+    "url":"/pkg/sparkfun/pxt-gamer-bit",
+    "cardType": "package"
 }, {
-  "name": "4tronix BitCommander",
-  "url":"/pkg/4tronix/BitCommander",
-  "cardType": "package"
+    "name": "4tronix BitCommander",
+    "url":"/pkg/4tronix/BitCommander",
+    "cardType": "package"
 }, {
-  "name": "51bit SFC/NES controller",
-  "url":"/pkg/51bit/SFC",
-  "cardType": "package"
+    "name": "51bit SFC/NES controller",
+    "url":"/pkg/51bit/SFC",
+    "cardType": "package"
 }, {
-  "name": "Pimoroni touch:bit",
-  "url":"/pkg/pimoroni/pxt-touchbit",
-  "cardType": "package"
+    "name": "Pimoroni touch:bit",
+    "url":"/pkg/pimoroni/pxt-touchbit",
+    "cardType": "package"
 }, {
-  "name": "ALS Robot JoyBit",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotJoyBit",
-  "cardType": "package"
+    "name": "ALS Robot JoyBit",
+    "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotJoyBit",
+    "cardType": "package"
 }]
 ```
 
@@ -156,45 +156,45 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
- "name": "DS3231",
-  "url":"/pkg/keble6/pxt-DS3231",
-  "cardType": "package"
+    "name": "DS3231",
+    "url":"/pkg/keble6/pxt-DS3231",
+    "cardType": "package"
 }, {
- "name": "Let's Talk Science COZIR sensor",
-  "url":"/pkg/letstalkscience/pxt-cozir",
-  "cardType": "package"
+    "name": "Let's Talk Science COZIR sensor",
+    "url":"/pkg/letstalkscience/pxt-cozir",
+    "cardType": "package"
 }, {
-  "name": "MAX6675",
-  "url":"/pkg/microsoft/pxt-max6675",
-  "cardType": "package"
+    "name": "MAX6675",
+    "url":"/pkg/microsoft/pxt-max6675",
+    "cardType": "package"
 }, {
-  "name": "Sonar",
-  "url":"/pkg/microsoft/pxt-sonar",
-  "cardType": "package"
+    "name": "Sonar",
+    "url":"/pkg/microsoft/pxt-sonar",
+    "cardType": "package"
 }, {
-  "name": "Non-blocking Ultrasonic Sensing",
-  "url":"/pkg/1010Technologies/pxt-makerbit-ultrasonic",
-  "cardType": "package"
+    "name": "Non-blocking Ultrasonic Sensing",
+    "url":"/pkg/1010Technologies/pxt-makerbit-ultrasonic",
+    "cardType": "package"
 }, {
-  "name": "HX711 Weight Sensor",
-  "url":"/pkg/daferdur/pxt-myHX711",
-  "cardType": "package"
+    "name": "HX711 Weight Sensor",
+    "url":"/pkg/daferdur/pxt-myHX711",
+    "cardType": "package"
 }, {
-  "name": "Bluetooth Temperature Sensor",
-  "url":"/pkg/microsoft/pxt-bluetooth-temperature-sensor",
-  "cardType": "package"
+    "name": "Bluetooth Temperature Sensor",
+    "url":"/pkg/microsoft/pxt-bluetooth-temperature-sensor",
+    "cardType": "package"
 }, {
-  "name": "Bluetooth MAX6675",
-  "url":"/pkg/microsoft/pxt-bluetooth-max6675",
-  "cardType": "package"
+    "name": "Bluetooth MAX6675",
+    "url":"/pkg/microsoft/pxt-bluetooth-max6675",
+    "cardType": "package"
 }, {
-  "name": "ky040 rotary",
-  "url":"/pkg/Tinkertanker/pxt-rotary-encoder-ky040",
-  "cardType": "package"
+    "name": "ky040 rotary",
+    "url":"/pkg/Tinkertanker/pxt-rotary-encoder-ky040",
+    "cardType": "package"
 }, {
-  "name": "GY521",
-  "url":"/pkg/PaulDFoster/pxt-microbit-GY521",
-  "cardType": "package"
+    "name": "GY521",
+    "url":"/pkg/PaulDFoster/pxt-microbit-GY521",
+    "cardType": "package"
 }, {
     "name": "DHT11 & DHT22 Temperature and Humidity",
     "url":"/pkg/alankrantas/pxt-DHT11_DHT22",
@@ -270,33 +270,33 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Wappsto:bit",
-  "url":"/pkg/Wappsto/pxt-wappsto",
-  "cardType": "package"
+    "name": "Wappsto:bit",
+    "url":"/pkg/Wappsto/pxt-wappsto",
+    "cardType": "package"
 }, {
-  "name": "Hardwario IoT Kit",
-  "url":"/pkg/hardwario/pxt-microbit-hardwario",
-  "cardType": "package"
+    "name": "Hardwario IoT Kit",
+    "url":"/pkg/hardwario/pxt-microbit-hardwario",
+    "cardType": "package"
 }, {
-  "name": "Pi Supply Lora Node",
-  "url":"/pkg/PiSupply/pxt-iot-lora-node",
-  "cardType": "package"
+    "name": "Pi Supply Lora Node",
+    "url":"/pkg/PiSupply/pxt-iot-lora-node",
+    "cardType": "package"
 }, {
-  "name": "WiFi:Bit",
-  "url":"/pkg/e-radionicacom/pxt-wifi",
-  "cardType": "package"
+    "name": "WiFi:Bit",
+    "url":"/pkg/e-radionicacom/pxt-wifi",
+    "cardType": "package"
 }, {
-  "name": "ESP8266 and ThingSpeak",
-  "url":"/pkg/alankrantas/pxt-ESP8266_ThingSpeak",
-  "cardType": "package"
+    "name": "ESP8266 and ThingSpeak",
+    "url":"/pkg/alankrantas/pxt-ESP8266_ThingSpeak",
+    "cardType": "package"
 }, {
-  "name": "DFRobot microIoT board",
-  "url":"/pkg/DFRobot/pxt-DFRobot-microIoT",
-  "cardType": "package"
+    "name": "DFRobot microIoT board",
+    "url":"/pkg/DFRobot/pxt-DFRobot-microIoT",
+    "cardType": "package"
 }, {
-  "name": "Muselab WiFi IoT Shield",
-  "url":"/pkg/MUSELAB/pxt-wifi-shield",
-  "cardType": "package"
+    "name": "Muselab WiFi IoT Shield",
+    "url":"/pkg/MUSELAB/pxt-wifi-shield",
+    "cardType": "package"
 }]
 ```
 
@@ -304,33 +304,33 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-   "name": "PT-BOT PTKidsBIT",
-   "url": "/pkg/iBuilds/pxt-PTKidsBIT",
-   "cardType": "package"
+    "name": "PT-BOT PTKidsBIT",
+    "url": "/pkg/iBuilds/pxt-PTKidsBIT",
+    "cardType": "package"
 }, {
-   "name": "Pi Supply tinker:kit",
-   "url": "/pkg/PiSupply/pxt-tinker-kit",
-   "cardType": "package"
+    "name": "Pi Supply tinker:kit",
+    "url": "/pkg/PiSupply/pxt-tinker-kit",
+    "cardType": "package"
 }, {
-   "name": "Freenove Starter Kit",
-   "url": "/pkg/Freenove/Makecode-Extension-Starter-Kit",
-   "cardType": "package"
+    "name": "Freenove Starter Kit",
+    "url": "/pkg/Freenove/Makecode-Extension-Starter-Kit",
+    "cardType": "package"
 }, {
-  "name": "Elecfreaks PlanetX sensor kit",
-  "url":"/pkg/elecfreaks/pxt-PlanetX",
-  "cardType": "package"
+    "name": "Elecfreaks PlanetX sensor kit",
+    "url":"/pkg/elecfreaks/pxt-PlanetX",
+    "cardType": "package"
 }, {
-  "name": "Inksmith Climate Action Kit",
-  "url":"/pkg/dugbraden/pxt-climate-action-kit",
-  "cardType": "package"
+    "name": "Inksmith Climate Action Kit",
+    "url":"/pkg/dugbraden/pxt-climate-action-kit",
+    "cardType": "package"
 }, {
-  "name": "Grove inventor kit",
-  "url":"/pkg/Seeed-Studio/pxt-grove",
-  "cardType": "package"
+    "name": "Grove inventor kit",
+    "url":"/pkg/Seeed-Studio/pxt-grove",
+    "cardType": "package"
 }, {
-  "name": "Minode Kit",
-  "url":"/pkg/minodekit/pxt-minode",
-  "cardType": "package"
+    "name": "Minode Kit",
+    "url":"/pkg/minodekit/pxt-minode",
+    "cardType": "package"
 }]
 ```
 
@@ -338,37 +338,37 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Kitronik Lamp:Bit",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-lampbit",
-  "cardType": "package"
+    "name": "Kitronik Lamp:Bit",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-lampbit",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Halo HD",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-halohd",
-  "cardType": "package"
+    "name": "Kitronik Halo HD",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-halohd",
+    "cardType": "package"
 }, {
-  "name": "NeoPixel",
-  "url":"/pkg/microsoft/pxt-neopixel",
-  "cardType": "package"
+    "name": "NeoPixel",
+    "url":"/pkg/microsoft/pxt-neopixel",
+    "cardType": "package"
 }, {
     "name": "WS2812B",
     "url": "/pkg/microsoft/pxt-ws2812b",
     "cardType": "package"
 }, {
-  "name": "4tronix Cube:Bit",
-  "url":"/pkg/4tronix/cubebit",
-  "cardType": "package"
+    "name": "4tronix Cube:Bit",
+    "url":"/pkg/4tronix/cubebit",
+    "cardType": "package"
 }, {
-  "name": "51bit ColorBit",
-  "url":"/pkg/51bit/ColorBit",
-  "cardType": "package"
+    "name": "51bit ColorBit",
+    "url":"/pkg/51bit/ColorBit",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Zip Tile",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-zip-tile",
-  "cardType": "package"
+    "name": "Kitronik Zip Tile",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-zip-tile",
+    "cardType": "package"
 }, {
-  "name": "MAX7219 8x8",
-  "url":"/pkg/alankrantas/pxt-MAX7219_8x8",
-  "cardType": "package"
+    "name": "MAX7219 8x8",
+    "url":"/pkg/alankrantas/pxt-MAX7219_8x8",
+    "cardType": "package"
 }]
 ```
 
@@ -376,214 +376,214 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "MU Vision camera",
-  "url":"/pkg/mu-opensource/pxt-muvision",
-  "cardType": "package"
+    "name": "MU Vision camera",
+    "url":"/pkg/mu-opensource/pxt-muvision",
+    "cardType": "package"
 }, {
-  "name": "DFRobot HuskyLens",
-  "url":"/pkg/DFRobot/pxt-DFRobot_HuskyLens",
-  "cardType": "package"
+    "name": "DFRobot HuskyLens",
+    "url":"/pkg/DFRobot/pxt-DFRobot_HuskyLens",
+    "cardType": "package"
 }]
 ```
 ## Robotics
 
 ```codecard
 [{
-  "name": "Finch 2.0",
-  "url":"/pkg/BirdBrainTechnologies/pxt-finch",
-  "cardType": "package"
+    "name": "Finch 2.0",
+    "url":"/pkg/BirdBrainTechnologies/pxt-finch",
+    "cardType": "package"
 }, {
-  "name": "Bouw je BEP",
-  "url":"/pkg/Bouw-je-BEP/Bouw-je-BEP",
-  "cardType": "package"
+    "name": "Bouw je BEP",
+    "url":"/pkg/Bouw-je-BEP/Bouw-je-BEP",
+    "cardType": "package"
 }, {
-  "name": "DF Robot Maqueen Plus",
-  "url":"/pkg/DFRobot/pxt-DFRobot-Maqueenplus",
-  "cardType": "package"
+    "name": "DF Robot Maqueen Plus",
+    "url":"/pkg/DFRobot/pxt-DFRobot-Maqueenplus",
+    "cardType": "package"
 }, {
-  "name": "Joy IT Joy Car",
-  "url":"/pkg/joy-it/Joy-Car",
-  "cardType": "package"
+    "name": "Joy IT Joy Car",
+    "url":"/pkg/joy-it/Joy-Car",
+    "cardType": "package"
 }, {
-  "name": "Kitronik :MOVE Motor",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-move-motor",
-  "cardType": "package"
+    "name": "Kitronik :MOVE Motor",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-move-motor",
+    "cardType": "package"
 }, {
-  "name": "A4 Technologies CODO",
-  "url":"/pkg/CODOmicrobit/pxt-CODO",
-  "cardType": "package"
+    "name": "A4 Technologies CODO",
+    "url":"/pkg/CODOmicrobit/pxt-CODO",
+    "cardType": "package"
 }, {
-  "name": "Strawbees Robotic Inventions Kit",
-  "url":"/pkg/strawbees/pxt-robotic-inventions",
-  "cardType": "package"
+    "name": "Strawbees Robotic Inventions Kit",
+    "url":"/pkg/strawbees/pxt-robotic-inventions",
+    "cardType": "package"
 }, {
-  "name": "Kitronik :MOVE mini",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-servo-lite",
-  "cardType": "package"
+    "name": "Kitronik :MOVE mini",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-servo-lite",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Integrated Robotics Board",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-robotics-board",
-  "cardType": "package"
+    "name": "Kitronik Integrated Robotics Board",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-robotics-board",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Motor Driver Board",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-motor-driver",
-  "cardType": "package"
+    "name": "Kitronik Motor Driver Board",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-motor-driver",
+    "cardType": "package"
 }, {
-  "name": "Kitronik 16 Servo Board",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-i2c-16-servo",
-  "cardType": "package"
+    "name": "Kitronik 16 Servo Board",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-i2c-16-servo",
+    "cardType": "package"
 }, {
-  "name": "YFROBOT Valon",
-  "url":"/pkg/YFROBOT-TM/pxt-yfrobot-valon",
-  "cardType": "package"
+    "name": "YFROBOT Valon",
+    "url":"/pkg/YFROBOT-TM/pxt-yfrobot-valon",
+    "cardType": "package"
 }, {
-  "name": "4tronix BitBot",
-  "url":"/pkg/4tronix/BitBot",
-  "cardType": "package"
+    "name": "4tronix BitBot",
+    "url":"/pkg/4tronix/BitBot",
+    "cardType": "package"
 },{
-  "name": "4tronix Orbit",
-  "url":"/pkg/4tronix/Orbit",
-  "cardType": "package"
+    "name": "4tronix Orbit",
+    "url":"/pkg/4tronix/Orbit",
+    "cardType": "package"
 }, {
-  "name": "4tronix Drive:Bit",
-  "url":"/pkg/4tronix/DriveBit",
-  "cardType": "package"
+    "name": "4tronix Drive:Bit",
+    "url":"/pkg/4tronix/DriveBit",
+    "cardType": "package"
 }, {
-  "name": "4tronix Servo:Bit",
-  "url":"/pkg/4tronix/ServoBit",
-  "cardType": "package"
+    "name": "4tronix Servo:Bit",
+    "url":"/pkg/4tronix/ServoBit",
+    "cardType": "package"
 }, {
-  "name": "4tronix MiniBit",
-  "url":"/pkg/4tronix/MiniBit",
-  "cardType": "package"
+    "name": "4tronix MiniBit",
+    "url":"/pkg/4tronix/MiniBit",
+    "cardType": "package"
 }, {
-  "name": "Elecfreaks TPBot",
-  "url":"/pkg/elecfreaks/pxt-TPBot",
-  "cardType": "package"
+    "name": "Elecfreaks TPBot",
+    "url":"/pkg/elecfreaks/pxt-TPBot",
+    "cardType": "package"
 }, {
-  "name": "DF Robot Maqueen",
-  "url":"/pkg/DFRobot/pxt-maqueen",
-  "cardType": "package"
+    "name": "DF Robot Maqueen",
+    "url":"/pkg/DFRobot/pxt-maqueen",
+    "cardType": "package"
 }, {
-  "name": "Sunfounder Sloth",
-  "url":"/pkg/sunfounder/pxt-sloth",
-  "cardType": "package"
+    "name": "Sunfounder Sloth",
+    "url":"/pkg/sunfounder/pxt-sloth",
+    "cardType": "package"
 }, {
-  "name": "Sphero RVR",
-  "url":"/pkg/sphero-inc/sphero-sdk-microbit-makecode",
-  "cardType": "package"
+    "name": "Sphero RVR",
+    "url":"/pkg/sphero-inc/sphero-sdk-microbit-makecode",
+    "cardType": "package"
 }, {
-  "name": "Sparkfun Moto:bit",
-  "url":"/pkg/sparkfun/pxt-moto-bit",
-  "cardType": "package"
+    "name": "Sparkfun Moto:bit",
+    "url":"/pkg/sparkfun/pxt-moto-bit",
+    "cardType": "package"
 }, {
- "name": "EBOTICS MIBO",
-  "url":"/pkg/EBOTICS/pxt-eboticsMIBO",
-  "cardType": "package"
+    "name": "EBOTICS MIBO",
+    "url":"/pkg/EBOTICS/pxt-eboticsMIBO",
+    "cardType": "package"
 }, {
-  "name": "ALSRobot MinCruise",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/MiniCruise",
-  "cardType": "package"
+    "name": "ALSRobot MinCruise",
+    "url":"/pkg/alsrobot-microbit-makecode-packages/MiniCruise",
+    "cardType": "package"
 }, {
-  "name": "ReroKit rero:micro",
-  "url":"/pkg/ReRoKit/pxt-reromicro",
-  "cardType": "package"
+    "name": "ReroKit rero:micro",
+    "url":"/pkg/ReRoKit/pxt-reromicro",
+    "cardType": "package"
 }, {
-  "name": "PLEN bit",
-  "url":"/pkg/plenprojectcompany/pxt-PLENbit",
-  "cardType": "package"
+    "name": "PLEN bit",
+    "url":"/pkg/plenprojectcompany/pxt-PLENbit",
+    "cardType": "package"
 }, {
-  "name": "UCL Junk Robot",
-  "url":"/pkg/chevyng/pxt-ucl-junkrobot",
-  "cardType": "package"
+    "name": "UCL Junk Robot",
+    "url":"/pkg/chevyng/pxt-ucl-junkrobot",
+    "cardType": "package"
 }, {
-  "name": "Elecfreaks Cutebot",
-  "url":"/pkg/elecfreaks/pxt-cutebot",
-  "cardType": "package"
+    "name": "Elecfreaks Cutebot",
+    "url":"/pkg/elecfreaks/pxt-cutebot",
+    "cardType": "package"
 }, {
-  "name": "Kittenbot RobotBit",
-  "url":"/pkg/kittenbot/pxt-robotbit",
-  "cardType": "package"
+    "name": "Kittenbot RobotBit",
+    "url":"/pkg/kittenbot/pxt-robotbit",
+    "cardType": "package"
 }, {
-  "name": "inex iBit",
-  "url":"/pkg/emwta/pxt-iBit",
-  "cardType": "package"
+    "name": "inex iBit",
+    "url":"/pkg/emwta/pxt-iBit",
+    "cardType": "package"
 }, {
-  "name": "InkSmith k8 robotics kit",
-  "url":"/pkg/k8robotics/pxt-k8",
-  "cardType": "package"
+    "name": "InkSmith k8 robotics kit",
+    "url":"/pkg/k8robotics/pxt-k8",
+    "cardType": "package"
 }, {
-  "name": "Freenove Micro:Rover",
-  "url":"/pkg/Freenove/Makecode-Extension-Rover",
-  "cardType": "package"
+    "name": "Freenove Micro:Rover",
+    "url":"/pkg/Freenove/Makecode-Extension-Rover",
+    "cardType": "package"
 }, {
-  "name": "Gigglebot",
-  "url":"/pkg/dexterind/pxt-giggle",
-  "cardType": "package"
+    "name": "Gigglebot",
+    "url":"/pkg/dexterind/pxt-giggle",
+    "cardType": "package"
 }, {
-  "name": "Robobit",
-  "url":"/pkg/4tronix/Robobit",
-  "cardType": "package"
+    "name": "Robobit",
+    "url":"/pkg/4tronix/Robobit",
+    "cardType": "package"
 }, {
-  "name": "Pi Supply Bit:Buggy",
-  "url":"/pkg/PiSupply/pxt-bitbuggy",
-  "cardType": "package"
+    "name": "Pi Supply Bit:Buggy",
+    "url":"/pkg/PiSupply/pxt-bitbuggy",
+    "cardType": "package"
 }, {
-  "name": "ALS Robot Coo Coo",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/CooCoo",
-  "cardType": "package"
+    "name": "ALS Robot Coo Coo",
+    "url":"/pkg/alsrobot-microbit-makecode-packages/CooCoo",
+    "cardType": "package"
 }, {
-  "name": "ALS Robot CruiseBit",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/CruiseBit",
-  "cardType": "package"
+    "name": "ALS Robot CruiseBit",
+    "url":"/pkg/alsrobot-microbit-makecode-packages/CruiseBit",
+    "cardType": "package"
 }, {
-  "name": "Hummingbird Bit",
-  "url":"/pkg/BirdBrainTechnologies/pxt-hummingbird-bit",
-  "cardType": "package"
+    "name": "Hummingbird Bit",
+    "url":"/pkg/BirdBrainTechnologies/pxt-hummingbird-bit",
+    "cardType": "package"
 }, {
-  "name": "Inex iKB-1 controller board",
-  "url":"/pkg/jcubuntu/pxt-iKB1",
-  "cardType": "package"
+    "name": "Inex iKB-1 controller board",
+    "url":"/pkg/jcubuntu/pxt-iKB1",
+    "cardType": "package"
 }, {
-  "name": "MakerBit motor controller",
-  "url":"/pkg/1010Technologies/pxt-makerbit-motor",
-  "cardType": "package"
+    "name": "MakerBit motor controller",
+    "url":"/pkg/1010Technologies/pxt-makerbit-motor",
+    "cardType": "package"
 }, {
-  "name": "mikRobot",
-  "url":"/pkg/KS-Bulme/pxt-mikRobot",
-  "cardType": "package"
+    "name": "mikRobot",
+    "url":"/pkg/KS-Bulme/pxt-mikRobot",
+    "cardType": "package"
 }, {
-  "name": "Tobbie II",
-  "url":"/pkg/kaku111/pxt-tobbieII",
-  "cardType": "package"
+    "name": "Tobbie II",
+    "url":"/pkg/kaku111/pxt-tobbieII",
+    "cardType": "package"
 }, {
-  "name": "Kitronik ACCESS:bit",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-accessbit",
-  "cardType": "package"
+    "name": "Kitronik ACCESS:bit",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-accessbit",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Fischertechnik interface",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-fischertechnik",
-  "cardType": "package"
+    "name": "Kitronik Fischertechnik interface",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-fischertechnik",
+    "cardType": "package"
 }, {
-  "name": "Keigan Motor",
-  "url": "/pkg/keigan-motor/pxt-KeiganMotor",
-  "cardType": "package"
+    "name": "Keigan Motor",
+    "url": "/pkg/keigan-motor/pxt-KeiganMotor",
+    "cardType": "package"
 }, {
-  "name": "TCEA Nexus:bit and Nexusbot",
-  "url":"/pkg/beyond-coding-tw/pxt-nexusbot",
-  "cardType": "package"
+    "name": "TCEA Nexus:bit and Nexusbot",
+    "url":"/pkg/beyond-coding-tw/pxt-nexusbot",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Klip Motor",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-klip-motor",
-  "cardType": "package"
+    "name": "Kitronik Klip Motor",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-klip-motor",
+    "cardType": "package"
 }, {
-  "name": "Keyestudio Robot Car",
-  "url":"/pkg/Veilkrand/pxt-RobotCar",
-  "cardType": "package"  
+    "name": "Keyestudio Robot Car",
+    "url":"/pkg/Veilkrand/pxt-RobotCar",
+    "cardType": "package"  
 }, {
-  "name": "TinkerTanker Stepper Motor",
-  "url":"/pkg/Tinkertanker/pxt-stepper-motor",
-  "cardType": "package"
+    "name": "TinkerTanker Stepper Motor",
+    "url":"/pkg/Tinkertanker/pxt-stepper-motor",
+    "cardType": "package"
 }]
 ```
 
@@ -591,85 +591,85 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "DFRobot Natural Science Board",
-  "url":"/pkg/DFRobot/pxt-DFRobot-NaturalScience",
-  "cardType": "package"
+    "name": "DFRobot Natural Science Board",
+    "url":"/pkg/DFRobot/pxt-DFRobot-NaturalScience",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Klimate Board",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-klimate",
-  "cardType": "package"
+    "name": "Kitronik Klimate Board",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-klimate",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Smart Greenhouse",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-smart-greenhouse",
-  "cardType": "package"
+    "name": "Kitronik Smart Greenhouse",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-smart-greenhouse",
+    "cardType": "package"
 }, {
-  "name": "Make&Learn micro:shield",
-  "url":"/pkg/MakeAndLearn/pxt-microshield",
-  "cardType": "package"
+    "name": "Make&Learn micro:shield",
+    "url":"/pkg/MakeAndLearn/pxt-microshield",
+    "cardType": "package"
 }, {
-  "name": "Sparkfun Weather:bit",
-  "url":"/pkg/sparkfun/pxt-weather-bit",
-  "cardType": "package"
+    "name": "Sparkfun Weather:bit",
+    "url":"/pkg/sparkfun/pxt-weather-bit",
+    "cardType": "package"
 }, {
-  "name": "Sparkfun gator:environment",
-  "url":"/pkg/sparkfun/pxt-gator-environment",
-  "cardType": "package"
+    "name": "Sparkfun gator:environment",
+    "url":"/pkg/sparkfun/pxt-gator-environment",
+    "cardType": "package"
 }, {
-  "name": "XinaBox SW01 Advanced Weather Sensor",
-  "url":"/pkg/xinabox/pxt-SW01",
-  "cardType": "package"
+    "name": "XinaBox SW01 Advanced Weather Sensor",
+    "url":"/pkg/xinabox/pxt-SW01",
+    "cardType": "package"
 }, {
-  "name": "Cytron Edubit",
-  "url":"/pkg/CytronTechnologies/pxt-edubit",
-  "cardType": "package"
+    "name": "Cytron Edubit",
+    "url":"/pkg/CytronTechnologies/pxt-edubit",
+    "cardType": "package"
 }, {
-  "name": "Cytron Rekabit",
-  "url":"/pkg/CytronTechnologies/pxt-rekabit",
-  "cardType": "package"
+    "name": "Cytron Rekabit",
+    "url":"/pkg/CytronTechnologies/pxt-rekabit",
+    "cardType": "package"
 }, {
-  "name": "Imagimaker Magisheild",
-  "url":"/pkg/Imagimaker/pxt-imagimaker",
-  "cardType": "package"
+    "name": "Imagimaker Magisheild",
+    "url":"/pkg/Imagimaker/pxt-imagimaker",
+    "cardType": "package"
 }, {
-  "name": "Kitronik clip detector",
-  "url": "/pkg/KitronikLtd/pxt-kitronik-clip-detector",
-  "cardType": "package"  
+    "name": "Kitronik clip detector",
+    "url": "/pkg/KitronikLtd/pxt-kitronik-clip-detector",
+    "cardType": "package"  
 }, {
-  "name": "Pimoroni Envirobit",
-  "url": "/pkg/pimoroni/pxt-envirobit",
-  "cardType": "package"
+    "name": "Pimoroni Envirobit",
+    "url": "/pkg/pimoroni/pxt-envirobit",
+    "cardType": "package"
 }, {
-  "name": "Pimoroni Automationbit",
-  "url":"/pkg/pimoroni/pxt-automationbit",
-  "cardType": "package"
+    "name": "Pimoroni Automationbit",
+    "url":"/pkg/pimoroni/pxt-automationbit",
+    "cardType": "package"
 }, {
-  "name": "51bit Smart Tools",
-  "url": "/pkg/51bit/SmartTools",
-  "cardType": "package"
+    "name": "51bit Smart Tools",
+    "url": "/pkg/51bit/SmartTools",
+    "cardType": "package"
 }, {
-  "name": "MakerBit",
-  "url": "/pkg/1010Technologies/pxt-makerbit",
-  "cardType": "package"
+    "name": "MakerBit",
+    "url": "/pkg/1010Technologies/pxt-makerbit",
+    "cardType": "package"
 }, {
-  "name": "MakerBit Pins",
-  "url": "/pkg/1010Technologies/pxt-makerbit-pins",
-  "cardType": "package"
+    "name": "MakerBit Pins",
+    "url": "/pkg/1010Technologies/pxt-makerbit-pins",
+    "cardType": "package"
 }, {
-  "name": "Elecfreaks Wukon",
-  "url": "/pkg/elecfreaks/pxt-wukong",
-  "cardType": "package"
+    "name": "Elecfreaks Wukon",
+    "url": "/pkg/elecfreaks/pxt-wukong",
+    "cardType": "package"
 }, {
-  "name": "Elite Longanbit",
-  "url": "/pkg/longan-link/pxt-longanbit",
-  "cardType": "package"
+    "name": "Elite Longanbit",
+    "url": "/pkg/longan-link/pxt-longanbit",
+    "cardType": "package"
 }, {
-  "name": "Adafruit Crickit",
-  "url": "/pkg/adafruit/pxt-crickit",
-  "cardType": "package"
+    "name": "Adafruit Crickit",
+    "url": "/pkg/adafruit/pxt-crickit",
+    "cardType": "package"
 }, {
-  "name": "Adafruit Seesaw",
-  "url": "/pkg/adafruit/pxt-seesaw",
-  "cardType": "package"
+    "name": "Adafruit Seesaw",
+    "url": "/pkg/adafruit/pxt-seesaw",
+    "cardType": "package"
 }]
 ```
 
@@ -677,17 +677,17 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Kitronik Klef Piano",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-klef-piano",
-  "cardType": "package"
+    "name": "Kitronik Klef Piano",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-klef-piano",
+    "cardType": "package"
 }, {
-  "name": "Catalex Serial MP3 Player v1.0",
-  "url": "/pkg/1010Technologies/pxt-makerbit-mp3",
-  "cardType": "package"
+    "name": "Catalex Serial MP3 Player v1.0",
+    "url": "/pkg/1010Technologies/pxt-makerbit-mp3",
+    "cardType": "package"
 }, {
-  "name": "51bit DFPlayer mini",
-  "url":"/pkg/51bit/dfplayermini",
-  "cardType": "package" 
+    "name": "51bit DFPlayer mini",
+    "url":"/pkg/51bit/dfplayermini",
+    "cardType": "package" 
 }]
 ```
 
@@ -695,82 +695,82 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-  "name": "Bright Wearables Bright Board",
-  "url":"/pkg/BrightWearables/pxt-microbit-brightboard",
-  "cardType": "package"
+    "name": "Bright Wearables Bright Board",
+    "url":"/pkg/BrightWearables/pxt-microbit-brightboard",
+    "cardType": "package"
 }]
 ```
 
 ## Utilities
 ```codecard
 [{
-  "name": "DS3231 Real Time Clock",
-  "url":"/pkg/AlexandreFrolov/DS3231",
-  "cardType": "package"
+    "name": "DS3231 Real Time Clock",
+    "url":"/pkg/AlexandreFrolov/DS3231",
+    "cardType": "package"
 }, {
-  "name": "Time & Date",
-  "url":"/pkg/bsiever/microbit-pxt-timeanddate",
-  "cardType": "package"
+    "name": "Time & Date",
+    "url":"/pkg/bsiever/microbit-pxt-timeanddate",
+    "cardType": "package"
 }, {
-  "name": "Kitronik Realtime Clock",
-  "url":"/pkg/KitronikLtd/pxt-kitronik-rtc",
-  "cardType": "package"
+    "name": "Kitronik Realtime Clock",
+    "url":"/pkg/KitronikLtd/pxt-kitronik-rtc",
+    "cardType": "package"
 }, {
-  "name": "Code Dojo Olney",
-  "url":"/pkg/CoderDojoOlney/pxt-olney",
-  "cardType": "package"
+    "name": "Code Dojo Olney",
+    "url":"/pkg/CoderDojoOlney/pxt-olney",
+    "cardType": "package"
 }, {
-  "name": "Inventura textbook",
-  "url":"/pkg/assirati/pxt-inventura",
-  "cardType": "package"
+    "name": "Inventura textbook",
+    "url":"/pkg/assirati/pxt-inventura",
+    "cardType": "package"
 }, {
-  "name": "File System",
-  "url":"/pkg/microsoft/pxt-filesystem",
-  "cardType": "package"
+    "name": "File System",
+    "url":"/pkg/microsoft/pxt-filesystem",
+    "cardType": "package"
 }, {
-  "name": "micro:turtle",
-  "url":"/pkg/microsoft/pxt-microturtle",
-  "cardType": "package"
+    "name": "micro:turtle",
+    "url":"/pkg/microsoft/pxt-microturtle",
+    "cardType": "package"
 }, {
-  "name": "MIDI",
-  "url":"/pkg/microsoft/pxt-midi",
-  "cardType": "package"
+    "name": "MIDI",
+    "url":"/pkg/microsoft/pxt-midi",
+    "cardType": "package"
 }, {
-  "name": "Bluetooth MIDI",
-  "url":"/pkg/microsoft/pxt-bluetooth-midi",
-  "cardType": "package"
+    "name": "Bluetooth MIDI",
+    "url":"/pkg/microsoft/pxt-bluetooth-midi",
+    "cardType": "package"
 }, {
-  "name": "BlockyTalkyBLE",
-  "url":"/pkg/LaboratoryForPlayfulComputation/pxt-BlockyTalkyBLE",
-  "cardType": "package"
+    "name": "BlockyTalkyBLE",
+    "url":"/pkg/LaboratoryForPlayfulComputation/pxt-BlockyTalkyBLE",
+    "cardType": "package"
 }, {
-  "name": "Katakana",
-  "url":"/pkg/mbitfun/pxt-katakana",
-  "cardType": "package"
+    "name": "Katakana",
+    "url":"/pkg/mbitfun/pxt-katakana",
+    "cardType": "package"
 }, {
-  "name": "LINE BLE beacon",
-  "url":"/pkg/pizayanz/pxt-linebeacon",
-  "cardType": "package"
+    "name": "LINE BLE beacon",
+    "url":"/pkg/pizayanz/pxt-linebeacon",
+    "cardType": "package"
 }, {
-  "name": "Pimoroni Scrollbit",
-  "url":"/pkg/pimoroni/pxt-scrollbit",
-  "cardType": "package"
+    "name": "Pimoroni Scrollbit",
+    "url":"/pkg/pimoroni/pxt-scrollbit",
+    "cardType": "package"
 }, {
-  "name": "SBRICK",
-  "url":"/pkg/vengit/pxt-sbrick",
-  "cardType": "package"
+    "name": "SBRICK",
+    "url":"/pkg/vengit/pxt-sbrick",
+    "cardType": "package"
 }, {
-  "name": "Annikken Andee",
-  "url":"/pkg/Annikken/pxt-Andee",
-  "cardType": "package"
+    "name": "Annikken Andee",
+    "url":"/pkg/Annikken/pxt-Andee",
+    "cardType": "package"
 }, {
-  "name": "Proportional Font",
-  "url":"/pkg/lwchkg/pxt-proportional-font",
-  "cardType": "package"
+    "name": "Proportional Font",
+    "url":"/pkg/lwchkg/pxt-proportional-font",
+    "cardType": "package"
 }, {
-  "name": "ALS Robot Keyboard",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotKeyboard",
-  "cardType": "package"
+    "name": "ALS Robot Keyboard",
+    "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotKeyboard",
+    "cardType": "package"
 }, {
     "name": "Elecfreaks NeZha",
     "url": "/pkg/elecfreaks/pxt-nezha",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -87,7 +87,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "cardType": "package"
 }, {
     "name": "I2C LCD 1602 Display",
-    "url": "/pkg/1010Technologies/pxt-makerbit-ir-lcd1602",
+    "url": "/pkg/1010Technologies/pxt-makerbit-lcd1602",
     "cardType": "package"
 }]
 ```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -55,6 +55,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "name": "Wearables",
     "url": "/extensions#wearables",
     "cardType": "link"
+}, {
+    "name": "Utilities",
+    "url": "/extensions#utilities",
+    "cardType": "link"
 }]
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -74,15 +74,15 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/xinabox/pxt-OD01",
     "cardType": "package"
 }, {
-    "name": "Tinkertanker ssd1306 OLED",
+    "name": "Tinkertanker SSD1306 OLED",
     "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
     "cardType": "package"
 }, {
-    "name": "Tinkertanker ssd1306 OLED with reset pin",
+    "name": "Tinkertanker SSD1306 OLED with reset pin",
     "url":"/pkg/Tinkertanker/pxt-oled-ssd1306",
     "cardType": "package"
 }, {
-    "name": "Muselab ssd1306 OLED",
+    "name": "MuseLab SSD1306 OLED",
     "url":"/pkg/MUSELAB/pxt-muselab-oled-v2",
     "cardType": "package"
 }, {
@@ -96,11 +96,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-    "name": "Kitronik Stop:Bit",
+    "name": "Kitronik STOP:Bit",
     "url":"/pkg/KitronikLtd/pxt-kitronik-stopbit",
     "cardType": "package"
 }, {
-    "name": "Kitronik Access:Bit",
+    "name": "Kitronik ACCESS:Bit",
     "url":"/pkg/KitronikLtd/pxt-kitronik-accessbit",
     "cardType": "package"
 }, {
@@ -130,7 +130,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/KitronikLtd/pxt-kitronik-game-controller",
     "cardType": "package"
 }, {
-    "name": "Sparkfun Gamer:bit",
+    "name": "SparkFun gamer:bit",
     "url":"/pkg/sparkfun/pxt-gamer-bit",
     "cardType": "package"
 }, {
@@ -188,7 +188,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/microsoft/pxt-bluetooth-max6675",
     "cardType": "package"
 }, {
-    "name": "ky040 rotary",
+    "name": "KY-040 Rotary Encoder",
     "url":"/pkg/Tinkertanker/pxt-rotary-encoder-ky040",
     "cardType": "package"
 }, {
@@ -216,7 +216,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/sparkfun/pxt-gator-soil",
     "cardType": "package"
 }, {
-    "name": "gator:temp Particle Sensor",
+    "name": "gator:particle Particle Sensor",
     "url":"/pkg/sparkfun/pxt-gator-particle",
     "cardType": "package"
 }, {
@@ -236,11 +236,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url": "/pkg/1010Technologies/pxt-makerbit-ir-receiver",
     "cardType": "package"
 }, {
-    "name": "BMP280 Barrometer",
+    "name": "BMP280 Barometer",
     "url": "/pkg/rebeccaclavier/pxt-bmp280",
     "cardType": "package"
 }, {
-    "name": "STTS751 temperature Sensor",
+    "name": "STTS751 Temperature Sensor",
     "url": "/pkg/makecode-extensions/STTS751",
     "cardType": "package"
 }, {    
@@ -252,15 +252,15 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url": "/pkg/makecode-extensions/LPS22",
     "cardType": "package"
 }, {
-    "name": "LIS2DW12 motion sensor",
+    "name": "LIS2DW12 Motion Sensor",
     "url": "/pkg/makecode-extensions/LIS2DW12",
     "cardType": "package"
 }, {    
-    "name": "LIS2MDL magnetic sensor",
+    "name": "LIS2MDL Magnetic Sensor",
     "url": "/pkg/makecode-extensions/LIS2MDL",
     "cardType": "package"
 }, {
-    "name": "HTS221 Humidity and temperature",
+    "name": "HTS221 Humidity and Temperature",
     "url": "/pkg/makecode-extensions/HTS221",
     "cardType": "package"
 }]
@@ -290,11 +290,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/alankrantas/pxt-ESP8266_ThingSpeak",
     "cardType": "package"
 }, {
-    "name": "DFRobot microIoT board",
+    "name": "DFRobot micro:IoT board",
     "url":"/pkg/DFRobot/pxt-DFRobot-microIoT",
     "cardType": "package"
 }, {
-    "name": "Muselab WiFi IoT Shield",
+    "name": "MuseLab WiFi IoT Shield",
     "url":"/pkg/MUSELAB/pxt-wifi-shield",
     "cardType": "package"
 }]
@@ -320,7 +320,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/elecfreaks/pxt-PlanetX",
     "cardType": "package"
 }, {
-    "name": "Inksmith Climate Action Kit",
+    "name": "InkSmith Climate Action Kit",
     "url":"/pkg/dugbraden/pxt-climate-action-kit",
     "cardType": "package"
 }, {
@@ -328,7 +328,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/Seeed-Studio/pxt-grove",
     "cardType": "package"
 }, {
-    "name": "Minode Kit",
+    "name": "mi:node Kit",
     "url":"/pkg/minodekit/pxt-minode",
     "cardType": "package"
 }]
@@ -338,11 +338,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-    "name": "Kitronik Lamp:Bit",
+    "name": "Kitronik LAMP:bit",
     "url":"/pkg/KitronikLtd/pxt-kitronik-lampbit",
     "cardType": "package"
 }, {
-    "name": "Kitronik Halo HD",
+    "name": "Kitronik :VIEW Halo HD",
     "url":"/pkg/KitronikLtd/pxt-kitronik-halohd",
     "cardType": "package"
 }, {
@@ -362,7 +362,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/51bit/ColorBit",
     "cardType": "package"
 }, {
-    "name": "Kitronik Zip Tile",
+    "name": "Kitronik ZIP Tile",
     "url":"/pkg/KitronikLtd/pxt-kitronik-zip-tile",
     "cardType": "package"
 }, {
@@ -397,11 +397,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/Bouw-je-BEP/Bouw-je-BEP",
     "cardType": "package"
 }, {
-    "name": "DF Robot Maqueen Plus",
+    "name": "DFRobot micro:Maqueen Plus",
     "url":"/pkg/DFRobot/pxt-DFRobot-Maqueenplus",
     "cardType": "package"
 }, {
-    "name": "Joy IT Joy Car",
+    "name": "Joy-IT Joy-Car",
     "url":"/pkg/joy-it/Joy-Car",
     "cardType": "package"
 }, {
@@ -461,11 +461,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/elecfreaks/pxt-TPBot",
     "cardType": "package"
 }, {
-    "name": "DF Robot Maqueen",
+    "name": "DFRobot micro:Maqueen",
     "url":"/pkg/DFRobot/pxt-maqueen",
     "cardType": "package"
 }, {
-    "name": "Sunfounder Sloth",
+    "name": "SunFounder Sloth",
     "url":"/pkg/sunfounder/pxt-sloth",
     "cardType": "package"
 }, {
@@ -473,11 +473,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/sphero-inc/sphero-sdk-microbit-makecode",
     "cardType": "package"
 }, {
-    "name": "Sparkfun Moto:bit",
+    "name": "SparkFun moto:bit",
     "url":"/pkg/sparkfun/pxt-moto-bit",
     "cardType": "package"
 }, {
-    "name": "EBOTICS MIBO",
+    "name": "ebotics MIBO",
     "url":"/pkg/EBOTICS/pxt-eboticsMIBO",
     "cardType": "package"
 }, {
@@ -485,11 +485,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/alsrobot-microbit-makecode-packages/MiniCruise",
     "cardType": "package"
 }, {
-    "name": "ReroKit rero:micro",
+    "name": "ReRoKit rero:micro",
     "url":"/pkg/ReRoKit/pxt-reromicro",
     "cardType": "package"
 }, {
-    "name": "PLEN bit",
+    "name": "PLEN:bit",
     "url":"/pkg/plenprojectcompany/pxt-PLENbit",
     "cardType": "package"
 }, {
@@ -517,11 +517,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/Freenove/Makecode-Extension-Rover",
     "cardType": "package"
 }, {
-    "name": "Gigglebot",
+    "name": "GiggleBot",
     "url":"/pkg/dexterind/pxt-giggle",
     "cardType": "package"
 }, {
-    "name": "Robobit",
+    "name": "4tronix Robobit Buggy",
     "url":"/pkg/4tronix/Robobit",
     "cardType": "package"
 }, {
@@ -549,7 +549,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/1010Technologies/pxt-makerbit-motor",
     "cardType": "package"
 }, {
-    "name": "mikRobot",
+    "name": "mik:robot",
     "url":"/pkg/KS-Bulme/pxt-mikRobot",
     "cardType": "package"
 }, {
@@ -565,11 +565,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/KitronikLtd/pxt-kitronik-fischertechnik",
     "cardType": "package"
 }, {
-    "name": "Keigan Motor",
+    "name": "KeiganMotor",
     "url": "/pkg/keigan-motor/pxt-KeiganMotor",
     "cardType": "package"
 }, {
-    "name": "TCEA Nexus:bit and Nexusbot",
+    "name": "TCEA Nexus:bit and NexusBot",
     "url":"/pkg/beyond-coding-tw/pxt-nexusbot",
     "cardType": "package"
 }, {
@@ -581,7 +581,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/Veilkrand/pxt-RobotCar",
     "cardType": "package"  
 }, {
-    "name": "TinkerTanker Stepper Motor",
+    "name": "Tinkertanker Stepper Motor",
     "url":"/pkg/Tinkertanker/pxt-stepper-motor",
     "cardType": "package"
 }]
@@ -607,11 +607,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/MakeAndLearn/pxt-microshield",
     "cardType": "package"
 }, {
-    "name": "Sparkfun Weather:bit",
+    "name": "SparkFun weather:bit",
     "url":"/pkg/sparkfun/pxt-weather-bit",
     "cardType": "package"
 }, {
-    "name": "Sparkfun gator:environment",
+    "name": "SparkFun gator:environment",
     "url":"/pkg/sparkfun/pxt-gator-environment",
     "cardType": "package"
 }, {
@@ -619,11 +619,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/xinabox/pxt-SW01",
     "cardType": "package"
 }, {
-    "name": "Cytron Edubit",
+    "name": "Cytron EDU:BIT",
     "url":"/pkg/CytronTechnologies/pxt-edubit",
     "cardType": "package"
 }, {
-    "name": "Cytron Rekabit",
+    "name": "Cytron REKA:BIT",
     "url":"/pkg/CytronTechnologies/pxt-rekabit",
     "cardType": "package"
 }, {
@@ -631,15 +631,15 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/Imagimaker/pxt-imagimaker",
     "cardType": "package"
 }, {
-    "name": "Kitronik clip detector",
+    "name": "Kitronik Clip Detector",
     "url": "/pkg/KitronikLtd/pxt-kitronik-clip-detector",
     "cardType": "package"  
 }, {
-    "name": "Pimoroni Envirobit",
+    "name": "Pimoroni enviro:bit",
     "url": "/pkg/pimoroni/pxt-envirobit",
     "cardType": "package"
 }, {
-    "name": "Pimoroni Automationbit",
+    "name": "Pimoroni automation:bit",
     "url":"/pkg/pimoroni/pxt-automationbit",
     "cardType": "package"
 }, {
@@ -677,15 +677,15 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
-    "name": "Kitronik Klef Piano",
+    "name": "Kitronik :KLEF Piano",
     "url":"/pkg/KitronikLtd/pxt-kitronik-klef-piano",
     "cardType": "package"
 }, {
-    "name": "Catalex Serial MP3 Player v1.0",
+    "name": "Catalex Serial MP3 Player",
     "url": "/pkg/1010Technologies/pxt-makerbit-mp3",
     "cardType": "package"
 }, {
-    "name": "51bit DFPlayer mini",
+    "name": "51bit DFPlayer Mini",
     "url":"/pkg/51bit/dfplayermini",
     "cardType": "package" 
 }]
@@ -712,7 +712,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/bsiever/microbit-pxt-timeanddate",
     "cardType": "package"
 }, {
-    "name": "Kitronik Realtime Clock",
+    "name": "Kitronik Clock Board (RTC)",
     "url":"/pkg/KitronikLtd/pxt-kitronik-rtc",
     "cardType": "package"
 }, {
@@ -752,11 +752,11 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "url":"/pkg/pizayanz/pxt-linebeacon",
     "cardType": "package"
 }, {
-    "name": "Pimoroni Scrollbit",
+    "name": "Pimoroni scroll:bit",
     "url":"/pkg/pimoroni/pxt-scrollbit",
     "cardType": "package"
 }, {
-    "name": "SBRICK",
+    "name": "SBrick",
     "url":"/pkg/vengit/pxt-sbrick",
     "cardType": "package"
 }, {


### PR DESCRIPTION
* correct wrong links to "LEDs and lights" and "Machine learning" categories
* add missing cardboard category "Utilities"
* uniformize indentation in cardboards to 4 spaces
* stylize product/extension names
* correct wrong link to 1010Technologies MakerBit LCD1602 extension