### PR TITLE
Get hardware version, compare versions

### DIFF
--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -16,6 +16,8 @@ enum class EventCreationMode {
     CreateAndFire = CREATE_AND_FIRE,
 };
 
+const char *MICROBIT_BOARD_VERSION[2] = { "2.0", "2.X" };
+
 // note the trailing '_' in names - otherwise we get conflict with the pre-processor
 // this trailing underscore is removed by enums.d.ts generation process
 
@@ -338,11 +340,22 @@ namespace control {
      * Returns the major version of the microbit
      */
     //% help=control/hardware-version
-    int _hardwareVersion() {
+    String _hardwareVersion() {
         #if MICROBIT_CODAL
-            return 2;
+            MicroBitVersion v = uBit.power.getVersion();
+            int versionIdx;
+            switch (v.board) {
+                case 0x9903:
+                case 0x9904:
+                    versionIdx = 0;
+                    break;
+                default:
+                    versionIdx = 1;
+                    break;
+            }
+            return mkString(MICROBIT_BOARD_VERSION[versionIdx], -1);
         #else
-            return 1;
+            return mkString("1.X", 1);
         #endif
     }
 

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -167,7 +167,7 @@ namespace control {
 
         for (let i = 0; i < v1Arr.length; i++) {
             if (parseInt(v1Arr[i]) != parseInt(v2Arr[i])) {
-                return parseInt(v1Arr[i]) < parseInt(v2Arr[i]) ? -1 : 1;
+                return parseInt(v1Arr[i]) - parseInt(v2Arr[i]);
             }
         }
         return 0;

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -133,9 +133,45 @@ namespace control {
         return t
     }
 
+    //%
+    export function compareVersion(version1: string, version2: string): number {
+        let v1Arr = version1.split(".");
+        let v2Arr = version2.split(".");
+
+        v1Arr = v1Arr.map((str) => {
+            if (str.includes("x") || str.includes("X")) {
+                return "0"
+            } else {
+                return str;
+            }
+        })
+        v2Arr = v2Arr.map((str) => {
+            if (str.includes("x") || str.includes("X")) {
+                return "0"
+            } else {
+                return str;
+            }
+        })
+
+        for (let i = v1Arr.length; i < Math.max(v1Arr.length, v2Arr.length); i++) {
+            v1Arr.push("0");
+        }
+
+        for (let i = v2Arr.length; i < Math.max(v1Arr.length, v2Arr.length); i++) {
+            v2Arr.push("0");
+        }
+
+        for (let i = 0; i < v1Arr.length; i++) {
+            if (parseInt(v1Arr[i]) != parseInt(v2Arr[i])) {
+                return parseInt(v1Arr[i]) < parseInt(v2Arr[i]) ? -1 : 1;
+            }
+        }
+        return 0;
+    }
+
     //% shim=control::_hardwareVersion
-    export function hardwareVersion(): number {
-        return 2;
+    export function hardwareVersion(): string {
+        return "2.0";
     }
 }
 

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -133,6 +133,10 @@ namespace control {
         return t
     }
 
+    /**
+     * Given two versions, returns -1 if the first version is less than
+     * the second, 1 if it's greater, and 0 if it's the same.
+     */
     //%
     export function compareVersion(version1: string, version2: string): number {
         let v1Arr = version1.split(".");

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -448,7 +448,7 @@ declare namespace control {
      * Returns the major version of the microbit
      */
     //% help=control/hardware-version shim=control::_hardwareVersion
-    function _hardwareVersion(): int32;
+    function _hardwareVersion(): string;
 
     /**
      * Derive a unique, consistent serial number of this device from internal data.
@@ -1013,7 +1013,7 @@ declare namespace serial {
     function writeBuffer(buffer: Buffer): void;
 
     /**
-     * Read multiple characters from the receive buffer.
+     * Read multiple characters from the receive buffer. 
      * If length is positive, pauses until enough characters are present.
      * @param length default buffer length
      */


### PR DESCRIPTION
for https://github.com/microsoft/pxt-microbit/issues/3743

Uses the given CODAL function to fetch the hardware version.  I copied the version table from https://github.com/lancaster-university/codal-microbit-v2/issues/77#issuecomment-855238467

Also adds a function to compare versions -- it handles versions like "1.X" as "1.0"