### PR TITLE
fix datalogger on winrt

### DIFF
--- a/sim/state/flashlog.ts
+++ b/sim/state/flashlog.ts
@@ -34,7 +34,7 @@ namespace pxsim.flashlog {
         data += "\n";
 
         /** edge 18 does not support text encoder, so fall back to length **/
-        logSize += TextEncoder ? (new TextEncoder().encode(data)).length : data.length;
+        logSize += typeof TextEncoder !== "undefined" ? (new TextEncoder().encode(data)).length : data.length;
         if (logSize >= logEnd) {
             board().bus.queue(DAL.MICROBIT_ID_LOG, DAL.MICROBIT_LOG_EVT_LOG_FULL);
             clear(false);


### PR DESCRIPTION
My check on whether textencoder was available was bad, fix that.

fix https://github.com/microsoft/pxt-microbit/issues/4220