### PR TITLE
-ignore two files that are intended to have gray blocks

### DIFF
--- a/docs/courses/blocks-to-javascript/conditional-loops.md
+++ b/docs/courses/blocks-to-javascript/conditional-loops.md
@@ -79,7 +79,7 @@ let count = 0
 } while (count < 5)
 ```
 
-You'll have a squiggle at the end of the line with ``} while (count < 5)`` which means we have invalid code. Don't worry, we'll fix that right now! At the beginning of the loop, insert the word ``do`` just before left brace `{`. The error should go away and the simulator will count from `0` to `4` just like before when the word ``while`` was at the beginning of the loop. 
+You'll have a squiggle at the end of the line with ``} while (count < 5)`` which means we have invalid code. Don't worry, we'll fix that right now! At the beginning of the loop, insert the word ``do`` just before left brace `{`. The error should go away and the simulator will count from `0` to `4` just like before when the word ``while`` was at the beginning of the loop.
 
 ```typescript
 let count = 0
@@ -115,7 +115,7 @@ for (let index = 4; index >= 0; index--) {
 
 You'll now see in the simulator that the value displayed on the screen counts down from `4` to `0`. This form of the **for** loop is too complicatied for blocks so when you switch back to the Blocks editor the entire loop is shown in a grey block.
 
-```block
+```block-ignore
 for (let index = 4; index >= 0; index--) {
     basic.showNumber(index)
     basic.pause(500)
@@ -196,4 +196,4 @@ for (let index = 0; index < 5; index++) {
 }
 ```
 
-Ah! Our original ``||loops:repeat||`` loop changed to a ``||loops:for||`` loop! Why? Well, this is because the code inside the loop used the index from the loop statement. This makes the loop more complex and it's no longer just simply repeating what's inside of it. 
+Ah! Our original ``||loops:repeat||`` loop changed to a ``||loops:for||`` loop! Why? Well, this is because the code inside the loop used the index from the loop statement. This makes the loop more complex and it's no longer just simply repeating what's inside of it.

--- a/docs/courses/blocks-to-javascript/starter-blocks.md
+++ b/docs/courses/blocks-to-javascript/starter-blocks.md
@@ -81,13 +81,13 @@ input.onButtonPressed(Button.A, function () {
 ## Grey blocks are a good sign!
 
 If you start to write more complex JavaScript (it's great that you are!), MakeCode might not be able to convert it back to blocks. In that case, you will see _grey blocks_ in your block code. They represent chunks of JavaScript that are too complicated for blocks.
- 
+
 * Go back to **JavaScript** and add a second frame to create animation. This is something you can do in JavaScript but not in blocks.
 
 ```typescript
 input.onButtonPressed(Button.A, function () {
     basic.showLeds(`
-        . . . . .    . . . . . 
+        . . . . .    . . . . .
         . . # . .    . # # # .
         . # # # .    . # # # .
         . . # . .    . # # # .
@@ -98,10 +98,10 @@ input.onButtonPressed(Button.A, function () {
 
 * Go to the **Blocks** editor and you will see a big **grey** block in the button handler. This is because you are creating code too complex for the blocks. Take it as a compliment!
 
-```blocks
+```blocks-ignore
 input.onButtonPressed(Button.A, function () {
     basic.showLeds(`
-        . . . . .    . . . . . 
+        . . . . .    . . . . .
         . . # . .    . # # # .
         . # # # .    . # # # .
         . . # . .    . # # # .


### PR DESCRIPTION
in https://github.com/microsoft/pxt/pull/8034 I'm fixing a check which was intended to note errors on blocks snippets that contain gray blocks. appending -ignore to these two snippets that do intentionally contain gray blocks to avoid failing when that gets merged in