### PR TITLE
Update README to use npm link instead of pxt link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ This step is only required if you intend to make changes to pxt and/or
 pxt-common-packages repos. If all you want is serve a local Makecode, you can skip
 this step.
 ```
-pxt link ../pxt
-pxt link ../pxt-common-packages
+npm link ../pxt
+npm link ../pxt-common-packages
 ```
 Note the above command assumes the folder structure of   
 ```


### PR DESCRIPTION
pxt link doesn't work and everyone seems to use npm link, so we should just update our README accordingly