### PR TITLE
Bumping pxt-microbit CODAL version to v0.2.38.

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -165,7 +165,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.37",
+                    "branch": "v0.2.38",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
The only addition since v0.2.37 is an increase in a timeout that should improve the data logging problem in issue https://github.com/microsoft/pxt-microbit/issues/4676.