### PR TITLE
Include category links in block gallery page

### DIFF
--- a/docs/block-gallery.md
+++ b/docs/block-gallery.md
@@ -1,6 +1,54 @@
 # Blocks Gallery
 
-Listing of the blocks and their images for @boardname@.
+Gallery of the blocks and their images for @boardname@.
+
+## Categories
+
+```codecard
+[
+{
+  "name": "Basic",
+  "description": "Basic display and control blocks.",
+  "url": "/block-gallery#basic"
+},{
+  "name": "Input",
+  "description": "Events and data from buttons and sensors.",
+  "url": "/block-gallery#input"
+},{
+  "name": "Music",
+  "description": "Generation of tones and melodies.",
+  "url": "/block-gallery#music"
+},{
+  "name": "Led",
+  "description": "Display information and images on the LED screen.",
+  "url": "/block-gallery#led"
+},{
+  "name": "Radio",
+  "description": "Transmit and receive data with the radio.",
+  "url": "/block-gallery#radio"
+},{
+  "name": "Game",
+  "description": "Control sprites and keep score in games.",
+  "url": "/block-gallery#game"
+},{
+  "name": "Images",
+  "description": "Create pixel images to display on the LED screen.",
+  "url": "/block-gallery#images"
+},{
+  "name": "Pins",
+  "description": "Read from and write data to the pins on the board.",
+  "url": "/block-gallery#pins"
+},{
+  "name": "Serial",
+  "description": "Use the serial connection to read and write data.",
+  "url": "/block-gallery#serial"
+},{
+  "name": "Control",
+  "description": "Use timers and custom events in programs.",
+  "url": "/block-gallery#control"
+}
+]
+```
 
 ## Basic
 


### PR DESCRIPTION
Add in a category header to ease browsing of block gallery. Requested by @microbit-mark.

RE: #2139

