### PR TITLE
Updating references to InkSmith Climate Action Kits

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -376,8 +376,8 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "url":"/pkg/elecfreaks/pxt-PlanetX",
   "cardType": "package"
 }, {
-  "name": "Inksmith Climate Action Kit",
-  "url":"/pkg/dugbraden/pxt-climate-action-kit",
+  "name": "Inksmith Climate Action Kit: Land",
+  "url":"/pkg/climate-action-kits/pxt-climate-action-kit-land",
   "cardType": "package"
 }, {
   "name": "Grove inventor kit",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -159,7 +159,7 @@
             "BrightWearables/pxt-microbit-brightboard",
             "EBOTICS/pxt-eboticsMIBO",
             "KitronikLtd/pxt-kitronik-halohd",
-            "dugbraden/pxt-climate-action-kit",
+            "climate-action-kits/pxt-climate-action-kit-land",
             "alsrobot-microbit-makecode-packages/MiniCruise",
             "4tronix/ServoBit",
             "DFRobot/pxt-maqueen",


### PR DESCRIPTION
Updating references to InkSmith Climate Action Kits so they don't point to personal accounts, and reflect revised naming. #4410 