### PR TITLE
Deprecate Eddystone APIs

### DIFF
--- a/docs/reference/bluetooth.md
+++ b/docs/reference/bluetooth.md
@@ -36,6 +36,14 @@ bluetooth.onUartDataReceived(",", () => {})
 
 ## Eddystone
 
+### ~ reminder
+
+#### Deprecated
+
+These blocks are deprecated. The Eddystone beacon format is no longer supported, see [Google Beacon format (Deprecated)](https://developers.google.com/beacons/eddystone).
+
+### ~
+
 ```cards
 bluetooth.advertiseUid(42, 1, 7, true);
 bluetooth.advertiseUrl("https://makecode.microbit.org/", 7, true);

--- a/docs/reference/bluetooth/advertise-uid-buffer.md
+++ b/docs/reference/bluetooth/advertise-uid-buffer.md
@@ -2,6 +2,18 @@
 
 Advertises a UID via the Eddystone protocol over Bluetooth.
 
+```sig
+bluetooth.advertiseUidBuffer(pins.createBuffer(16), 7, true);
+```
+
+### ~ reminder
+
+#### Deprecated
+
+This API is deprecated. The Eddystone beacon format is no longer supported, see [Google Beacon format (Deprecated)](https://developers.google.com/beacons/eddystone).
+
+### ~
+
 ## ~hint
 
 ## Eddystone
@@ -16,10 +28,6 @@ iBeacon is Apple's beacon message format. Eddystone comes from Google.
 Read more at https://lancaster-university.github.io/microbit-docs/ble/eddystone/ .
 
 ## ~
-
-```sig
-bluetooth.advertiseUidBuffer(pins.createBuffer(16), 7, true);
-```
 
 ## Parameters
 

--- a/docs/reference/bluetooth/advertise-uid.md
+++ b/docs/reference/bluetooth/advertise-uid.md
@@ -2,6 +2,18 @@
 
 Advertises a UID via the Eddystone protocol over Bluetooth.
 
+```sig
+bluetooth.advertiseUid(42, 1, 7, true);
+```
+
+### ~ reminder
+
+#### Deprecated
+
+This API is deprecated. The Eddystone beacon format is no longer supported, see [Google Beacon format (Deprecated)](https://developers.google.com/beacons/eddystone).
+
+### ~
+
 ## ~hint
 
 ## Eddystone
@@ -16,10 +28,6 @@ iBeacon is Apple's beacon message format. Eddystone comes from Google.
 Read more at https://lancaster-university.github.io/microbit-docs/ble/eddystone/ .
 
 ## ~
-
-```sig
-bluetooth.advertiseUid(42, 1, 7, true);
-```
 
 ## Parameters
 

--- a/docs/reference/bluetooth/advertise-url.md
+++ b/docs/reference/bluetooth/advertise-url.md
@@ -2,6 +2,18 @@
 
 Advertises a URL via the Eddystone protocol over Bluetooth.
 
+```sig
+bluetooth.advertiseUrl("https://makecode.microbit.org/", 7, true);
+```
+
+### ~ reminder
+
+#### Deprecated
+
+This API is deprecated. The Eddystone beacon format is no longer supported, see [Google Beacon format (Deprecated)](https://developers.google.com/beacons/eddystone).
+
+### ~
+
 ## ~hint
 
 ## Eddystone
@@ -16,10 +28,6 @@ iBeacon is Apple's beacon message format. Eddystone comes from Google.
 Read more at https://lancaster-university.github.io/microbit-docs/ble/eddystone/ .
 
 ## ~
-
-```sig
-bluetooth.advertiseUrl("https://makecode.microbit.org/", 7, true);
-```
 
 ## Parameters
 

--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -183,6 +183,7 @@ namespace bluetooth {
     //% blockId=eddystone_advertise_url block="bluetooth advertise url %url|with power %power|connectable %connectable"
     //% parts=bluetooth weight=11 blockGap=8
     //% help=bluetooth/advertise-url blockExternalInputs=1
+    //% hidden=1 deprecated=1
     void advertiseUrl(String url, int power, bool connectable) {
 #if CONFIG_ENABLED(MICROBIT_BLE_EDDYSTONE_URL)
         power = min(MICROBIT_BLE_POWER_LEVELS-1, max(0, power));
@@ -198,7 +199,7 @@ namespace bluetooth {
 	* @param power power level between 0 and 7, eg: 7
     * @param connectable true to keep bluetooth connectable for other services, false otherwise.
     */
-    //% parts=bluetooth weight=12 advanced=true
+    //% parts=bluetooth weight=12 advanced=true deprecated=1
     void advertiseUidBuffer(Buffer nsAndInstance, int power, bool connectable) {
 #if CONFIG_ENABLED(MICROBIT_BLE_EDDYSTONE_UID)        
         auto buf = nsAndInstance;
@@ -226,6 +227,7 @@ namespace bluetooth {
     //% blockId=eddystone_stop_advertising block="bluetooth stop advertising"
     //% parts=bluetooth weight=10
     //% help=bluetooth/stop-advertising advanced=true
+    //% hidden=1 deprecated=1
     void stopAdvertising() {
         uBit.bleManager.stopAdvertising();
     } 

--- a/libs/bluetooth/bluetooth.ts
+++ b/libs/bluetooth/bluetooth.ts
@@ -78,6 +78,7 @@ namespace bluetooth {
     //% blockId=eddystone_advertise_uid block="bluetooth advertise UID|namespace (bytes 6-9)%ns|instance (bytes 2-6)%instance|with power %power|connectable %connectable"
     //% parts=bluetooth weight=12 blockGap=8
     //% help=bluetooth/advertise-uid blockExternalInputs=1
+    //% hidden=1 deprecated=1
     export function advertiseUid(ns: number, instance: number, power: number, connectable: boolean) {
         const buf = pins.createBuffer(16);
         buf.setNumber(NumberFormat.Int32BE, 6, ns);

--- a/libs/bluetooth/shims.d.ts
+++ b/libs/bluetooth/shims.d.ts
@@ -109,7 +109,8 @@ declare namespace bluetooth {
      */
     //% blockId=eddystone_advertise_url block="bluetooth advertise url %url|with power %power|connectable %connectable"
     //% parts=bluetooth weight=11 blockGap=8
-    //% help=bluetooth/advertise-url blockExternalInputs=1 shim=bluetooth::advertiseUrl
+    //% help=bluetooth/advertise-url blockExternalInputs=1
+    //% hidden=1 deprecated=1 shim=bluetooth::advertiseUrl
     function advertiseUrl(url: string, power: int32, connectable: boolean): void;
 
     /**
@@ -118,7 +119,7 @@ declare namespace bluetooth {
      * @param power power level between 0 and 7, eg: 7
      * @param connectable true to keep bluetooth connectable for other services, false otherwise.
      */
-    //% parts=bluetooth weight=12 advanced=true shim=bluetooth::advertiseUidBuffer
+    //% parts=bluetooth weight=12 advanced=true deprecated=1 shim=bluetooth::advertiseUidBuffer
     function advertiseUidBuffer(nsAndInstance: Buffer, power: int32, connectable: boolean): void;
 
     /**
@@ -134,7 +135,8 @@ declare namespace bluetooth {
      */
     //% blockId=eddystone_stop_advertising block="bluetooth stop advertising"
     //% parts=bluetooth weight=10
-    //% help=bluetooth/stop-advertising advanced=true shim=bluetooth::stopAdvertising
+    //% help=bluetooth/stop-advertising advanced=true
+    //% hidden=1 deprecated=1 shim=bluetooth::stopAdvertising
     function stopAdvertising(): void;
 }
 


### PR DESCRIPTION
Deprecate Eddystone APIs due to [Google shutting down](https://developers.google.com/beacons/eddystone) it's support.

- [x] Reminder note added to reference pages that these are now deprecated APIs.
- [x] Add `deprecate` and `hidden` flag attributes to the decls.

Closes #3910