### PR TITLE
Approve non-nested version of ml4f extension

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,6 +13,7 @@
             "microsoft/pxt-ws2812b",
             "microsoft/pxt-apa102",
             "microsoft/pxt-radio-firefly",
+            "microsoft/pxt-ml",
             "KitronikLtd/pxt-kitronik-servo-lite",
             "KitronikLtd/pxt-kitronik-motor-driver",
             "KitronikLtd/pxt-kitronik-I2C-16-servo",
@@ -270,6 +271,7 @@
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },
         "approvedEditorExtensionUrls": [
+            "https://microsoft.github.io/ml4f/",
             "https://microsoft.github.io/jacdac-docs/tools/makecode-editor-extension"
         ]
     },


### PR DESCRIPTION
The pxt-ml/ml4f was merged into pxt-ml so this should no longer trigger the cloud