### PR TITLE
better handling of nan numbers in common APIs

### DIFF
--- a/docs/reference/basic/pause.md
+++ b/docs/reference/basic/pause.md
@@ -9,7 +9,7 @@ basic.pause(400)
 
 ## Parameters
 
-* ``ms`` is the number of milliseconds that you want to pause (100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second). If `ms` is `NaN` (not a number), it will default to `20` ms.
+* ``ms`` is the number of milliseconds that you want to pause (100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second).
 
 ## Example: diagonal line
 
@@ -23,6 +23,10 @@ for (let i = 0; i < 5; i++) {
     basic.pause(500)
 }
 ```
+
+## Advanced
+
+If `ms` is `NaN` (not a number), it will default to `20` ms.
 
 ## See also
 

--- a/docs/reference/basic/pause.md
+++ b/docs/reference/basic/pause.md
@@ -9,7 +9,7 @@ basic.pause(400)
 
 ## Parameters
 
-* ``ms`` is the number of milliseconds that you want to pause (100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second).
+* ``ms`` is the number of milliseconds that you want to pause (100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second). If `ms` is `NaN` (not a number), it will default to `20` ms.
 
 ## Example: diagonal line
 

--- a/docs/reference/basic/show-number.md
+++ b/docs/reference/basic/show-number.md
@@ -8,7 +8,7 @@ basic.showNumber(2)
 
 ## Parameters
 
-* `value` is a [Number](/types/number). If the number is not single-digit number, it will scroll on the display. If `value` is `NaN` (not a number), `?` is displayed.
+* `value` is a [Number](/types/number). If the number is not single-digit number, it will scroll on the display.
 * `interval` is an optional [Number](/types/number). It means the number of milliseconds before sliding the `value` left by one LED each time. Bigger intervals make the sliding slower.
 
 ## Examples:
@@ -36,6 +36,10 @@ for (let i = 0; i < 6; i++) {
     basic.pause(200)
 }
 ```
+
+## Advanced
+
+If `value` is `NaN` (not a number), `?` is displayed.
 
 ## Other show functions
 

--- a/docs/reference/basic/show-number.md
+++ b/docs/reference/basic/show-number.md
@@ -8,7 +8,7 @@ basic.showNumber(2)
 
 ## Parameters
 
-* `value` is a [Number](/types/number). If the number is not single-digit number, it will scroll on the display.
+* `value` is a [Number](/types/number). If the number is not single-digit number, it will scroll on the display. If `value` is `NaN` (not a number), `?` is displayed.
 * `interval` is an optional [Number](/types/number). It means the number of milliseconds before sliding the `value` left by one LED each time. Bigger intervals make the sliding slower.
 
 ## Examples:

--- a/libs/core/basic.ts
+++ b/libs/core/basic.ts
@@ -10,7 +10,10 @@ namespace basic {
     //% async
     //% parts="ledmatrix" interval.defl=150
     export function showNumber(value: number, interval?: number) {
-        showString(Math.roundWithPrecision(value, 2).toString(), interval);
+        if (isNaN(value))
+            showString("?")
+        else
+            showString(Math.roundWithPrecision(value, 2).toString(), interval);
     }
 }
 
@@ -19,6 +22,7 @@ namespace basic {
  * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
  */
 function pause(ms: number): void {
+    if (isNaN(ms)) ms = 20
     basic.pause(ms);
 }
 

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -40,6 +40,10 @@ namespace led {
         const now = input.runningTime();
         if (barGraphToConsole)
             console.logValue("", value);
+        if (isNaN(value)) {
+            basic.clearScreen()
+            return
+        }
         value = Math.abs(value);
 
         // auto-scale "high" is not provided


### PR DESCRIPTION
A bit more runtime defense in the case of null/undefined/NaN parameters passed to common apis.

- [x] basic.showNumber(NaN) -> ?
- [x] led.plotBarGraph(NaN) -> clear screen
- [x] pause(NaN) => pause(20)