### PR TITLE
Support docs for datalogger extension

### DIFF
--- a/libs/datalogger/docs/reference/datalogger.md
+++ b/libs/datalogger/docs/reference/datalogger.md
@@ -28,13 +28,18 @@ A data item consits of value name, which is it's assigned column too, and the it
 ```blocks
 let item = datalogger.createCV("temperature", input.temperature())
 ```
+The order and the names of the data items are set using column titles.
 
-Data items are logged to storage as a row. Here's an example of logging a row of data.
+```blocks
+datalogger.setColumnTitles("temperature", "acceleration", "light")
+```
+
+Data items are logged to storage as a row. Here's an example of logging a row of data. Each different data value is associated with its colunm before it's logged.
 
 ```blocks
 let temp = datalogger.createCV("temperature", input.temperature())
 let accel = datalogger.createCV("acceleration", input.acceleration(Dimension.X))
-let lite = datalogger.createCV("temperature", input.lightLevel())
+let lite = datalogger.createCV("light", input.lightLevel())
 datalogger.log(temp, accel, lite)
 ```
 

--- a/libs/datalogger/docs/reference/datalogger.md
+++ b/libs/datalogger/docs/reference/datalogger.md
@@ -1,0 +1,65 @@
+# Datalogger
+
+The Datalogger extension logs user data to the flash storage on the @boardname@. Each data item is stored in a column of as part of a row of data. Data is logged to storage by rows. The columns can have names to specify the meaning of data item values.
+
+### ~ reminder
+
+#### Works with micro:bit V2
+
+![works with micro:bit V2 only image](/static/v2/v2-only.png)
+
+Using these blocks requires the [micro:bit V2](/device/v2) hardware. If you use any blocks that attempt access flash memory on a micro:bit v1 board, you will see the **927** error code on the screen.
+
+### ~
+
+## Data logs
+
+A data log will represent a table of information like:
+
+| Temperature | Acceleration | Light level |
+| - | - | - |
+| 20 | 3 |123 |
+| 23 | 2 | 210 |
+| 19 | 4 | 98 |
+<br/>
+
+A data item consits of value name, which is it's assigned column too, and the item's value. They are called "column-value" items. Here's how a column-value item is created.
+
+```blocks
+let item = datalogger.createCV("temperature", input.temperature())
+```
+
+Data items are logged to storage as a row. Here's an example of logging a row of data.
+
+```blocks
+let temp = datalogger.createCV("temperature", input.temperature())
+let accel = datalogger.createCV("acceleration", input.acceleration(Dimension.X))
+let lite = datalogger.createCV("temperature", input.lightLevel())
+datalogger.log(temp, accel, lite)
+```
+
+## Blocks in this extension
+
+```cards
+datalogger.createCV("", 0)
+datalogger.setColumnTitles([""])
+datalogger.log(datalogger.createCV("", null))
+datalogger.deleteLog(DeleteType.Fast)
+datalogger.includeTimestamp(FlashLogTimeStampFormat.None)
+datalogger.onLogFull(function() {})
+datalogger.mirrorToSerial(false)
+```
+
+## See also
+
+[create cv](/reference/datalogger/create-cv),
+[set column titles](/reference/datalogger/set-column-titles),
+[log](/reference/datalogger/log),
+[delete log](/reference/datalogger/delete-log),
+[include timestamp](/reference/datalogger/include-timestamp),
+[on log full](/reference/datalogger/send-to-console),
+[mirror to serial](/reference/datalogger/mirror-to-serial)
+
+```package
+datalogger
+```

--- a/libs/datalogger/docs/reference/datalogger/log.md
+++ b/libs/datalogger/docs/reference/datalogger/log.md
@@ -12,7 +12,7 @@ A log entry is made up of one or more "column-value" objects inserted into an ar
 
 ## Parameters
 
-* **data1 - data10**: one or more (up tp 10) of "column-value" objects to write to the data log.
+* **data1 - data10**: one or more (up to 10) of "column-value" objects to write to the data log.
 
 ## Example
 

--- a/libs/datalogger/docs/reference/datalogger/log.md
+++ b/libs/datalogger/docs/reference/datalogger/log.md
@@ -1,0 +1,33 @@
+# log
+
+Write a set data item parameters to the data log.
+
+```sig
+datalogger.log(null)
+```
+
+Data log entries are written to the log as an array of "column" and "value" data items. Each data value you want to record in the log has an column which it belongs to. The data value is attached to it's column by creating a "column-value" object with the data value matched to a column name.
+
+A log entry is made up of one or more "column-value" objects inserted into an array. This array is sent to the data log to write as the next log entry.
+
+## Parameters
+
+* **data1 - data10**: one or more (up tp 10) of "column-value" objects to write to the data log.
+
+## Example
+
+Record the state of the buttons on the @boardname@ every 500 milliseconds.
+
+```blocks
+loops.everyInterval(500, function () {
+    datalogger.log(datalogger.createCV("Button A", input.buttonIsPressed(Button.A)), datalogger.createCV("Button B", input.buttonIsPressed(Button.B)))
+})
+```
+
+## See also
+
+[create cv](/reference/datalogger/create-cv), [set column titles](/reference/datalogger/set-column-titles)
+
+```package
+datalogger
+```

--- a/libs/datalogger/docs/reference/datalogger/set-column-titles.md
+++ b/libs/datalogger/docs/reference/datalogger/set-column-titles.md
@@ -1,0 +1,35 @@
+# set Column Titles
+
+Set the names and order of the columns in the data log.
+
+```sig
+datalogger.setColumnTitles("")
+```
+
+The first entry in the data log is the "header" row which names the columns of the data values recorded. By default, the order in which the columns appear depends on the order of the column-value items appearing in the first entry written to the data log containing those items.
+
+You can set the names and the order of the columns for the log so that data values appear in the positions that you want them to be in. This also helps keep column order when data items happen to be in different places in log entry column-value array.
+
+## Parameters
+
+* **col1 - col10 **: one or more (up to 10) [strings](/types/string) that are the column names in the order they will appear in the data log header.
+
+## Example
+
+Set the columns for the data log to `value1`, `value2`, and `value3`. Make 3 log entries with the data items set in a different order. Check the logged values to see that they all appear in the correct colunms.
+
+```blocks
+datalogger.includeTimestamp(FlashLogTimeStampFormat.None)
+datalogger.setColumnTitles("value1", "value2", "value3")
+datalogger.logData([datalogger.createCV("value2", 9873), datalogger.createCV("value1", 23987), datalogger.createCV("value3", 5789)])
+datalogger.logData([datalogger.createCV("value3", 567), datalogger.createCV("value2", 789), datalogger.createCV("value1", 62)])
+datalogger.logData([datalogger.createCV("value1", 0), datalogger.createCV("value3", 87), datalogger.createCV("value2", 8)])
+```
+
+## See also
+
+[create cv](/reference/datalogger/create-cv), [include timestamp](/reference/datalogger/include-timestamp)
+
+```package
+datalogger
+```


### PR DESCRIPTION
Add a `datalogger` top level page to support the extension card's "Learn more" link. Also, add the `log` and `setColumnTitles` pages.

Fixes #4752