### PR TITLE
Use 'setGroup' in radio examples

### DIFF
--- a/docs/projects/mood-radio.md
+++ b/docs/projects/mood-radio.md
@@ -15,6 +15,7 @@ between @boardname@s using the radio antenna, just like a phone can send text me
 Let's add blocks that send a number when button ``A`` is pressed. We assume that `0` is the "mood code" to send for **smiley**.
 
 ```blocks
+radio.setGroup(1)
 input.onButtonPressed(Button.A, () => {
     radio.sendNumber(0)
     basic.showIcon(IconNames.Happy)
@@ -65,9 +66,10 @@ That's it. Download your code to multiple @boardname@s and try it out!
 
 Try adding a new code and use the ``||input:on shake||`` event to send it.
 
-## Full sources
+## Complete program
 
 ```blocks
+radio.setGroup(1)
 input.onButtonPressed(Button.A, () => {
     radio.sendNumber(0)
     basic.showIcon(IconNames.Happy)

--- a/docs/projects/multi-dice.md
+++ b/docs/projects/multi-dice.md
@@ -22,9 +22,9 @@ input.onGesture(Gesture.Shake, function () {
 
 We need to store the result of the dice cast in a variable. A **variable** is like a place in the memory of the @boardname@ where you save information, like numbers.
 
-* Go to the **Variables** toolbox and click ``||Make a Variable||`` to create a new variable. We will call it **dice**.
-* Add a ``||set dice to||`` block and drag the ``||pick random||`` into it.
-* Drag a ``||dice||`` from the **Variables** toolbox into the ``||basic:show number||`` block.
+* Go to the **Variables** toolbox and click ``Make a Variable`` to create a new variable. We will call it **dice**.
+* Add a ``||variables:set dice to||`` block and drag the ``||math:pick random||`` into it.
+* Drag a ``||variables:dice||`` variable from the **Variables** toolbox into the ``||basic:show number||`` block.
 
 ```blocks
 let dice = 0
@@ -36,9 +36,10 @@ input.onGesture(Gesture.Shake, function () {
 
 ## Send the dice
 
-Put in a ``||radio:send number||`` and a ``||dice||`` to send the value stored in the ``dice`` variable via radio.
+Put in a ``||radio:send number||`` and a ``||variables:dice||`` to send the value stored in the ``||variables:dice||`` variable via radio. Make sure to add a ``||radio:set group||`` to ``||basic:on start||`` with the group number set to the group you want to use.
 
 ```blocks
+radio.setGroup(1)
 let dice = 0
 input.onGesture(Gesture.Shake, function () {
     dice = randint(1, 6)
@@ -49,7 +50,7 @@ input.onGesture(Gesture.Shake, function () {
 
 ## Receive the dice
 
-Go get an ``||radio:on received number||`` event block. This event runs when a radio message from another @boardname@ arrives. The ``receivedNumber`` value is the value of the dice in this game.
+Go get an ``||radio:on received number||`` event block. This event runs when a radio message from another @boardname@ arrives. The ``||variables:receivedNumber||`` value is the value of the dice in this game.
 
 ```blocks
 radio.onReceivedNumber(function (receivedNumber) {
@@ -58,7 +59,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 
 ## Check your cast
 
-Add a ``||logic:if||`` block to test if ``receivedNumber`` is greater or equal to ``dice``.
+Add a ``||logic:if||`` block to test if ``||variables:receivedNumber||`` is greater or equal to ``||variables:dice||``.
 If is, you lost so display a sad face on the screen.
 
 ```blocks
@@ -78,6 +79,7 @@ If you have more than one @boardname@, download your code onto each one and try 
 
 ```blocks
 let dice = 0
+radio.setGroup(1)
 input.onGesture(Gesture.Shake, function () {
     dice = randint(1, 6)
     basic.showNumber(dice)

--- a/docs/reference/radio/on-received-buffer.md
+++ b/docs/reference/radio/on-received-buffer.md
@@ -19,6 +19,7 @@ Two @boardname@s work like remote levels. They lie flat and detect any change in
 ```typescript
 let ax = 0;
 let ay = 0;
+radio.setGroup(3)
 basic.forever(() => {
     ax = input.acceleration(Dimension.X);
     ay = input.acceleration(Dimension.Y);

--- a/docs/reference/radio/on-received-number.md
+++ b/docs/reference/radio/on-received-number.md
@@ -29,6 +29,7 @@ thing from nearby @boardname@s. It shows these numbers as a
 [bar graph](/reference/led/plot-bar-graph).
 
 ```blocks
+radio.setGroup(1)
 basic.forever(() => {
     radio.sendNumber(input.acceleration(Dimension.X));
 })
@@ -43,6 +44,7 @@ This program uses the signal strength from received packets to graph the
 approximate distance between two @boardname@s.
 
 ```blocks
+radio.setGroup(1)
 basic.forever(() => {
     radio.sendNumber(0)
 })

--- a/docs/reference/radio/on-received-string.md
+++ b/docs/reference/radio/on-received-string.md
@@ -23,6 +23,7 @@ https://www.youtube.com/watch?v=Re3H2ISfQE8
 This program continuously sends a cheerful message. It also receives a messages from nearby @boardname@s. It shows these messages on the screen.
 
 ```blocks
+radio.setGroup(1)
 basic.forever(() => {
     radio.sendString("I'm happy");
 })

--- a/docs/reference/radio/on-received-value.md
+++ b/docs/reference/radio/on-received-value.md
@@ -27,6 +27,7 @@ thing from nearby @boardname@s, show the numbers as a
 [bar graph](/reference/led/plot-bar-graph).
 
 ```blocks
+radio.setGroup(1)
 basic.forever(() => {
     radio.sendValue("accel-x", input.acceleration(Dimension.X))
 })

--- a/docs/reference/radio/received-packet.md
+++ b/docs/reference/radio/received-packet.md
@@ -28,6 +28,7 @@ This program uses the signal strength from received packets to graph the
 approximate distance between two @boardname@s.
 
 ```blocks
+radio.setGroup(1)
 basic.forever(() => {
     radio.sendNumber(0)
 })

--- a/docs/reference/radio/send-buffer.md
+++ b/docs/reference/radio/send-buffer.md
@@ -19,6 +19,7 @@ If you load this program onto two @boardname@s, each board will send the level i
 ```typescript
 let ax = 0;
 let ay = 0;
+radio.setGroup(6)
 basic.forever(() => {
     ax = input.acceleration(Dimension.X);
     ay = input.acceleration(Dimension.Y);

--- a/docs/reference/radio/send-string.md
+++ b/docs/reference/radio/send-string.md
@@ -26,6 +26,7 @@ code word from one of them to the others by pressing button `A`.  The
 other @boardname@s will receive the code word and then show it.
 
 ```blocks
+radio.setGroup(1)
 input.onButtonPressed(Button.A, () => {
     radio.sendString("Codeword: TRIMARAN")
     basic.showString("SENT");

--- a/docs/reference/radio/set-group.md
+++ b/docs/reference/radio/set-group.md
@@ -24,8 +24,7 @@ to talk to each other because they will have the same group ID.
 
 #### Default radio group
 
-The radio group for @boardname@ v2 and later is NOT set by default. To make your program work on
-all versions of the @boardname@, it's best to set a radio group number when your program begins.
+If you haven't set a radio group for the @boardname@, it will use one selected randomly. If you are transmiting data to a @boardname@ that has a different hardware version from the sending @boardname@, it will select a random default group that is not the same as the other @boardname@. To be certain that your program will send or receive data using the same radio group, you will need to first choose and set a radio group for your program if you want it to work between different versions of the @boardname@.
 
 ### ~
 

--- a/docs/reference/radio/set-group.md
+++ b/docs/reference/radio/set-group.md
@@ -20,6 +20,15 @@ to talk to each other because they will have the same group ID.
 
 * **id**: a [number](/types/number) from ``0`` to ``255``.
 
+### ~ reminder
+
+#### Default radio group
+
+The radio group for @boardname@ v2 and later is NOT set by default. To make your program work on
+all versions of the @boardname@, it's best to set a radio group number when your program begins.
+
+### ~
+
 ## Simulator
 
 This function only works on the @boardname@, not in browsers.

--- a/docs/reference/radio/write-received-packet-to-serial.md
+++ b/docs/reference/radio/write-received-packet-to-serial.md
@@ -40,6 +40,7 @@ the second @boardname@), this program sends temperature data to the
 serial port.
 
 ```blocks
+radio.setGroup(44)
 input.onButtonPressed(Button.A, function () {
     radio.sendNumber(input.temperature())
     radio.sendValue("temp", input.temperature())

--- a/docs/reference/radio/write-value-to-serial.md
+++ b/docs/reference/radio/write-value-to-serial.md
@@ -29,6 +29,7 @@ the second @boardname@), this program sends temperature data to
 serial.
 
 ```blocks
+radio.setGroup(1)
 input.onButtonPressed(Button.A, () => {
     radio.sendNumber(input.temperature());
 });


### PR DESCRIPTION
A default radio group isn't set on v2+ boards. Including `radio.setGroup()` in examples.

Closes #4261