### PR TITLE
add support for meta "v2" part

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -305,7 +305,9 @@
 
                 "builtinspeaker",
                 "microphone",
-                "logotouch"
+                "logotouch",
+
+                "v2"
             ],
             "pinStyles": {
                 "P0": "croc",

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -135,7 +135,12 @@ namespace pxsim {
             const cmpDefs = msg.partDefinitions || {};
             const fnArgs = msg.fnArgs;
 
-            const v2Parts: pxt.Map<boolean> = { "microphone": true, "logotouch": true, "builtinspeaker": true };
+            const v2Parts: pxt.Map<boolean> = { 
+                "microphone": true, 
+                "logotouch": true, 
+                "builtinspeaker": true,
+                "v2": true
+            };
             if (msg.builtinParts) {
                 const v2PartsUsed = msg.builtinParts.filter(k => v2Parts[k])
                 if (v2PartsUsed.length) {


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/8065

Allow a library writer to specify that a function requires the v2 micro:bit, without having to make a dummy call to a v2 feature. This will be used by Jacdac.