### PR TITLE
Some 'playSoundEffect' doc updates

### DIFF
--- a/docs/reference/music/create-sound-effect.md
+++ b/docs/reference/music/create-sound-effect.md
@@ -34,12 +34,32 @@ A sound expression is set of parameters that describe a **[Sound](/types/sound)*
 
 * a [sound](/types/sound) expression [string](/types/string) with the the desired sound effect parameters.
 
-## Example
+## Examples
+
+### Sine wave sound
 
 Create a sound expression string and assign it to a variable. Play the sound for the sound expression.
 
 ```blocks
 let mySound = music.createSoundEffect(WaveShape.Sine, 2000, 0, 1023, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
+music.playSoundEffect(mySound, SoundExpressionPlayMode.UntilDone)
+```
+
+### Complex waveform sound
+
+Create a `triangle` wave sound expression with `vibrato` and a `curve` interpolation. Play the sound until it finishes.
+
+```typescript
+let mySound = music.createSoundEffect(
+    WaveShape.Triangle,
+    1000,
+    2700,
+    255,
+    255,
+    500,
+    SoundExpressionEffect.Vibrato,
+    InterpolationCurve.Curve
+    )
 music.playSoundEffect(mySound, SoundExpressionPlayMode.UntilDone)
 ```
 

--- a/docs/reference/music/play-sound-effect.md
+++ b/docs/reference/music/play-sound-effect.md
@@ -8,6 +8,8 @@ music.playSoundEffect("", SoundExpressionPlayMode.UntilDone)
 
 This will play a **[Sound](/types/sound)** object created from a sound expression. The sound will play for the duration that was set in the sound expression. The sound can play on the speaker or at a pin that is set for sound output.
 
+You can also play [built-in sound effects](/reference/music/builtin-sound-effect) like `giggle`, `happy`, or `twinkle`.
+
 Your program can wait for the sound to finish before it runs its next step. To do this, set the play mode to `until done`. Otherwise, use `background` for the program to continue immediately after the sound starts.
 
 ### ~ reminder
@@ -25,12 +27,23 @@ This block requires the [micro:bit V2](/device/v2) hardware. If you use this blo
 * **sound**: a [string](/types/string) that is the sound expression for the sound you want to play.
 * **mode**: the play mode for the sound, either `until done` or `background`.
 
-## Example
+## Examples
 
-Play a sound from a sound expression for `1` second.
+### Waveform sound
+
+Play the sound effect from a sine wave sound expression for `1` second.
 
 ```blocks
 music.playSoundEffect(music.createSoundEffect(WaveShape.Sine, 2000, 0, 1023, 0, 1000, SoundExpressionEffect.None, InterpolationCurve.Linear), SoundExpressionPlayMode.UntilDone)
+```
+
+### Built-in sounds
+
+Play a [built-in sound effect](/reference/music/builtin-sound-effect) until it finishes.
+
+```blocks
+music.playSoundEffect(music.builtinSoundEffect(soundExpression.giggle), SoundExpressionPlayMode.UntilDone)
+
 ```
 
 ## See also

--- a/docs/reference/music/play-sound-effect.md
+++ b/docs/reference/music/play-sound-effect.md
@@ -29,7 +29,7 @@ This block requires the [micro:bit V2](/device/v2) hardware. If you use this blo
 
 ## Examples
 
-### Waveform sound
+### Simple waveform sound
 
 Play the sound effect from a sine wave sound expression for `1` second.
 
@@ -37,9 +37,26 @@ Play the sound effect from a sine wave sound expression for `1` second.
 music.playSoundEffect(music.createSoundEffect(WaveShape.Sine, 2000, 0, 1023, 0, 1000, SoundExpressionEffect.None, InterpolationCurve.Linear), SoundExpressionPlayMode.UntilDone)
 ```
 
+### Complex waveform sound
+
+Play a `triangle` wave sound effect with `vibrato` and a `curve` interpolation.
+
+```typescript
+music.playSoundEffect(music.createSoundEffect(
+    WaveShape.Triangle,
+    1000,
+    2700,
+    255,
+    255,
+    500,
+    SoundExpressionEffect.Vibrato,
+    InterpolationCurve.Curve
+    ), SoundExpressionPlayMode.UntilDone)
+```
+
 ### Built-in sounds
 
-Play a [built-in sound effect](/reference/music/builtin-sound-effect) until it finishes.
+Play the `giggle` [built-in sound effect](/reference/music/builtin-sound-effect) until it finishes.
 
 ```blocks
 music.playSoundEffect(music.builtinSoundEffect(soundExpression.giggle), SoundExpressionPlayMode.UntilDone)

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -311,8 +311,8 @@ namespace soundExpression {
 namespace music {
     /**
      * Play a sound effect from a sound expression string.
-     * @param sound expression string
-     * @param mode to play until done or in the background
+     * @param sound the sound expression string
+     * @param mode the play mode, play until done or in the background
      */
     //% blockId=soundExpression_playSoundEffect
     //% block="play sound $sound $mode"
@@ -331,14 +331,14 @@ namespace music {
 
     /**
      * Create a sound expression from a set of sound effect parameters.
-     * @param waveShape for the sound effect 
-     * @param startFrequency for the sound effect waveform
-     * @param endFrequency for the sound effect waveform
-     * @param startVolume of the sound, or starting amplitude
-     * @param endVolume of the sound, or ending amplitude
-     * @param duration in milliseconds (ms) that sound will play for
-     * @param effect to apply to the waveform or volume
-     * @param interpolation for frequency scaling
+     * @param waveShape waveform of the sound effect 
+     * @param startFrequency starting frequency for the sound effect waveform
+     * @param endFrequency ending frequency for the sound effect waveform
+     * @param startVolume starting volume of the sound, or starting amplitude
+     * @param endVolume ending volume of the sound, or ending amplitude
+     * @param duration the amount of time in milliseconds (ms) that sound will play for
+     * @param effect the effect to apply to the waveform or volume
+     * @param interpolation interpolation method for frequency scaling
      */
     //% blockId=soundExpression_createSoundEffect
     //% help=music/create-sound-effect
@@ -412,7 +412,7 @@ namespace music {
 
     /**
      * Get the sound expression string for a built-in a sound effect.
-     * @param soundExpression for a built-in sound effect
+     * @param soundExpression a sound expression for a built-in sound effect
      */
     //% blockId=soundExpression_builtinSoundEffect
     //% block="$soundExpression"


### PR DESCRIPTION
Some updates to the sound expression reference pages:

- [x] Adds a mention/example of 'built-in' sound effects in the `playSoundEffect` reference page.
- [x] Add example with modified parameters (this, unfortunately,  doesn't show in an expanded block).
- [x] Sentencize the parameter descriptions.

Closes #4744, maybe.

