### PR TITLE
Insert missing melody/music ref pages

### DIFF
--- a/docs/reference/music/note-frequency.md
+++ b/docs/reference/music/note-frequency.md
@@ -1,0 +1,31 @@
+# note Frequency
+
+Get the frequency of a musical note.
+
+```sig
+music.noteFrequency(Note.C)
+```
+
+## Parameters
+
+* ``name`` is the name of the **Note** you want a frequency value for.
+
+## Returns
+
+* a [number](/types/number) that is the frequency (in [Hertz](https://wikipedia.org/wiki/Hertz))
+of a note you chose.
+
+## Example #example
+
+Play a 'C' note for one second, rest for one second, and then play an 'A' note for one second.
+
+```blocks
+music.playTone(music.noteFrequency(Note.C), 1000)
+music.rest(1000)
+music.playTone(music.noteFrequency(Note.A), 1000)
+```
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/docs/reference/music/play-melody.md
+++ b/docs/reference/music/play-melody.md
@@ -1,0 +1,38 @@
+# play Melody
+
+Play a short melody of notes composed in a string.
+
+```sig
+music.playMelody("", 120);
+```
+
+The melody is short series of notes composed in a string. The melody is played at a rate set by the **tempo** value you give. The melody string contains a sequence of notes formatted like this:
+
+``"E B C5 A B G A F "``
+
+The melody is shown in the ``||music:play melody||`` block as note symbols which also appear in the Melody Editor.
+
+```block
+music.playMelody("E B C5 A B G A F ", 120);
+```
+
+The melodies are most often created in the Melody Editor from the block so that valid notes are chosen and the correct melody length is set.
+
+## Parameters
+
+* **melody**: a [string](/types/string) which contains the notes of the melody.
+* **tempo**: a [number](/types/number) which is the rate to play the melody at in beats per minute.
+
+## Example #example
+
+Play the ``Mystery`` melody continuously.
+
+```blocks
+basic.forever(function () {
+    music.playMelody("E F G F E G B C5 ", 120)
+})
+```
+
+## See also #seealso
+
+[set tempo](/reference/music/set-tempo), [play](/reference/music/play), [play until done](/reference/music/play-until-done)

--- a/docs/reference/music/stop-all-sounds.md
+++ b/docs/reference/music/stop-all-sounds.md
@@ -1,0 +1,34 @@
+# stop All Sounds
+
+Stop all the sounds that are playing right now and any others waiting to play.
+
+```sig
+music.stopAllSounds()
+```
+
+If you play sounds or sound effects more than once, the sounds you asked to play later have to wait until the sounds played earlier finish. You can stop the sound that is playing now and all the sounds waiting to play with ``||music:stop all sounds||``.
+
+## #simnote
+
+### ~hint
+
+#### Simulator
+
+``||music:stop all sounds||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
+
+## Example #example
+
+Play a tone but stop it right away.
+
+```blocks
+let freq = music.noteFrequency(Note.C);
+music.playTone(freq, 1000)
+music.stopAllSounds()
+```
+
+## See also #seealso
+
+[play melody](/reference/music/play-melody), [play](/reference/music/play),
+[play tone](/reference/music/play-tone)


### PR DESCRIPTION
Pirate a few docs from [pxt-common-packages](https://github.com/microsoft/pxt-common-packages/tree/master/libs/music/docs/reference/music) (with slight mods) to fill in the missing `music` ref pages.

Closes #4073