### PR TITLE
allow disabling plotbargraph console output

### DIFF
--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -25,7 +25,7 @@ namespace led {
     /**
      * Controls where plotbargraph prints to the console
      **/ 
-    let barGraphToConsole = true
+    export let barGraphToConsole = true
 
     /**
      * Displays a vertical bar graph based on the `value` and `high` value.

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -21,6 +21,11 @@ namespace led {
     let barGraphHigh = 0;
     // when was the current high value recorded
     let barGraphHighLast = 0;
+    
+    /**
+     * Controls where plotbargraph prints to the console
+     **/ 
+    let barGraphToConsole = true
 
     /**
      * Displays a vertical bar graph based on the `value` and `high` value.
@@ -33,7 +38,8 @@ namespace led {
     //% parts="ledmatrix"
     export function plotBarGraph(value: number, high: number): void {
         const now = input.runningTime();
-        console.logValue("", value);
+        if (barGraphToConsole)
+            console.logValue("", value);
         value = Math.abs(value);
 
         // auto-scale "high" is not provided


### PR DESCRIPTION
Add a typescript only field to disable automatic output of led.plotBarGraph to the console. The default behavior is unchanged.