### PR TITLE
print out dmesg() buffer to serial on panic

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -24,7 +24,11 @@ int list_fibers(Fiber **dest) {
 #endif
 
 extern "C" void target_panic(int error_code) {
-#if !MICROBIT_CODAL
+#if MICROBIT_CODAL
+    target_disable_irq();
+    DMESG("PANIC %d", error_code);
+    pxt::dumpDmesg();
+#else
     // wait for serial to flush
     sleep_us(300000);
 #endif
@@ -46,7 +50,7 @@ MicroBitEvent lastEvent;
 bool serialLoggingDisabled;
 
 void platform_init() {
-    microbit_seed_random();    
+    microbit_seed_random();
     int seed = microbit_random(0x7fffffff);
     DMESG("random seed: %d", seed);
     seedRandom(seed);
@@ -87,8 +91,6 @@ static void initCodal() {
     // repeat error 4 times and restart as needed
     microbit_panic_timeout(4);
 }
-
-void dumpDmesg() {}
 
 // ---------------------------------------------------------------------------
 // An adapter for the API expected by the run-time.

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -46,6 +46,10 @@ enum BaudRate {
 //% weight=2 color=#002050 icon="\uf287"
 //% advanced=true
 namespace serial {
+#if MICROBIT_CODAL
+    bool is_redirected;
+#endif
+
     // note that at least one // followed by % is needed per declaration!
 
     /**
@@ -167,8 +171,10 @@ namespace serial {
     //% blockGap=8
     void redirect(SerialPin tx, SerialPin rx, BaudRate rate) {
 #if MICROBIT_CODAL
-      if (getPin(tx) && getPin(rx))
+      if (getPin(tx) && getPin(rx)) {
         uBit.serial.redirect(*getPin(tx), *getPin(rx));
+        is_redirected = 1;
+      }
       uBit.serial.setBaud(rate);
 #else
       PinName txn;
@@ -232,4 +238,29 @@ namespace serial {
     void setTxBufferSize(uint8_t size) {
       uBit.serial.setTxBufferSize(size);
     }
+
+    /** Send DMESG debug buffer over serial. */
+    //%
+    void writeDmesg() {
+        pxt::dumpDmesg();
+    }
+}
+
+namespace pxt {
+
+static void sendString(const char *c, int len) {
+  while (len--)
+    uBit.serial.putc(*c++);
+}
+
+void dumpDmesg() {
+#if MICROBIT_CODAL
+    if (serial::is_redirected)
+      return;
+    unsigned len = codalLogStore.ptr;
+    codalLogStore.ptr = 0;
+    sendString(codalLogStore.buffer, len);
+#endif
+}
+
 }

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -209,6 +209,7 @@ namespace serial {
     //% blockId=serial_redirect_to_usb block="serial|redirect to USB"
     void redirectToUSB() {
 #if MICROBIT_CODAL
+      is_redirected = false;
       uBit.serial.redirect(uBit.io.usbTx, uBit.io.usbRx);
       uBit.serial.setBaud(115200);
 #else

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -1119,6 +1119,10 @@ declare namespace serial {
     //% blockId=serialSetTxBufferSize block="serial set tx buffer size to $size"
     //% advanced=true shim=serial::setTxBufferSize
     function setTxBufferSize(size: uint8): void;
+
+    /** Send DMESG debug buffer over serial. */
+    //% shim=serial::writeDmesg
+    function writeDmesg(): void;
 }
 
 


### PR DESCRIPTION
also add serial::writeDmesg() for manual printout

This is disabled when serial is redirected.

This helps diagnose crashes, especially 999 which is unhandled exception - it will print out exception value, which is useful especially when it's a string.

fixes https://github.com/microsoft/jacdac/issues/994