### PR TITLE
Jacdac + WebUSB fixes

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -717,8 +717,17 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             log(`jacdac: disabled`)
             return
         }
-        await pxt.Util.delay(700); // wait for the program to start and setup memory correctly
-        const xchg = await this.findJacdacXchgAddr()
+        // allow jacdac to boot
+        const now = pxt.U.now()
+        await pxt.Util.delay(1000)
+        let xchgRetry = 0
+        let xchg: number
+        while (xchg == null && xchgRetry++ < 2) {
+            log(`jacdac: finding xchg address (retry ${xchgRetry})`)
+            await pxt.Util.delay(100); // wait for the program to start and setup memory correctly
+            xchg = await this.findJacdacXchgAddr()
+        }
+        log(`jacdac: exchange address 0x${xchg ? xchg.toString(16) : "?"}; ${xchgRetry} retries; ${(pxt.U.now() - now) | 0}ms`)
         if (xchg == null) {
             log("jacdac: xchg address not found")
             pxt.tickEvent("hid.flash.jacdac.error.missingxchg");

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -252,15 +252,16 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         pxt.tickEvent("hid.flash.connect", { codal: this.usesCODAL ? 1 : 0, daplink: daplinkVersion, bin: binVersion });
 
+        // set baud rate
         const baud = new Uint8Array(5)
         baud[0] = 0x82 // set baud
         pxt.HF2.write32(baud, 1, 115200)
         await this.dapCmd(baud)
         // setting the baud rate on serial may reset NRF (depending on daplink version), so delay after
         await pxt.Util.delay(200);
-
         // only init after setting baud rate, in case we got reset
         await this.cortexM.init()
+        await this.cortexM.reset(true)
 
         const res = await this.readWords(0x10000010, 2);
         this.pageSize = res[0]

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -308,7 +308,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         log("reflash")
         startTime = 0
         const codalJson = resp.outfiles["codal.json"]
-        this.jacdacInHex = codalJson && !!pxt.Util.jsonTryParse(codalJson)?.definitions?.JACDAC
+        // JACDAC_WEBUSB is defined in microsoft/pxt-jacdac/pxt.json
+        this.jacdacInHex = codalJson && !!pxt.Util.jsonTryParse(codalJson)?.definitions?.JACDAC_WEBUSB
         this.flashAborted = false;
         this.flashing = true;
         return (this.io.isConnected() ? Promise.resolve() : this.io.reconnectAsync())


### PR DESCRIPTION
- [x] fix "bad trans" after flashing no-jacdac to with-jacdac programs
- [x] connecting to Jacdac may be slow if missing (multiple seconds), only do it when jacdac is detected in .hex.

Requires https://github.com/microsoft/pxt/pull/8818