### PR TITLE
add back timestamp to csv sim (don't restrict to mirrorToSerial)

### DIFF
--- a/sim/state/flashlog.ts
+++ b/sim/state/flashlog.ts
@@ -89,7 +89,7 @@ namespace pxsim.flashlog {
         if (!currentRow.some(el => el !== "" && el != undefined))
             return DAL.DEVICE_OK;
 
-        if (timestampFormat !== FlashLogTimeStampFormat.None && mirrorToSerial) {
+        if (timestampFormat !== FlashLogTimeStampFormat.None) {
             let unit = "";
             switch(timestampFormat) {
                 case FlashLogTimeStampFormat.Milliseconds:


### PR DESCRIPTION
I should've looked at this again to make sure it was not implemented before putting up the other csv pr, but I thought this code I wrote had gotten deleted prior to merging last release but it was actually just disabled when mirrorToSerial is off. 

fix https://github.com/microsoft/pxt-microbit/issues/4746

![image](https://user-images.githubusercontent.com/5615930/173685279-4579262f-fd0d-40c0-adb8-1042195e9c13.png)
