### PR TITLE
Allow ml4f (machine learning) editor extension

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,7 +13,7 @@
             "microsoft/pxt-ws2812b",
             "microsoft/pxt-apa102",
             "microsoft/pxt-radio-firefly",
-            "microsoft/pxt-ml4f",
+            "microsoft/pxt-ml/ml4f",
             "KitronikLtd/pxt-kitronik-servo-lite",
             "KitronikLtd/pxt-kitronik-motor-driver",
             "KitronikLtd/pxt-kitronik-I2C-16-servo",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,6 +13,7 @@
             "microsoft/pxt-ws2812b",
             "microsoft/pxt-apa102",
             "microsoft/pxt-radio-firefly",
+            "microsoft/pxt-ml4f",
             "KitronikLtd/pxt-kitronik-servo-lite",
             "KitronikLtd/pxt-kitronik-motor-driver",
             "KitronikLtd/pxt-kitronik-I2C-16-servo",
@@ -270,7 +271,8 @@
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },
         "approvedEditorExtensionUrls": [
-            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension"
+            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension",
+            "https://microsoft.github.io/ml4f/"
         ]
     },
     "galleries": {


### PR DESCRIPTION
Extension https://github.com/microsoft/pxt-ml allows for running Tensor Flow machine learning models on cortex-m4f+ (including m:b v2) using my compiler from https://github.com/microsoft/ml4f

The UI for importing models is right now quite basic https://microsoft.github.io/ml4f/

This is mostly an experiment for now - the user has to search for "ml4f" extension, and then click "Import Model" button in "ML" namespace.