### PR TITLE
Purple tutorial theme

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -32,7 +32,7 @@
 --------------------*/
 
 @mainMenuInvertedBackground: @blue;
-@mainMenuTutorialBackground: @orange;
+@mainMenuTutorialBackground: @purple;
 
 @mainMenuBlocksJsToggleColor: @primaryColor;
 

--- a/theme/style.less
+++ b/theme/style.less
@@ -62,19 +62,20 @@
         background-position: 50% 25%;
     }
 
-    .detailview .actions .card-action .button.approve {
-        background-color: @mainMenuTutorialBackground;
+    .detailview .actions .card-action {
+        .button.approve {
+            background-color: @mainMenuTutorialBackground;
+        }
+
+        &:first-child .button.approve {
+            background-color: @green;
+        }
+
     }
     .tutorial-progress.orange {
         background-color: @mainMenuTutorialBackground !important;
         border-color: @mainMenuTutorialBackground !important;
     }
-}
-
-.hc #homescreen .ui.home .tutorial-progress.orange {
-    border-color: @HCtextColor !important;
-    background-color: @HCbackground !important;
-    color: @HCtextColor !important;
 }
 
 #tutorialcard {

--- a/theme/style.less
+++ b/theme/style.less
@@ -66,11 +66,6 @@
         .button.approve {
             background-color: @mainMenuTutorialBackground;
         }
-
-        &:first-child .button.approve {
-            background-color: @green;
-        }
-
     }
     .tutorial-progress.orange {
         background-color: @mainMenuTutorialBackground !important;
@@ -82,7 +77,7 @@
     .ui.button.orange.right.attached {
         background-color: @mainMenuTutorialBackground;
         &:focus, &:hover {
-            background-color: darken(@mainMenuTutorialBackground, 20%)
+            background-color: darken(@mainMenuTutorialBackground, 20%);
         }
     }
 }

--- a/theme/style.less
+++ b/theme/style.less
@@ -46,7 +46,7 @@
 }
 
 .ui.button.exit-tutorial-btn {
-    &:extend(.ui.blue.button all);
+    &:extend(.ui.inverted.button all);
 }
 
 #filelist, #editortools {
@@ -65,6 +65,16 @@
         &:first-child .button.approve {
             background-color: lighten(@primaryColor, 10%);
         }
+    }
+
+    .detailview .actions .card-action .button.approve {
+        background-color: @mainMenuTutorialBackground;
+    }
+
+
+    .tutorial-progress.orange {
+        background-color: @mainMenuTutorialBackground !important;
+        border-color: @mainMenuTutorialBackground !important;
     }
 }
 
@@ -106,15 +116,15 @@
             justify-content: center;
             display: flex;
             padding: 1rem;
-    
+
             img {
-                height:100px;            
+                height:100px;
             }
         }
     }
     .instructions {
         img {
-            margin-bottom:1rem;            
+            margin-bottom:1rem;
         }
     }
 }

--- a/theme/style.less
+++ b/theme/style.less
@@ -82,6 +82,18 @@
     }
 }
 
+#root:not(.hc) .tutorial-menu {
+    .ui.circular.label.selected {
+        background-color: @purple !important;
+        color: #e8e8e8 !important;
+        border: 1px solid #e8e8e8 !important;
+
+        &:focus, &:hover {
+            background-color: darken(@purple, 20%) !important;
+        }
+    }
+}
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
     #filelist {

--- a/theme/style.less
+++ b/theme/style.less
@@ -68,10 +68,8 @@
     }
 
     .detailview .actions .card-action .button.approve {
-        background-color: @mainMenuTutorialBackground;
+        background-color: @mainMenuTutorialBackground !important;
     }
-
-
     .tutorial-progress.orange {
         background-color: @mainMenuTutorialBackground !important;
         border-color: @mainMenuTutorialBackground !important;

--- a/theme/style.less
+++ b/theme/style.less
@@ -57,22 +57,32 @@
     background: transparent !important;
 }
 
-.ui.home {
+#homescreen .ui.home {
     .getting-started-segment {
         background-position: 50% 25%;
     }
-    .detailview .actions .card-action {
-        &:first-child .button.approve {
-            background-color: lighten(@primaryColor, 10%);
-        }
-    }
 
     .detailview .actions .card-action .button.approve {
-        background-color: @mainMenuTutorialBackground !important;
+        background-color: @mainMenuTutorialBackground;
     }
     .tutorial-progress.orange {
         background-color: @mainMenuTutorialBackground !important;
         border-color: @mainMenuTutorialBackground !important;
+    }
+}
+
+.hc #homescreen .ui.home .tutorial-progress.orange {
+    border-color: @HCtextColor !important;
+    background-color: @HCbackground !important;
+    color: @HCtextColor !important;
+}
+
+#tutorialcard {
+    .ui.button.orange.right.attached {
+        background-color: @mainMenuTutorialBackground;
+        &:focus, &:hover {
+            background-color: darken(@mainMenuTutorialBackground, 20%)
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in design office hours, the orange is jarring & is very inaccessible / conflicts with other editor colors. This switches the tutorial colors to be the microbit purple colors as we had talked about there

* fix https://github.com/microsoft/pxt-microbit/issues/3949
* fix https://github.com/microsoft/pxt-microbit/issues/2290
* fix color bunch of colors: tutorial preview in my projects gallery, detail view, tutorial buttons, etc (no issue filed but is currently inaccessible)

build: https://makecode.microbit.org/app/8674fc02997b6643600aa3d7182a320ea5887d60-f82ef95661

![image](https://user-images.githubusercontent.com/5615930/114254079-3336b480-9962-11eb-8092-8fa20e818bce.png)
![image](https://user-images.githubusercontent.com/5615930/114246181-d4177680-9946-11eb-9f10-cbcbecc35c50.png)
![image](https://user-images.githubusercontent.com/5615930/114246247-ff01ca80-9946-11eb-9d99-0406273a18d1.png)
![image](https://user-images.githubusercontent.com/5615930/114248673-1fcd1e80-994d-11eb-810a-a2e9e2dfd21a.png)

