### PR TITLE
Make datalogger searchOnly

### DIFF
--- a/libs/datalogger/pxt.json
+++ b/libs/datalogger/pxt.json
@@ -8,6 +8,7 @@
     "disablesVariants": [
         "mbdal"
     ],
+    "searchOnly": true,
     "dependencies": {
         "core": "file:../core",
         "flashlog": "file:../flashlog"


### PR DESCRIPTION
Taking time to fix some timing issue in the CODAL space for battery. We will enable it by default in a month or so.