### PR TITLE
Extension: Add gator-soil

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -303,6 +303,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
     "name": "HTS221 Humidity and temperature",
     "url": "/pkg/makecode-extensions/HTS221",
     "cardType": "package"
+}, {
+    "name": "Gator Soil Sensor",
+    "url": "/pkg/sparkfun/pxt-gator-soil",
+    "cardType": "package"
 }]
 ```
 


### PR DESCRIPTION
New Sparkfun gator-soil product for extension approval. Note, did not change targetconfig.json file as gator-soil was already on the list