### PR TITLE
remove extra space on snippet section

### DIFF
--- a/docs/live-coding.md
+++ b/docs/live-coding.md
@@ -4,7 +4,7 @@ Live coding of tutorials for MakeCode for micro:bit on https://mixer.com/MakeCod
 
 ## Videos
 
-###  ~ codecard
+### ~ codecard
 * name: Flashing Heart
 * description: In this video, we'll be going through the Flashing Heart Tutorial - https://makecode.microbit.org/#tutorial:/projects/flashing-heart.
 * youTubeId: NvEOKZ8wh9s


### PR DESCRIPTION
The category is not currently showing up due to this extra space

![image](https://user-images.githubusercontent.com/5615930/127416702-be46704d-f770-41c3-a3bb-f2a8e035ebbf.png)
