### PR TITLE
Set category of 'basic' to 'forever' loop text style

### DIFF
--- a/docs/projects/plot-acceleration.md
+++ b/docs/projects/plot-acceleration.md
@@ -6,7 +6,7 @@ The ``||led:plot bar graph||`` uses the screen to display the _magnitude_ (how b
 
 ## Acceleration
 
-In a ``||loops:forever||`` loop, ``||led:plot||`` ``||input:acceleration||`` in the ``x`` dimension on the LEDs.
+In a ``||basic:forever||`` loop, ``||led:plot||`` ``||input:acceleration||`` in the ``x`` dimension on the LEDs.
 
 ```blocks
 basic.forever(function() {


### PR DESCRIPTION
The 'forever' block style tag should be for 'basic' and not 'loops'.

Fixes #4239