### PR TITLE
Revert "Allow ml4f (machine learning) editor extension"

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,7 +13,6 @@
             "microsoft/pxt-ws2812b",
             "microsoft/pxt-apa102",
             "microsoft/pxt-radio-firefly",
-            "microsoft/pxt-ml/ml4f",
             "KitronikLtd/pxt-kitronik-servo-lite",
             "KitronikLtd/pxt-kitronik-motor-driver",
             "KitronikLtd/pxt-kitronik-I2C-16-servo",
@@ -271,8 +270,7 @@
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },
         "approvedEditorExtensionUrls": [
-            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension",
-            "https://microsoft.github.io/ml4f/"
+            "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension"
         ]
     },
     "galleries": {


### PR DESCRIPTION
Reverts microsoft/pxt-microbit#4338