### PR TITLE
bring allocateEventSource to microbit

### DIFF
--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -105,6 +105,15 @@ namespace control {
         panic(108)
     }
 
+    let _evSource = 0x8000
+    /**
+     * Incrementally allocates event source identifiers.
+     * @returns 
+     */
+    export function allocateEventSource() {
+        return ++_evSource
+    }    
+
     /**
      * Display warning in the simulator.
      */


### PR DESCRIPTION
This is a helper available in common packages, but because we have our own control.ts in micro:bit, it is missing.

https://github.com/microsoft/pxt-common-packages/blob/ce3f164271d8e5e2bd2fae977524aa15c8ffa718/libs/base/control.ts#L86