### PR TITLE
Support the incompatible hardware dialog in pxt-core

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -218,6 +218,13 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         return (this.usesCODAL ? "mbcodal-" : "mbdal-") + pxtc.BINARY_HEX;
     }
 
+    unsupportedParts() {
+        if (!this.usesCODAL) {
+            return ["logotouch", "builtinspeaker", "microphone", "flashlog"]
+        }
+        return [];
+    }
+
     async reconnectAsync(): Promise<void> {
         log(`reconnect`)
         this.flashAborted = false;

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -16,6 +16,7 @@ class SoundExpression {
     //% blockGap=8
     //% help=music/play
     //% group="micro:bit (V2)"
+    //% parts=builtinspeaker
     play() {
         music.__playSoundExpression(this.notes, false)
     }
@@ -28,6 +29,7 @@ class SoundExpression {
     //% blockGap=8
     //% help=music/play-until-done
     //% group="micro:bit (V2)"
+    //% parts=builtinspeaker
     playUntilDone() {
         music.__playSoundExpression(this.notes, true)
     }

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -585,6 +585,7 @@
             "downloadHelpURL" : "/device/usb",
             "firmwareHelpURL": "/device/usb/webusb/troubleshoot",
             "troubleshootWebUSBHelpURL": "/device/usb/webusb/troubleshoot",
+            "incompatibleHardwareHelpURL": "/device/v2",
 
             "dragFileImage": "/static/download/transfer.png",
             "connectDeviceImage": "/static/download/connect.png",


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/8213 but safe to merge now.

Adds the necessary code to make that dialog show up. Also adds missing parts tags for the sound expression apis