### PR TITLE
Reference page for 'every' block

### DIFF
--- a/docs/blocks/loops.md
+++ b/docs/blocks/loops.md
@@ -1,3 +1,15 @@
 # @extends
 
 ## #specific
+
+```cards
+loops.everyInterval(500, function () {})
+```
+
+## #seealso
+
+[for](/blocks/loops/for), 
+[while](/blocks/loops/while), 
+[repeat](/blocks/loops/repeat), 
+[for of](/blocks/loops/for-of),
+[every](/reference/loops/every)

--- a/docs/reference/basic/forever.md
+++ b/docs/reference/basic/forever.md
@@ -1,4 +1,4 @@
-# Forever
+# forever
 
 Keep running part of a program 
 [in the background](/reference/control/in-background).
@@ -8,7 +8,20 @@ basic.forever(() => {
 })
 ```
 
-## Example: compass
+You can have part of a program continuously by placing it in an **forever** loop. The **forever** loop will _yield_ to the other code in your program though, allowing that code to have time to run when needs to.
+
+### ~ reminder
+
+#### Event-based loops
+
+Both the **forever** loop and the **every** loop are _event-based_ loops where the code inside is run as part of a function. These are different from the [for](/blocks/loops/for) and [while](/blocks/loops/while) loops. Those are loops are part of the programming language and can have [break](/blocks/loops/break) and [continue](/blocks/loops/continue) statements in them.
+You can NOT use **break** or **continue** in either a **forever** loop or an **every** loop.
+
+### ~
+
+## Examples
+
+### Example: compass
 
 The following example constantly checks the 
 [compass heading](/reference/input/compass-heading) 
@@ -32,7 +45,7 @@ basic.forever(() => {
 })
 ```
 
-## Example: counter
+### Example: counter
 
 The following example keeps showing the [number](/types/number) stored in a global variable.
 When you press button `A`, the number gets bigger.
@@ -66,5 +79,5 @@ input.onButtonPressed(Button.A, () => {
 
 ## See also
 
-[while](/blocks/loops/while), [on button pressed](/reference/input/on-button-pressed), [in background](/reference/control/in-background)
+[while](/blocks/loops/while), [in background](/reference/control/in-background), [every](/reference/loops/every-interval)
 

--- a/docs/reference/loops/every-interval.md
+++ b/docs/reference/loops/every-interval.md
@@ -1,0 +1,42 @@
+# every Interval
+
+Run part of the program in a loop continuously at a time interval.
+
+```sig
+loops.everyInterval(500, function () {})
+```
+
+If you want to run some code continuously, but on a time interval, then use an **every** loop. You set the amount of time that the loop waits before the code inside runs again. This is similar to a [forever](/reference/basic/forever) loop, in that it runs continuously, except that there's a time interval set to wait on before the loop runs the next time. This loop is useful when you want some of a program's code run on a _schedule_.
+
+## Parameters
+
+* **interval**: a [number](/types/number) that is the amount of time in milliseconds to wait before running the loop again.
+
+### ~ reminder
+
+#### Event-based loops
+
+Both the **every** loop and the **forever** loop are _event-based_ loops where the code inside is run as part of a function. These are different from the [for](/blocks/loops/for) and [while](/blocks/loops/while) loops. Those are loops are part of the programming language and can have [break](/blocks/loops/break) and [continue](/blocks/loops/continue) statements in them.
+You can NOT use **break** or **continue** in either an **every** loop or a **forever** loop.
+
+### ~
+
+## Example
+
+At every `200` milliseconds of time, check if either the **A** or **B** button is pressed. If so, show on the screen which one is pressed.
+
+```blocks
+loops.everyInterval(200, function () {
+    if (input.buttonIsPressed(Button.A)) {
+        basic.showString("A")
+    } else if (input.buttonIsPressed(Button.B)) {
+        basic.showString("B")
+    } else {
+        basic.clearScreen()
+    }
+})
+```
+
+## See also
+
+[forever](/reference/basic/forever)

--- a/libs/core/loops.ts
+++ b/libs/core/loops.ts
@@ -8,7 +8,7 @@ namespace loops {
      */
     //% weight=45 blockAllowMultiple=1
     //% interval.shadow=longTimePicker
-    //% afterOnStart=true
+    //% afterOnStart=true help=loops/every-interval
     //% blockId=every_interval block="every $interval ms"
     export function everyInterval(interval: number, a: () => void): void {
         control.runInParallel(() => {


### PR DESCRIPTION
Add a reference page for the `every` block and include other associated changes.

- [x] Add the reference page for `every-interval`.
- [x] Add help path in source.
- [x] Extend the `loops.md` card page.
- [x] Add "event-based" note to both `every-interval` and `forever` loop pages.

Closes #4272