### PR TITLE
Update pxt-muvision version to 1.2.28

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -295,7 +295,7 @@
             "sparkfun/pxt-gator-particle": "dv:mbcodal",
             "sparkfun/pxt-gator-microphone": "dv:mbcodal",
             "rebeccaclavier/pxt-bmp280": "dv:mbcodal",
-            "mu-opensource/pxt-muvision": "min:v1.2.25",
+            "mu-opensource/pxt-muvision": "min:v1.2.28",
             "elecfreaks/pxt-PlanetX": "min:v0.13.1",
             "bsiever/microbit-pxt-timeanddate": "min:v2.0.11"
         },


### PR DESCRIPTION
After a few trials and errors, finally found the correct way to work around the simulator crash bug (https://github.com/microsoft/pxt-microbit/issues/4292) for native extensions. Updating muvision to the latest release.