### PR TITLE
Add a block for disabling the audio output pin

### DIFF
--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -656,6 +656,7 @@ namespace pins {
     //% name.fieldEditor="gridpicker" name.fieldOptions.columns=4
     //% name.fieldOptions.tooltips="false" name.fieldOptions.width="250"
     //% weight=1
+    //% blockGap=8
     void setAudioPin(AnalogPin name) {
 #if MICROBIT_CODAL
         uBit.audio.setPin(*getPin((int)name));

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -333,6 +333,7 @@ namespace pins {
     PinCompat* pitchPin = NULL;
     uint8_t pitchVolume = 0xff;
     bool analogTonePlaying = false;
+    bool edgeConnectorSoundDisabled = false;
 
     /**
      * Set the pin used when using analog pitch or music.
@@ -372,7 +373,7 @@ namespace pins {
 
         if (analogTonePlaying) {
             int v = pitchVolume == 0 ? 0 : 1 << (pitchVolume >> 5);
-            if (NULL != pitchPin)
+            if (NULL != pitchPin && !edgeConnectorSoundDisabled)
                 pitchPin->setAnalogValue(v);
         }
     }
@@ -404,10 +405,12 @@ namespace pins {
             pitchPin = &uBit.audio.virtualOutputPin;
 #else
             pitchPin = getPin((int)AnalogPin::P0);
-#endif            
+#endif
         }
         // set pitch
         analogTonePlaying = true;
+
+#if MICROBIT_CODAL
         if (NULL != pitchPin)
             pinAnalogSetPitch(pitchPin, frequency, ms);
         // clear pitch
@@ -419,6 +422,19 @@ namespace pins {
             // causes issues with v2 DMA.
             // fiber_sleep(5);
         }
+#else
+        if (NULL != pitchPin && !edgeConnectorSoundDisabled)
+            pinAnalogSetPitch(pitchPin, frequency, ms);
+        // clear pitch
+        if (ms > 0) {
+            fiber_sleep(ms);
+            if (NULL != pitchPin && !edgeConnectorSoundDisabled)
+                pitchPin->setAnalogValue(0);
+            analogTonePlaying = false;
+            // causes issues with v2 DMA.
+            // fiber_sleep(5);
+        }
+#endif
     }
 
 
@@ -636,17 +652,31 @@ namespace pins {
     * @param name pin to modulate pitch from
     */
     //% blockId=pin_set_audio_pin block="set audio pin $name"
-    //% help=pins/set-audio-pin weight=3
+    //% help=pins/set-audio-pin
     //% name.fieldEditor="gridpicker" name.fieldOptions.columns=4
     //% name.fieldOptions.tooltips="false" name.fieldOptions.width="250"
     //% weight=1
     void setAudioPin(AnalogPin name) {
 #if MICROBIT_CODAL
         uBit.audio.setPin(*getPin((int)name));
-        uBit.audio.setPinEnabled(true);
+        uBit.audio.setPinEnabled(!edgeConnectorSoundDisabled);
 #else
         // v1 behavior
         pins::analogSetPitchPin(name);
+#endif
+    }
+
+    /**
+    * Sets whether or not audio will be output using a pin on the edge
+    * connector.
+    */
+    //% blockId=pin_set_audio_pin_enabled
+    //% block="set audio pin enabled $enabled"
+    //% weight=0
+    void setAudioPinEnabled(bool enabled) {
+        edgeConnectorSoundDisabled = !enabled;
+#if MICROBIT_CODAL
+        uBit.audio.setPinEnabled(enabled);
 #endif
     }
 }

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -29,6 +29,8 @@ namespace pxsim {
 }
 
 namespace pxsim.pins {
+    export let edgeConnectorSoundDisabled = false;
+
     export function digitalReadPin(pinId: number): number {
         let pin = getPin(pinId);
         if (!pin) return -1;
@@ -130,7 +132,7 @@ namespace pxsim.pins {
         const pins = ec.pins;
         const pin = ec.pitchEnabled && (pins.filter(pin => !!pin && pin.pitch)[0] || pins[0]);
         const pitchVolume = ec.pitchVolume | 0;
-        if (pin) {
+        if (pin && !edgeConnectorSoundDisabled) {
             pin.mode = PinFlags.Analog | PinFlags.Output;
             if (frequency <= 0 || pitchVolume <= 0) {
                 pin.value = 0;
@@ -152,7 +154,7 @@ namespace pxsim.pins {
         else {
             setTimeout(() => {
                 AudioContextManager.stop();
-                if (pin) {
+                if (pin && !edgeConnectorSoundDisabled) {
                     pin.value = 0;
                     pin.period = 0;
                     pin.mode = PinFlags.Unused;
@@ -182,5 +184,9 @@ namespace pxsim.music {
 namespace pxsim.pins {
     export function setAudioPin(pinId: number) {
         pxsim.pins.analogSetPitchPin(pinId);
+    }
+
+    export function setAudioPinEnabled(enabled: boolean) {
+        edgeConnectorSoundDisabled = !enabled;
     }
 }

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -214,7 +214,7 @@ namespace pxsim.pins {
             }
 
             if (!enabled) {
-                const img = document.createElementNS("http://www.w3.org/2000/svg","image") as SVGImageElement;
+                const img = document.createElementNS("http://www.w3.org/2000/svg", "image") as SVGImageElement;
                 img.setAttribute("href", "data:image/svg+xml;utf8," + encodeURIComponent(disabledSVG))
                 img.setAttribute("id", "headphone-disabled");
                 img.style.transform = "scale(1.5) translate(-10px, -10px)";

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -186,7 +186,40 @@ namespace pxsim.pins {
         pxsim.pins.analogSetPitchPin(pinId);
     }
 
+    const disabledSVG = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <clipPath id="bounds" clipPathUnits="userSpaceOnUse">
+        <circle cx="50" cy="50" r="45" />
+        </clipPath>
+        <circle cx="50" cy="50" r="40" stroke-width="10" stroke="red" fill="none" clip-path="url(#bounds)" />
+        <line x1="100" y1="0" x2="0" y2="100" stroke="red" stroke-width="10" clip-path="url(#bounds)" />
+    </svg>
+    `
+
     export function setAudioPinEnabled(enabled: boolean) {
         edgeConnectorSoundDisabled = !enabled;
+
+        const headphone = board().viewHost.getView().querySelector("g.sim-headphone-cmp");
+
+        if (headphone) {
+            const existing = headphone.querySelector("#headphone-disabled");
+
+            if (existing) {
+                if (enabled) {
+                    existing.remove();
+                }
+                else {
+                    return;
+                }
+            }
+
+            if (!enabled) {
+                const img = document.createElementNS("http://www.w3.org/2000/svg","image") as SVGImageElement;
+                img.setAttribute("href", "data:image/svg+xml;utf8," + encodeURIComponent(disabledSVG))
+                img.setAttribute("id", "headphone-disabled");
+                img.style.transform = "scale(1.5) translate(-10px, -10px)";
+                headphone.appendChild(img)
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3937

Tested on V1 and V2 by @livcheerful (thanks again!)

Also has simulator support that looks like this when pin is disabled:

<img width="365" alt="Screen Shot 2022-03-11 at 11 50 04 AM" src="https://user-images.githubusercontent.com/13754588/157948281-5f013d71-a752-489a-b253-465a353c86fe.png">

