### PR TITLE
Enable multiple custom files

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -376,6 +376,7 @@
         "ignoreDocsErrors": false,
         "errorList": true,
         "allowPackageExtensions": true,
+        "addNewTypeScriptFile": true,
         "experiments": [
             "accessibleBlocks",
             "debugExtensionCode",


### PR DESCRIPTION
turns the addNewTypeScriptFile flag on, fixes https://github.com/microsoft/pxt-microbit/issues/3345