### PR TITLE
Find the correct link for networking course

### DIFF
--- a/docs/courses.md
+++ b/docs/courses.md
@@ -66,7 +66,7 @@ Tutorials, lessons, and mini-courses about programming and computing.
 }, {
   "name": "Networking with the micro:bit",
   "description": "A series of activities to teach the basics of computer networks.",
-  "url": "https://microbit.org/projects/make-it-code-it/",
+  "url": "https://microbit.nominetresearch.uk/",
   "imageUrl": "/static/courses/networking-book.png"  
 }, {
   "name": "SparkFun Videos",


### PR DESCRIPTION
The "Networking with the micro:bit" course had the wrong link. It had the "Make it, Code it" course link attached instead.

![image](https://user-images.githubusercontent.com/27789908/122453311-12d93680-cf5f-11eb-8fa3-607ee7439681.png)

https://microbit.org/projects/make-it-code-it/ ===> https://microbit.nominetresearch.uk/

Fixes #4192