### PR TITLE
Make Datalogger extension search only

### DIFF
--- a/libs/datalogger/pxt.json
+++ b/libs/datalogger/pxt.json
@@ -5,6 +5,7 @@
         "datalogger.ts"
     ],
     "public": true,
+    "searchOnly": true,
     "disablesVariants": [
         "mbdal"
     ],


### PR DESCRIPTION
There are timing issues in CODAL on battery while data logging. Lets make this search only for now and will revert it later point of time. /stable channel only change.