### PR TITLE
define hero banner as card

### DIFF
--- a/docs/hero-banner.md
+++ b/docs/hero-banner.md
@@ -1,0 +1,33 @@
+# Hero Banner
+
+Here are some cool activities to get you started with your @boardname@!
+
+## Basic
+
+### ~ codecard
+* name: Intro to micro:bit
+* description: Introduction to the BBC micro:bit
+* imageUrl: /static/mb/projects/name-tag.png
+* url: https://microbit.org/get-started/first-steps/introduction/
+* cardType: link
+---
+* name: Behind the MakeCode Hardware
+* description: Behind the MakeCode Hardware
+* imageUrl: /static/mb/science-experiments/data-collection.jpg
+* youTubePlaylistId: PLMMBk9hE-SeqDYtw9pGNPsQ10V_EGMyGe
+---
+* name: Fun with Radio
+* description: Send messages with your micro:bit
+* imageUrl: /static/mb/projects/a9-radio.png
+* url: /projects/micro-chat
+* cardType: tutorial
+---
+* name: Soil Moisture Project
+* description: Track the soil moisture of your plants!
+* imageUrl: /static/mb/projects/soilmoisture.jpg
+* url: /projects/soil-moisture
+### ~
+
+
+
+* youTubeId: qqBmvHD5bCw

--- a/docs/hero-banner.md
+++ b/docs/hero-banner.md
@@ -2,7 +2,7 @@
 
 Here are some cool activities to get you started with your @boardname@!
 
-## Basic
+## Intro Content
 
 ### ~ codecard
 * name: Intro to micro:bit
@@ -27,7 +27,3 @@ Here are some cool activities to get you started with your @boardname@!
 * imageUrl: /static/mb/projects/soilmoisture.jpg
 * url: /projects/soil-moisture
 ### ~
-
-
-
-* youTubeId: qqBmvHD5bCw

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -364,7 +364,7 @@
             "description": "New? Start here!",
             "cardType": "tutorial"
         },
-        "homeScreenHeroGallery": "/tutorials",
+        "homeScreenHeroGallery": "/hero-banner",
         "homeUrl": "https://makecode.microbit.org/",
         "embedUrl": "https://makecode.microbit.org/",
         "shareUrl": "https://makecode.microbit.org/",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -357,7 +357,13 @@
         "organizationUrl": "https://makecode.com/",
         "organizationLogo": "./static/Microsoft-logo_rgb_c-gray-square.png",
         "organizationWideLogo": "./static/Microsoft-logo_rgb_c-white.png",
-        "homeScreenHero": "./static/hero.png",
+        "homeScreenHero": {
+            "imageUrl": "/static/hero.png",
+            "name": "Flashing Heart",
+            "url": "/projects/flashing-heart",
+            "description": "New? Start here!",
+            "cardType": "tutorial"
+        },
         "homeScreenHeroGallery": "/tutorials",
         "homeUrl": "https://makecode.microbit.org/",
         "embedUrl": "https://makecode.microbit.org/",


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/8171

define the card for the initial hero banner, as well as the hero gallery. (This may change whenever we get the final banner gallery contents decided, but just want the change in for testing tomorrow.)

(just pointed at random imageUrls that are loosely connected for now but we'll be getting more banners from sonia before release).