### PR TITLE
datalogger block configure line break for inline input mode

### DIFF
--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -132,6 +132,7 @@ namespace datalogger {
     //% data9.shadow=dataloggercreatecolumnvalue
     //% data10.shadow=dataloggercreatecolumnvalue
     //% inlineInputMode="variable"
+    //% inlineInputModeLimit=2
     //% group="micro:bit (V2)"
     //% weight=100 help=datalogger/log
     export function log(
@@ -196,6 +197,7 @@ namespace datalogger {
     //% block="set columns $col1||$col2 $col3 $col4 $col5 $col6 $col7 $col8 $col9 $col10"
     //% blockId=dataloggersetcolumntitles
     //% inlineInputMode="variable"
+    //% inlineInputModeLimit=2
     //% group="micro:bit (V2)"
     //% weight=70 help=datalogger/set-column-titles
     //% col1.shadow=datalogger_columnfield

--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -132,7 +132,7 @@ namespace datalogger {
     //% data9.shadow=dataloggercreatecolumnvalue
     //% data10.shadow=dataloggercreatecolumnvalue
     //% inlineInputMode="variable"
-    //% inlineInputModeLimit=2
+    //% inlineInputModeLimit=1
     //% group="micro:bit (V2)"
     //% weight=100 help=datalogger/log
     export function log(
@@ -197,7 +197,7 @@ namespace datalogger {
     //% block="set columns $col1||$col2 $col3 $col4 $col5 $col6 $col7 $col8 $col9 $col10"
     //% blockId=dataloggersetcolumntitles
     //% inlineInputMode="variable"
-    //% inlineInputModeLimit=2
+    //% inlineInputModeLimit=1
     //% group="micro:bit (V2)"
     //% weight=70 help=datalogger/set-column-titles
     //% col1.shadow=datalogger_columnfield


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4716

configure data logger block w/ options added in https://github.com/microsoft/pxt/pull/8868 to make it break sooner:

![image](https://user-images.githubusercontent.com/5615930/172240100-cb833107-758e-49dc-b10e-a4de62232520.png)
