### PR TITLE
Change 'see also' links in stopAnimation page

### DIFF
--- a/docs/reference/led/stop-animation.md
+++ b/docs/reference/led/stop-animation.md
@@ -29,4 +29,4 @@ to go.
 
 ## See Also
 
-[show animation](/reference/basic/show-animation)
+[show leds](/reference/basic/show-leds), [show icon](/reference/basic/show-icon), [plot](/reference/led/plot)


### PR DESCRIPTION
The 'showAnimation' page was removed in #3934 but this page (stop-animation.md) had a link to it remaining. 

The `stopAnimation` function remains as a block to service stopping the other `showXxx` blocks as they use scrolling, which is a display animate feature.

Fixes #4056