### PR TITLE
add app path names to bypass notification banner

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -563,6 +563,7 @@
         "editorVersionPaths": {
             "0": "v0"
         },
+        "appPathNames": [ "/v4" ],
         "showProjectSettings": true,
         "scriptManager": true,
         "debugger": true,


### PR DESCRIPTION
This is to make isExperimentalUrlPath evaluates to false here: https://github.com/microsoft/pxt/blob/master/webapp/src/notification.tsx#L118-L119 so that the notification banner does not show on windows app in /v4

![7885f89e-47e7-4af5-9593-ec1c95f69b3e](https://user-images.githubusercontent.com/5615930/174412874-dac4f2bd-3fbe-4b14-9914-cc74b4ba7532.jpg)