### PR TITLE
Sync USB OS version level with browser page

### DIFF
--- a/docs/device/usb.md
+++ b/docs/device/usb.md
@@ -29,8 +29,10 @@ Here are instructions for different browsers on Windows and Mac computers. Choos
 * [Chrome](/device/usb/mac-chrome)
 * [Firefox](/device/usb/mac-firefox)
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/mac-chrome.md
+++ b/docs/device/usb/mac-chrome.md
@@ -16,7 +16,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A Mac running OS X 10.9 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -61,9 +61,10 @@ By copying the script onto the `MICROBIT` drive, you have programmed it into the
 flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
+### ~hint
 
-## ~hint
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/mac-firefox.md
+++ b/docs/device/usb/mac-firefox.md
@@ -16,7 +16,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A Mac running OS X 10.9 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -64,8 +64,10 @@ By copying the script onto the `MICROBIT` drive, you have programmed it into the
 flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/mac-safari.md
+++ b/docs/device/usb/mac-safari.md
@@ -16,7 +16,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A Mac running OS X 10.9 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -61,8 +61,10 @@ flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/windows-chrome.md
+++ b/docs/device/usb/windows-chrome.md
@@ -24,7 +24,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A PC running Windows 7 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -85,8 +85,10 @@ Alternatively, right-click on the hex file, choose **Send to**, and then **MICRO
    flash memory on the micro:bit, which means even after you unplug the micro:bit,
    your program will still run if the micro:bit is powered by battery.
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/windows-edge.md
+++ b/docs/device/usb/windows-edge.md
@@ -18,7 +18,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A PC running Windows 7 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -65,8 +65,10 @@ By copying the script onto the `MICROBIT` drive, you have programmed it into the
 flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/windows-firefox.md
+++ b/docs/device/usb/windows-firefox.md
@@ -18,7 +18,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A PC running Windows 7 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -64,8 +64,10 @@ By copying the script onto the `MICROBIT` drive, you have programmed it into the
 flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~

--- a/docs/device/usb/windows-ie.md
+++ b/docs/device/usb/windows-ie.md
@@ -17,7 +17,7 @@ You need the following things to transfer and run a script on your micro:bit:
 
 * A-Male to Micro USB cable to connect your computer to your micro:bit. This is
     the same cable that is commonly used to connect a smart phone to a computer.
-* A PC running Windows 7 or later, or a Mac running OS X 10.6 or later
+* A PC running Windows 7 or later.
 
 ## Step 1: Connect your micro:bit to your computer
 
@@ -63,8 +63,10 @@ flash memory on the micro:bit, which means even after you unplug the micro:bit,
 your program will still run if the micro:bit is powered by battery.
 
 
-## ~hint
+### ~hint
+
+#### Transfer problems?
 
 Transfer not working? See some [troubleshooting tips](/device/usb/troubleshoot).
 
-## ~
+### ~


### PR DESCRIPTION
Edits to harmonize the USB OS X version level in the `device/usb` pages with the [browsers](https://makecode.microbit.org/browsers) page.

- [x] Setting the OS X minimum version to **10.9** to match the min version in the browsers page.

Closes #3315

RE: https://github.com/microsoft/pxt/pull/8030