### PR TITLE
API to fetch microbit version 

### DIFF
--- a/docs/reference/control.md
+++ b/docs/reference/control.md
@@ -4,7 +4,7 @@ Runtime and event utilities.
 
 ```cards
 control.inBackground(() => {
-    
+
 });
 control.reset();
 control.waitMicros(4);
@@ -12,6 +12,7 @@ control.onEvent(0, 0, () => { });
 control.raiseEvent(0, 0);
 control.eventTimestamp();
 control.eventValue();
+control.hardwareVersion();
 ```
 
 ## See Also

--- a/docs/reference/control/hardware-version.md
+++ b/docs/reference/control/hardware-version.md
@@ -1,0 +1,7 @@
+# WaitMicros
+
+Returns the major version of the microbit.
+
+```sig
+control.hardwareVersion()
+```

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -334,6 +334,18 @@ namespace control {
     }
 
     /**
+     * Returns the major version of the microbit
+     */
+    //% help=control/hardware-version
+    int hardwareVersion() {
+        #if MICROBIT_CODAL
+            return 2;
+        #else
+            return 1;
+        #endif
+    }
+
+    /**
     * Derive a unique, consistent serial number of this device from internal data.
     */
     //% blockId="control_device_serial_number" block="device serial number" weight=9

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -337,7 +337,7 @@ namespace control {
      * Returns the major version of the microbit
      */
     //% help=control/hardware-version
-    int hardwareVersion() {
+    int _hardwareVersion() {
         #if MICROBIT_CODAL
             return 2;
         #else

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -132,6 +132,11 @@ namespace control {
             t += 0x3fffffff
         return t
     }
+
+    //% shim=control::hardwareVersion
+    export function hardwareVersion(): number {
+        return 2;
+    }
 }
 
 /**

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -133,7 +133,7 @@ namespace control {
         return t
     }
 
-    //% shim=control::hardwareVersion
+    //% shim=control::_hardwareVersion
     export function hardwareVersion(): number {
         return 2;
     }

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -444,6 +444,12 @@ declare namespace control {
     function deviceName(): string;
 
     /**
+     * Returns the major version of the microbit
+     */
+    //% help=control/hardware-version shim=control::hardwareVersion
+    function hardwareVersion(): int32;
+
+    /**
      * Derive a unique, consistent serial number of this device from internal data.
      */
     //% blockId="control_device_serial_number" block="device serial number" weight=9
@@ -486,12 +492,6 @@ declare namespace control {
     function dmesgPtr(str: string, ptr: Object): void;
 }
 declare namespace control {
-
-    /**
-     * Dump internal information about a value.
-     */
-    //% shim=control::dmesgValue
-    function dmesgValue(v: any): void;
 
     /**
      * Force GC and dump basic information about heap.

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -494,6 +494,12 @@ declare namespace control {
 declare namespace control {
 
     /**
+     * Dump internal information about a value.
+     */
+    //% shim=control::dmesgValue
+    function dmesgValue(v: any): void;
+
+    /**
      * Force GC and dump basic information about heap.
      */
     //% shim=control::gc
@@ -1012,7 +1018,7 @@ declare namespace serial {
     function writeBuffer(buffer: Buffer): void;
 
     /**
-     * Read multiple characters from the receive buffer. 
+     * Read multiple characters from the receive buffer.
      * If length is positive, pauses until enough characters are present.
      * @param length default buffer length
      */

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -446,8 +446,8 @@ declare namespace control {
     /**
      * Returns the major version of the microbit
      */
-    //% help=control/hardware-version shim=control::hardwareVersion
-    function hardwareVersion(): int32;
+    //% help=control/hardware-version shim=control::_hardwareVersion
+    function _hardwareVersion(): int32;
 
     /**
      * Derive a unique, consistent serial number of this device from internal data.


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3743

wasn't sure if i should be checkin in shims.d.ts, but it looked like it had recent changes so here it is.

Returning as a number bc that makes the most sense with just v1 and v2. It will be difficult to deal with if we ever do add minor versions too, but right now we don't have a good way to find that out! But lemme know if you think it should be...a string instead?