### PR TITLE
disable serial log by default for now

### DIFF
--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -22,7 +22,7 @@ namespace datalogger {
         initialized = true;
 
         includeTimestamp(FlashLogTimeStampFormat.Seconds);
-        mirrorToSerial(true);
+        mirrorToSerial(false);
 
         control.onEvent(DAL.MICROBIT_ID_LOG, DAL.MICROBIT_LOG_EVT_LOG_FULL, () => {
             _disabled = true;


### PR DESCRIPTION
For now datalogging blocks in simulator won't look like they do anything until special case simulator support is added, but doing that separately. Have to disable this default behavior as it requires a bootloader update to work properly on hardware