### PR TITLE
adding flags to test reset on connection

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -38,6 +38,8 @@ function log(msg: string) {
     pxt.debug(`dap ${ts}: ${msg}`)
 }
 const logV = /webusbdbg=1/.test(window.location.href) ? log : (msg: string) => { }
+const setBaudRateOnConnection = !/webusbbaud=0/.test(window.location.href)
+const resetOnConnection = !/webusbreset=0/.test(window.location.href)
 
 function murmur3_core(data: Uint8Array) {
     let h0 = 0x2F9BE6CC;
@@ -262,6 +264,25 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         return this.io.isConnecting() || (this.io.isConnected() && !this.initialized)
     }
 
+    private async setBaudRate() {
+        if (!setBaudRateOnConnection) return
+
+        log(`set baud rate to 115200`)
+        const baud = new Uint8Array(5)
+        baud[0] = 0x82 // set baud
+        pxt.HF2.write32(baud, 1, 115200)
+        await this.dapCmd(baud)
+        // setting the baud rate on serial may reset NRF (depending on daplink version), so delay after
+        await pxt.Util.delay(200);
+    }
+
+    private async readPageSize() {
+        const res = await this.readWords(0x10000010, 2);
+        this.pageSize = res[0]
+        this.numPages = res[1]
+        log(`page size ${this.pageSize}, num pages ${this.numPages}`);
+    }
+
     async reconnectAsync(): Promise<void> {
         log(`reconnect`)
         this.initialized = false
@@ -296,22 +317,15 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         pxt.tickEvent("hid.flash.connect", { codal: this.usesCODAL ? 1 : 0, daplink: daplinkVersion, bin: binVersion });
 
-        // set baud rate
-        const baud = new Uint8Array(5)
-        baud[0] = 0x82 // set baud
-        pxt.HF2.write32(baud, 1, 115200)
-        await this.dapCmd(baud)
-        // setting the baud rate on serial may reset NRF (depending on daplink version), so delay after
-        await pxt.Util.delay(200);
+       await this.setBaudRate()
         // only init after setting baud rate, in case we got reset
         await this.cortexM.init()
-        await this.cortexM.reset(true)
+        if (resetOnConnection){
+            log(`reset cortex`)
+            await this.cortexM.reset(true)
+        }
 
-        const res = await this.readWords(0x10000010, 2);
-        this.pageSize = res[0]
-        this.numPages = res[1]
-        log(`page size ${this.pageSize}, num pages ${this.numPages}`);
-
+        await this.readPageSize()
         // jacdac needs to run to set the xchg address
         await this.checkStateAsync(true);
         await this.initJacdac(connectionId)

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -265,8 +265,6 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
     }
 
     private async setBaudRate() {
-        if (!setBaudRateOnConnection) return
-
         log(`set baud rate to 115200`)
         const baud = new Uint8Array(5)
         baud[0] = 0x82 // set baud
@@ -317,7 +315,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         pxt.tickEvent("hid.flash.connect", { codal: this.usesCODAL ? 1 : 0, daplink: daplinkVersion, bin: binVersion });
 
-       await this.setBaudRate()
+        if (setBaudRateOnConnection)
+            await this.setBaudRate()
         // only init after setting baud rate, in case we got reset
         await this.cortexM.init()
         if (resetOnConnection){

--- a/libs/datalogger/_locales/datalogger-strings.json
+++ b/libs/datalogger/_locales/datalogger-strings.json
@@ -1,6 +1,7 @@
 {
   "datalogger.DeleteType.Fast|block": "fast",
   "datalogger.DeleteType.Full|block": "full",
+  "datalogger._columnField|block": "$column",
   "datalogger.createCV|block": "column $column value $value",
   "datalogger.deleteLog|block": "delete log||$deleteType",
   "datalogger.includeTimestamp|block": "set timestamp $format",


### PR DESCRIPTION
Two flags to test removing resets on connecting web usb:

- `webusbbaud=0` disables setting baud rate to 115200
- `webusbreset=0` disables reseting cortex on connection

@jaustin 