### PR TITLE
Combine sound blocks take 2!

### DIFF
--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -47,11 +47,11 @@ int volume() {
 * @param enabled whether the built-in speaker is enabled in addition to the sound pin
 */
 //% blockId=music_set_built_in_speaker_enable block="set built-in speaker $enabled"
-//% blockGap=8
 //% group="micro:bit (V2)"
 //% parts=builtinspeaker
 //% help=music/set-built-in-speaker-enabled
 //% enabled.shadow=toggleOnOff
+//% weight=0
 void setBuiltInSpeakerEnabled(bool enabled) {
 #if MICROBIT_CODAL
     uBit.audio.setSpeakerEnabled(enabled);

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -62,6 +62,13 @@ enum SoundExpressionEffect {
     Warble = 3
 }
 
+enum SoundExpressionPlayMode {
+    //% block="until done"
+    UntilDone,
+    //% block="in background"
+    InBackground
+}
+
 namespace soundExpression {
     //% fixedInstance whenUsed block="{id:soundexpression}giggle"
     export const giggle = new SoundExpression("giggle");
@@ -291,22 +298,18 @@ namespace soundExpression {
 
 namespace music {
     //% blockId=soundExpression_playSoundEffect
-    //% block="play sound $sound"
-    //% sound.shadow=soundExpression_createSoundEffect
-    //% weight=101
-    //% blockGap=8
-    //% group="micro:bit (V2)"
-    export function playSoundEffect(sound: string) {
-        new SoundExpression(sound).play();
-    }
-
-    //% blockId=soundExpression_playSoundEffectUntilDone
-    //% block="play sound $sound until done"
+    //% block="play sound $sound $mode"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=100
+    //% blockGap=8
     //% group="micro:bit (V2)"
-    export function playSoundEffectUntilDone(sound: string) {
-        new SoundExpression(sound).playUntilDone();
+    export function playSoundEffect(sound: string, mode: SoundExpressionPlayMode) {
+        if (mode === SoundExpressionPlayMode.InBackground) {
+            new SoundExpression(sound).play();
+        }
+        else {
+            new SoundExpression(sound).playUntilDone();
+        }
     }
 
     //% blockId=soundExpression_createSoundEffect
@@ -370,6 +373,9 @@ namespace music {
     //% block="$soundExpression"
     //% blockGap=8
     //% group="micro:bit (V2)"
+    //% toolboxParent=soundExpression_playSoundEffect
+    //% toolboxParentArgument=sound
+    //% weight=102
     export function builtinSoundEffect(soundExpression: SoundExpression) {
         return soundExpression.getNotes();
     }

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -304,7 +304,7 @@ namespace music {
     //% block="play sound $sound until done"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=100
-    //% group="Sound Effects"
+    //% group="micro:bit (V2)"
     export function playSoundEffectUntilDone(sound: string) {
         new SoundExpression(sound).playUntilDone();
     }

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -17,6 +17,7 @@ class SoundExpression {
     //% help=music/play
     //% group="micro:bit (V2)"
     //% parts=builtinspeaker
+    //% deprecated=1
     play() {
         music.__playSoundExpression(this.notes, false)
     }
@@ -30,8 +31,13 @@ class SoundExpression {
     //% help=music/play-until-done
     //% group="micro:bit (V2)"
     //% parts=builtinspeaker
+    //% deprecated=1
     playUntilDone() {
         music.__playSoundExpression(this.notes, true)
+    }
+
+    getNotes() {
+        return this.notes;
     }
 }
 
@@ -44,7 +50,6 @@ enum WaveShape {
 }
 
 enum InterpolationCurve {
-    None,
     Linear,
     Curve,
     Logarithmic
@@ -282,19 +287,29 @@ namespace soundExpression {
 
         new SoundExpression(src).playUntilDone();
     }
+}
 
+namespace music {
     //% blockId=soundExpression_playSoundEffect
-    //% blockNamespace=music
     //% block="play sound $sound"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=101
     //% blockGap=8
-    export function playSoundEffect(sound: soundExpression.Sound) {
-        soundExpression.playSound(sound);
+    //% group="micro:bit (V2)"
+    export function playSoundEffect(sound: string) {
+        new SoundExpression(sound).play();
+    }
+
+    //% blockId=soundExpression_playSoundEffectUntilDone
+    //% block="play sound $sound until done"
+    //% sound.shadow=soundExpression_createSoundEffect
+    //% weight=100
+    //% group="Sound Effects"
+    export function playSoundEffectUntilDone(sound: string) {
+        new SoundExpression(sound).playUntilDone();
     }
 
     //% blockId=soundExpression_createSoundEffect
-    //% blockNamespace=music
     //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
     //% waveShape.defl=WaveShape.Sine
     //% waveShape.fieldEditor=soundeffect
@@ -307,7 +322,8 @@ namespace soundExpression {
     //% interpolation.defl=InterpolationCurve.Linear
     //% compileHiddenArguments=true
     //% inlineInputMode="variable"
-    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve) {
+    //% group="micro:bit (V2)"
+    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): string {
         const sound = new soundExpression.Sound();
         sound.wave = waveShape;
         sound.frequency = startFrequency;
@@ -318,10 +334,6 @@ namespace soundExpression {
         sound.fx = effect;
 
         switch (interpolation) {
-            case InterpolationCurve.None:
-                sound.shape = soundExpression.InterpolationEffect.None;
-                sound.steps = 128;
-                break;
             case InterpolationCurve.Linear:
                 sound.shape = soundExpression.InterpolationEffect.Linear;
                 sound.steps = 128;
@@ -351,6 +363,14 @@ namespace soundExpression {
                 break;
         }
 
-        return sound;
+        return sound.src;
+    }
+
+    //% blockId=soundExpression_builtinSoundEffect
+    //% block="$soundExpression"
+    //% blockGap=8
+    //% group="micro:bit (V2)"
+    export function builtinSoundEffect(soundExpression: SoundExpression) {
+        return soundExpression.getNotes();
     }
 }

--- a/sim/state/soundexpression.ts
+++ b/sim/state/soundexpression.ts
@@ -6,7 +6,7 @@ namespace pxsim.music {
     }
 
     export function __stopSoundExpressions() {
-        AudioContextManager.stopAll();
+        pxsim.codal.music.__stopSoundExpressions();
     }
 
     const giggle = "giggle";


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/8794

As discussed earlier, combining the two blocks and putting them both in the toolbox:

<img width="444" alt="Screen Shot 2022-04-21 at 12 40 36 PM" src="https://user-images.githubusercontent.com/13754588/164539989-4dacb214-8974-45df-9b63-9f3d8c8243a7.png">

I can also remove the loose sound effect block, but i thought it was useful!

