### PR TITLE
lower bluetooth to last of built in exts

### DIFF
--- a/libs/bluetooth/pxt.json
+++ b/libs/bluetooth/pxt.json
@@ -10,6 +10,7 @@
         "BLEHF2Service.h",
         "BLEHF2Service.cpp"
     ],
+    "weight": 10,
     "icon": "./static/packages/bluetooth/icon.png",
     "public": true,
     "dependencies": {

--- a/libs/bluetooth/pxt.json
+++ b/libs/bluetooth/pxt.json
@@ -11,6 +11,7 @@
         "BLEHF2Service.cpp"
     ],
     "weight": 10,
+    "searchOnly": true,
     "icon": "./static/packages/bluetooth/icon.png",
     "public": true,
     "dependencies": {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3933

This drops it down to be the last of the built in extensions (for reference, [default weight=50](https://github.com/microsoft/pxt/blob/e46205c8a3bbc245687d7daccfd79daa6214f247/webapp/src/scriptsearch.tsx#L356)). Also added a flag so that it only shows up after a search has been started, which requires https://github.com/microsoft/pxt/pull/8207 to do anything but is fine to merge before that gets bumped in.