### PR TITLE
Update micro:bit V1 Yotta target to use GitHub.

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -137,7 +137,7 @@
         "useNewFunctions": true
     },
     "compileService": {
-        "yottaTarget": "bbc-microbit-classic-gcc",
+        "yottaTarget": "bbc-microbit-classic-gcc@https://github.com/lancaster-university/yotta-target-bbc-microbit-classic-gcc",
         "yottaCorePackage": "microbit",
         "githubCorePackage": "lancaster-university/microbit",
         "gittag": "v2.2.0-rc6",


### PR DESCRIPTION
By adding the GitHub repo URL, otherwise it tries to fetch the target from the Yotta registry, which is no longer operational.

Fixes https://github.com/microsoft/pxt-microbit/issues/4684.