### PR TITLE
jacdac: update iframe flags

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -213,8 +213,8 @@
         "partsAspectRatio": 0.69,
         "messageSimulators": {
             "jacdac": {
-                "url": "https://microsoft.github.io/jacdac-docs/tools/makecode-sim?webusb=0&webble=0&parentOrigin=$PARENT_ORIGIN$",
-                "localHostUrl": "http://localhost:8000/tools/makecode-sim?webusb=0&webble=0&parentOrigin=$PARENT_ORIGIN$",
+                "url": "https://microsoft.github.io/jacdac-docs/tools/makecode-sim?parentOrigin=$PARENT_ORIGIN$",
+                "localHostUrl": "http://localhost:8000/tools/makecode-sim?parentOrigin=$PARENT_ORIGIN$",
                 "aspectRatio": 1.22,
                 "permanent": true
             }

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -213,8 +213,8 @@
         "partsAspectRatio": 0.69,
         "messageSimulators": {
             "jacdac": {
-                "url": "https://microsoft.github.io/jacdac-docs/tools/makecode-sim?webusb=0&parentOrigin=$PARENT_ORIGIN$",
-                "localHostUrl": "http://localhost:8000/tools/makecode-sim?webusb=0&parentOrigin=$PARENT_ORIGIN$",
+                "url": "https://microsoft.github.io/jacdac-docs/tools/makecode-sim?webusb=0&webble=0&parentOrigin=$PARENT_ORIGIN$",
+                "localHostUrl": "http://localhost:8000/tools/makecode-sim?webusb=0&webble=0&parentOrigin=$PARENT_ORIGIN$",
                 "aspectRatio": 1.22,
                 "permanent": true
             }

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -250,7 +250,7 @@
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },
         "approvedEditorExtensionUrls": [
-            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension"
+            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension?webusb=0&webble=0"
         ]
     },
     "galleries": {

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -250,7 +250,7 @@
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },
         "approvedEditorExtensionUrls": [
-            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension?webusb=0&webble=0"
+            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension?parentOrigin=$PARENT_ORIGIN$"
         ]
     },
     "galleries": {


### PR DESCRIPTION
Don't turn on webble when loading jacdac iframe