### PR TITLE
Combine sound blocks

### DIFF
--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -47,11 +47,11 @@ int volume() {
 * @param enabled whether the built-in speaker is enabled in addition to the sound pin
 */
 //% blockId=music_set_built_in_speaker_enable block="set built-in speaker $enabled"
-//% blockGap=8
 //% group="micro:bit (V2)"
 //% parts=builtinspeaker
 //% help=music/set-built-in-speaker-enabled
 //% enabled.shadow=toggleOnOff
+//% weight=0
 void setBuiltInSpeakerEnabled(bool enabled) {
 #if MICROBIT_CODAL
     uBit.audio.setSpeakerEnabled(enabled);

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -304,7 +304,7 @@ namespace music {
     //% block="play sound $sound until done"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=100
-    //% group="Sound Effects"
+    //% group="micro:bit (V2)"
     export function playSoundEffectUntilDone(sound: string) {
         new SoundExpression(sound).playUntilDone();
     }

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -17,6 +17,7 @@ class SoundExpression {
     //% help=music/play
     //% group="micro:bit (V2)"
     //% parts=builtinspeaker
+    //% deprecated=1
     play() {
         music.__playSoundExpression(this.notes, false)
     }
@@ -30,8 +31,13 @@ class SoundExpression {
     //% help=music/play-until-done
     //% group="micro:bit (V2)"
     //% parts=builtinspeaker
+    //% deprecated=1
     playUntilDone() {
         music.__playSoundExpression(this.notes, true)
+    }
+
+    getNotes() {
+        return this.notes;
     }
 }
 
@@ -44,7 +50,6 @@ enum WaveShape {
 }
 
 enum InterpolationCurve {
-    None,
     Linear,
     Curve,
     Logarithmic
@@ -282,19 +287,29 @@ namespace soundExpression {
 
         new SoundExpression(src).playUntilDone();
     }
+}
 
+namespace music {
     //% blockId=soundExpression_playSoundEffect
-    //% blockNamespace=music
     //% block="play sound $sound"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=101
     //% blockGap=8
-    export function playSoundEffect(sound: soundExpression.Sound) {
-        soundExpression.playSound(sound);
+    //% group="micro:bit (V2)"
+    export function playSoundEffect(sound: string) {
+        new SoundExpression(sound).play();
+    }
+
+    //% blockId=soundExpression_playSoundEffectUntilDone
+    //% block="play sound $sound until done"
+    //% sound.shadow=soundExpression_createSoundEffect
+    //% weight=100
+    //% group="Sound Effects"
+    export function playSoundEffectUntilDone(sound: string) {
+        new SoundExpression(sound).playUntilDone();
     }
 
     //% blockId=soundExpression_createSoundEffect
-    //% blockNamespace=music
     //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
     //% waveShape.defl=WaveShape.Sine
     //% waveShape.fieldEditor=soundeffect
@@ -307,7 +322,8 @@ namespace soundExpression {
     //% interpolation.defl=InterpolationCurve.Linear
     //% compileHiddenArguments=true
     //% inlineInputMode="variable"
-    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve) {
+    //% group="micro:bit (V2)"
+    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): string {
         const sound = new soundExpression.Sound();
         sound.wave = waveShape;
         sound.frequency = startFrequency;
@@ -318,10 +334,6 @@ namespace soundExpression {
         sound.fx = effect;
 
         switch (interpolation) {
-            case InterpolationCurve.None:
-                sound.shape = soundExpression.InterpolationEffect.None;
-                sound.steps = 128;
-                break;
             case InterpolationCurve.Linear:
                 sound.shape = soundExpression.InterpolationEffect.Linear;
                 sound.steps = 128;
@@ -351,6 +363,14 @@ namespace soundExpression {
                 break;
         }
 
-        return sound;
+        return sound.src;
+    }
+
+    //% blockId=soundExpression_builtinSoundEffect
+    //% block="$soundExpression"
+    //% blockGap=8
+    //% group="micro:bit (V2)"
+    export function builtinSoundEffect(soundExpression: SoundExpression) {
+        return soundExpression.getNotes();
     }
 }

--- a/sim/state/soundexpression.ts
+++ b/sim/state/soundexpression.ts
@@ -6,7 +6,7 @@ namespace pxsim.music {
     }
 
     export function __stopSoundExpressions() {
-        AudioContextManager.stopAll();
+        pxsim.codal.music.__stopSoundExpressions();
     }
 
     const giggle = "giggle";


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4523

Also part of https://github.com/microsoft/pxt-microbit/issues/4454

Deprecates the old play sound blocks and combines them with the new block. Also move the new block under the music namespace and changes the return type to string.

Here are the new blocks (note that builtin sounds like "giggle" have their own reporter block):

<img width="425" alt="Screen Shot 2022-04-19 at 4 14 10 PM" src="https://user-images.githubusercontent.com/13754588/164116383-b6ac6a6a-0d97-477f-bfde-ec611b7c05f5.png">

And here's what the old blocks were:

<img width="413" alt="Screen Shot 2022-04-19 at 4 16 54 PM" src="https://user-images.githubusercontent.com/13754588/164116436-039d2eba-84fc-4559-a272-72a3b13b30a2.png">

@Jaqster FYI!

