### PR TITLE
typo: milleseconds -> milliseconds

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -468,7 +468,7 @@
   "led.displayMode": "Gets the current display mode",
   "led.enable": "Turns on or off the display",
   "led.fadeIn": "Fades in the screen display.",
-  "led.fadeIn|param|ms": "fade time in milleseconds",
+  "led.fadeIn|param|ms": "fade time in milliseconds",
   "led.fadeOut": "Fades out the screen brightness.",
   "led.fadeOut|param|ms": "fade time in milliseconds",
   "led.plot": "Turn on the specified LED using x, y coordinates (x is horizontal, y is vertical). (0,0) is upper left.",

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -112,7 +112,7 @@ namespace led {
 
     /**
      * Fades in the screen display.
-     * @param ms fade time in milleseconds
+     * @param ms fade time in milliseconds
      */
     //% help=led/fade-in
     //% parts="ledmatrix"


### PR DESCRIPTION
Fix the typo: https://crowdin.com/translate/kindscript/66/en-zhcn#862016