### PR TITLE
Tutorial theme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,19 @@
         "**/yotta_modules/**": true,
         "**/yotta_targets": true,
         "**/pxt_modules/**": true
-    },    
+    },
     "search.exclude": {
         "**/node_modules": true,
         "**/yotta_modules/**": true,
         "**/yotta_targets": true,
         "**/pxt_modules/**": true
-    },    
+    },
+    "files.associations": {
+        "*.blocks": "html",
+        "*.overrides": "less",
+        "*.variables": "less",
+        "*.jres": "json"
+    },
     "tslint.enable": true,
     "tslint.rulesDirectory": "node_modules/tslint-microsoft-contrib",
     "typescript.tsdk": "./node_modules/typescript/lib"

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -87,6 +87,10 @@
 @serialGraphBackground: #d9d9d9;
 
 /*---------------------------
-   Tutorial Code Validation
+   Tutorial
 ----------------------------*/
 @tutorialCodeValidationCorrectBackground: #cd0365;
+@sidebarPrimaryColor: @primaryColor;
+@sidebarSecondaryColor: @white;
+@sidbarActiveTabIconColor: @primaryColor;
+@tutorialBarBackgroundColor: #ecf0f1;


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/8791

Fixes https://github.com/microsoft/pxt-microbit/issues/4535
Fixes https://github.com/microsoft/pxt-microbit/issues/4534

Theming the tutorial using micro:bit editor colors. Also adding some missing file associations to the checked in vscode settings.

<img width="642" alt="Screen Shot 2022-04-20 at 2 27 27 PM" src="https://user-images.githubusercontent.com/13754588/164326475-ae41399f-5549-44dc-9768-9fddd75b77b5.png">

