### PR TITLE
Open Step Counter tutorial links in a new tab

### DIFF
--- a/docs/projects/step-counter.md
+++ b/docs/projects/step-counter.md
@@ -6,7 +6,7 @@
 
 This project turns the @boardname@ into a simple step counter. A step counter is also known as a pedometer. Each **shake** event increments a **counter** variable. The step count is displayed on the LEDs.
 
-If you built a watch in the [make](/projects/watch/make) portion of the of the [Watch](/projects/watch) project, you can use the code from this project with it too.
+If you built a watch in the [make](https://makecode.microbit.org/projects/watch/make) portion of the of the [Watch](https://makecode.microbit.org/projects/watch) project, you can use the code from this project with it too.
 
 ## A counter
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4145

we open relative links in the same tab and absolute (usually these are external) links in a new tab. this is generally the right behavior and we are sometimes reliant on the open-in-same-tab behavior (eg the multipart tutorials, which use `#recipe` URLS), so i'm fixing the markdown for this case