### PR TITLE
Change snippet types in 'Complex Conditionals' page

### DIFF
--- a/docs/courses/blocks-to-javascript/complex-conditionals.md
+++ b/docs/courses/blocks-to-javascript/complex-conditionals.md
@@ -71,9 +71,9 @@ basic.forever(function () {
 
 The two ``||input:button is pressed||`` blocks are connected with an ``||logic:or||`` in the ``||logic:if then||`` conditional to make the check to see if one of the two buttons is currently pressed.
 
-Looking at the condition inside the ``if`` statement in JavaScript editor, we see that the two conditions are connected with the OR (``||``) operator which makes the condition `true` if either button is pressed. So, the conditions work in _parallel_.
+Looking at the condition inside the ``if`` statement in the JavaScript editor, we see that the two conditions are connected with the OR (``||``) operator which makes the condition `true` if either button is pressed. So, the conditions work in _parallel_.
 
-```typescript
+```typescript-ignore
 if (input.buttonIsPressed(Button.A) || input.buttonIsPressed(Button.B)) {
     basic.showIcon(IconNames.Square)
 }
@@ -115,7 +115,7 @@ let cold = input.temperature() < 10
 
 In the JavaScript editor, this block appears as this simple variable assignment:
 
-```typescript
+```typescript-ignore
 let cold = input.temperature() < 10
 ```
 


### PR DESCRIPTION
Switch snippet types for the simple, illustrative, code block analogs to ```` ```typescript-ignore ````. Since they aren't intended to be complete programs, the reader is prevented from trying to run them in the embedded sim.

Fixes #4065 