### PR TITLE
additianol logging, error catching on jacdac

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -342,7 +342,9 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             .then(() => this.recvPacketAsync())
             .then(resp => {
                 if (resp[0] != buf[0]) {
+                    pxt.tickEvent('hid.flash.cmderror', { req: buf[0], resp: resp[0] })
                     const msg = `bad dapCmd response: ${buf[0]} -> ${resp[0]}`
+
                     // in case we got an invalid response, try to get another response, in case the current
                     // response is a left-over from previous communications
                     log(msg + "; retrying")
@@ -375,8 +377,10 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                 .then(() => this.dapCmdNums(0x8A /* DAPLinkFlash.OPEN */, 1))
                 .then((res) => {
                     log(`daplinkflash open: ${pxt.U.toHex(res)}`)
-                    if (res[1] !== 0)
+                    if (res[1] !== 0) {
+                        pxt.tickEvent('hid.flash.full.error.open', { res: res[1] })
                         throw new Error(lf("Download failed, please try again"));
+                    }
                     const binFile = resp.outfiles[this.binName];
                     log(`bin file ${this.binName} in ${Object.keys(resp.outfiles).join(', ')}, ${binFile?.length || -1}b`)
                     const hexUint8 = pxt.U.stringToUint8Array(binFile);

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -148,7 +148,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             this.pendingSerial = buf.length ? buf : null
             if (this.pendingSerial) {
                 this.lastPendingSerial = Date.now()
-                logV(`pending serial ${this.pendingSerial.length}`)
+                //logV(`pending serial ${this.pendingSerial.length}`)
             }
         } else if (this.pendingSerial) {
             const d = Date.now() - this.lastPendingSerial

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -159,6 +159,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             try {
                 while (rid === this.readSerialId) {
                     const len = await this.readSerial()
+                    logV(`serial read ${len} bytes`)
                     const hasData = len > 0
                     await this.jacdacProcess(hasData)
                 }
@@ -675,26 +676,26 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
     private async jacdacSetup() {
         this.xchgAddr = null
         if (!this.useJACDAC) {
-            log(`jacdac disabled`)
+            log(`jacdac: disabled`)
             return
         }
         await pxt.Util.delay(700); // wait for the program to start and setup memory correctly
         const xchg = await this.findJacdacXchgAddr()
         if (xchg == null) {
-            log("no jacdac stack found")
+            log("jacdac: xchg address not found")
             return
         }
         const info = await this.readBytes(xchg, 16)
         this.irqn = info[8]
         if (info[12 + 2] != 0xff) {
-            console.error("invalid memory; try power-cycling the micro:bit")
+            log("jacdac: invalid memory; try power-cycling the micro:bit")
             console.debug({ info, xchg })
             return
         }
         this.xchgAddr = xchg
         // clear initial lock
         await this.writeWord(xchg + 12, 0)
-        log(`jacdac exchange address: 0x${xchg.toString(16)}; irqn=${this.irqn}`)
+        log(`jacdac: exchange address 0x${xchg.toString(16)}; irqn=${this.irqn}`)
     }
 
     private async triggerIRQ(irqn: number) {

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -105,7 +105,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
     private pendingSerial: Uint8Array
     private lastPendingSerial: number
 
-    private processSerial(line: Uint8Array) {
+    private processSerialLine(line: Uint8Array) {
         if (this.onSerial) {
             try {
                 // catch encoding bugs
@@ -129,9 +129,9 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             let beg = 0
             while (ptr < buf.length) {
                 if (buf[ptr] == 10 || buf[ptr] == 13) {
-                    const line = buf.slice(beg, ptr)
+                    const line = buf.slice(beg, ptr + 1)
                     if (line.length)
-                        this.processSerial(line);
+                        this.processSerialLine(line);
                     beg = ptr + 1
                 }
                 ptr++
@@ -145,7 +145,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         } else if (this.pendingSerial) {
             const d = Date.now() - this.lastPendingSerial
             if (d > 500) {
-                this.processSerial(this.pendingSerial)
+                this.processSerialLine(this.pendingSerial)
                 this.pendingSerial = null
             }
         }
@@ -495,11 +495,11 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                         this.checkAborted();
                         let b = changed[i];
                         if (b.targetAddr >= 0x10000000) {
-                            log(`target address ${b.targetAddr.toString(16)} > 0x10000000`)
-                            return Promise.resolve();
+                            log(`target address 0x${b.targetAddr.toString(16)} > 0x10000000`)
+                            //return Promise.resolve();
                         }
 
-                        log("about to write at 0x" + b.targetAddr.toString(16));
+                        log(`about to write at 0x${b.targetAddr.toString(16)}`);
 
                         let writeBl = Promise.resolve();
 

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -129,14 +129,19 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             let beg = 0
             while (ptr < buf.length) {
                 if (buf[ptr] == 10 || buf[ptr] == 13) {
-                    const line = buf.slice(beg, ptr + 1)
+                    ptr++;
+                    // eat \r\n
+                    while(ptr < buf.length && (buf[ptr] == 10 || buf[ptr] == 13))
+                        ptr++;
+                    const line = buf.slice(beg, ptr)
                     if (line.length)
                         this.processSerialLine(line);
-                    beg = ptr + 1
+                    beg = ptr
                 }
-                ptr++
+                else
+                    ptr++
             }
-            buf = buf.slice(ptr)
+            buf = buf.slice(beg)
             this.pendingSerial = buf.length ? buf : null
             if (this.pendingSerial) {
                 this.lastPendingSerial = Date.now()
@@ -161,8 +166,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                 while (rid === this.readSerialId) {
                     const len = await this.readSerial()
                     const hasData = len > 0
-                    if (hasData)
-                        logV(`serial read ${len} bytes`)
+                    //if (hasData)
+                    //    logV(`serial read ${len} bytes`)
                     await this.jacdacProcess(hasData)
                 }
                 log(`stopped serial reader ${rid}`)

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -305,6 +305,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             .then(() => this.checkStateAsync())
             .then(() => this.readUICR())
             .then(uicr => {
+                pxt.tickEvent("hid.flash.uicr", { uicr });
                 // shortcut, do a full flash
                 if (uicr != 0 || this.forceFullFlash) {
                     pxt.tickEvent("hid.flash.uicrfail");
@@ -313,6 +314,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                 // check flash checksums
                 return this.computeFlashChecksum(resp)
                     .then(chk => {
+                        pxt.tickEvent("hid.flash.checksum", { quick: chk.quick ? 1 : 0, changed: chk.changed ? chk.changed.length : 0 });
                         // let's do a quick flash!
                         if (chk.quick)
                             return this.quickHidFlashAsync(chk.changed);
@@ -321,6 +323,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                     });
             })
             .then(() => this.checkStateAsync(true))
+            .then(() => pxt.tickEvent("hid.flash.success"))
             .finally(() => { this.flashing = false })
         // don't disconnect here
         // the micro:bit will automatically disconnect and reconnect


### PR DESCRIPTION
- [x] integrate serial data reconstruction from jacdac-docs
```
basic.forever(function () {
    led.toggle(0, 0)
    serial.writeLine("hello")
    serial.writeLine("world")
})
```
- [x] catch any kind of decoding error on serial

```
led.plot(0,0)
basic.forever(function () {
    pause(500)
    const buf = pins.createBuffer(Math.randomRange(5, 60))
    for(let i = 0; i < buf.length; ++i)
        buf[i] = Math.randomRange(0, 255)
	serial.writeBuffer(buf)
    led.toggle(1, 0)
})
```
- [ ] add ticks