### PR TITLE
Use the correct category on 'forvever' in Light Level Meter

### DIFF
--- a/docs/projects/light-level-meter.md
+++ b/docs/projects/light-level-meter.md
@@ -7,7 +7,7 @@ to detect the amount of light.
 
 ## Save a reading
 
-Create a variable, ``||variables:reading||``, to set to the current ``||input:light level||`` inside the ``||loops:forever||`` loop.
+Create a variable, ``||variables:reading||``, to set to the current ``||input:light level||`` inside the ``||basic:forever||`` loop.
 
 ```blocks
 let reading = 0


### PR DESCRIPTION
Block styling had the 'loops' category rather than 'basic' on the forever block name in the Step 1 text.

Fixes #4044