### PR TITLE
Modify descriptions of game sprite properties

### DIFF
--- a/docs/reference/game/change.md
+++ b/docs/reference/game/change.md
@@ -1,19 +1,23 @@
 # change (Sprite Property)
 
-Change the kind of [number](/types/number) you say for a [sprite](/reference/game/create-sprite).
+Change a value for a [sprite](/reference/game/create-sprite) property by some amount.
 
 ```sig
 game.createSprite(0,0).change(LedSpriteProperty.X, 0);
 ```
 
+The value of a sprite propery is changed by using either a positive or negative number. Giving `1` will increase a property value by `1` and giving a `-1` will decrease it by `1`.
+
 ## Parameters
 
 * **property**: the property of the **Sprite** you want to change, like:
->* ``x`` - how far up or down the sprite is on the screen (`0`-`4`)
->* ``y`` - how far left or right the sprite is on the screen (`0`-`4`)
->* ``direction`` - which way the sprite is pointing (this works the same way as the [turn](/reference/game/turn) function)
->* ``brightness`` - how bright the LED sprite is (this works the same way as the [brightness](/reference/led/brightness) function)
->* ``blink`` -  how fast the sprite is blinking (the bigger the number is, the faster the sprite is blinking)
+>* ``x`` - the change in horizontal location to set the sprite at on the LED screen (`0`-`4`)
+>* ``y`` - the change vertical location to set the sprite at on the LED screen (`0`-`4`)
+>* ``direction`` - the change of direction in degrees for the sprite to go when the next [move](/reference/game/move) happens. Direction degree range is from `-180` to `180`.
+>* ``brightness`` - the change in brightness for the LED sprite. Completely dark is `0` and very bright is `255`.
+>* ``blink`` - the change in how fast the sprite is will blink on and off. The blink rate is in milliseconds.
+
+* **value**: a [number](/types/number) value that is the amount of change for the property.
 
 ## Example
 

--- a/docs/reference/game/get.md
+++ b/docs/reference/game/get.md
@@ -1,6 +1,6 @@
 # get (Sprite Property)
 
-Find something out about a [sprite](/reference/game/create-sprite).
+Get a value for a [sprite](/reference/game/create-sprite) property.
 
 ```sig
 game.createSprite(0,0).get(LedSpriteProperty.X);
@@ -9,11 +9,11 @@ game.createSprite(0,0).get(LedSpriteProperty.X);
 ## Parameters
 
 * **property**: the property of the **Sprite** you want to know about, like:
->* ``x`` - how far up or down the sprite is on the screen (`0`-`4`)
->* ``y`` - how far left or right the sprite is on the screen (`0`-`4`)
->* ``direction`` - which way the sprite is pointing (this works the same way as the [turn](/reference/game/turn) function)
->* ``brightness`` - how bright the LED sprite is (this works the same way as the [brightness](/reference/led/brightness) function)
->* ``blink`` - how fast the sprite is blinking (the bigger the number is, the faster the sprite is blinking)
+>* ``x`` - the horizontal location to set the sprite at on the LED screen (`0`-`4`)
+>* ``y`` - the vertical location to set the sprite at on the LED screen (`0`-`4`)
+>* ``direction`` - the direction in degrees for the sprite to go when the next [move](/reference/game/move) happens. The degree range is from `-180` to `180`.
+>* ``brightness`` - how bright the LED sprite is. Completely dark is `0` and very bright is `255`.
+>* ``blink`` - how fast the sprite is will blink on and off. The blink rate is in milliseconds.
 
 ## Returns
 

--- a/docs/reference/game/set.md
+++ b/docs/reference/game/set.md
@@ -1,6 +1,6 @@
 # set (Sprite Property)
 
-Make a [sprite](/reference/game/create-sprite) store the kind of [number](/types/number) you say.
+Set a value for a [sprite](/reference/game/create-sprite) property.
 
 ```sig
 game.createSprite(0,0).set(LedSpriteProperty.X, 0);
@@ -9,22 +9,39 @@ game.createSprite(0,0).set(LedSpriteProperty.X, 0);
 ## Parameters
 
 * **property**: the property of the **Sprite** you want to store a value for, like:
->* ``x`` - how far up or down the sprite is on the screen (`0`-`4`)
->* ``y`` - how far left or right the sprite is on the screen (`0`-`4`)
->* ``direction`` - which way the sprite is pointing (this works the same way as the [turn](/reference/game/turn) function)
->* ``brightness`` - how bright the LED sprite is (this works the same way as the [brightness](/reference/led/brightness) function)
->* ``blink`` - how fast the sprite is blinking (the bigger the number is, the faster the sprite is blinking)
+>* ``x`` - the horizontal location to set the sprite at on the LED screen (`0`-`4`)
+>* ``y`` - the vertical location to set the sprite at on the LED screen (`0`-`4`)
+>* ``direction`` - the direction in degrees for the sprite to go when the next [move](/reference/game/move) happens. The degree range is from `-180` to `180`.
+>* ``brightness`` - how bright the LED sprite is. Completely dark is `0` and very bright is `255`.
+>* ``blink`` - how fast the sprite is will blink on and off. The blink rate is in milliseconds.
+
+* **value**: the a [number](/types/number) value to set for the property.
 
 ## Example
 
-This program makes a sprite on the left side of the screen,
-waits two seconds (2000 milliseconds),
-and then moves it to the right side of the screen.
+Make an LED sprite move to random locations on the screen. Use button **A** to freeze and unfreeze the sprite while it's moving. When the sprite is frozen, it will blink and dim to half brightness.
 
 ```blocks
-let ball = game.createSprite(0, 2);
-basic.pause(2000);
-ball.set(LedSpriteProperty.X, 4);
+input.onButtonPressed(Button.A, function () {
+    if (freeze) {
+        sprite.set(LedSpriteProperty.Brightness, 255)
+        sprite.set(LedSpriteProperty.Blink, 0)
+    } else {
+        sprite.set(LedSpriteProperty.Brightness, 128)
+        sprite.set(LedSpriteProperty.Blink, 200)
+    }
+    freeze = !(freeze)
+})
+let freeze = false
+let sprite: game.LedSprite = null
+sprite = game.createSprite(0, 0)
+basic.forever(function () {
+    if (!(freeze)) {
+        sprite.set(LedSpriteProperty.X, randint(0, 4))
+        sprite.set(LedSpriteProperty.Y, randint(0, 4))
+    }
+    basic.pause(500)
+})
 ```
 
 ## See also


### PR DESCRIPTION
Restate the property descriptions in the `set`, `get`, and `change` reference pages for game sprites.

Closes #3900