### PR TITLE
remove youtubeid in jacdac gallery

### DIFF
--- a/docs/jacdac.md
+++ b/docs/jacdac.md
@@ -23,8 +23,7 @@ Connect and Code. Instantly.
         "name": "Button smasher",
         "description": "How many times can you smash the button in 10 seconds?",
         "url": "https://microsoft.github.io/jacdac-docs/clients/makecode/projects/button-smasher/",
-        "imageUrl": "/static/jacdac/button-smasher.jpg",
-        "youTubeId": "rlK_8oqMAmo"
+        "imageUrl": "/static/jacdac/button-smasher.jpg"
     },
     {
         "name": "Slider Sound Bender",


### PR DESCRIPTION
The gallery item has a url and a youtubeid, pxt gets confused and renders a "play video" button that points to the URL. This feels like a regression (can we have a video + a project link?) but it's probably not worth a hot patch.

You can test the current broken behavior in makecode.microbit.org

<img width="730" alt="image" src="https://user-images.githubusercontent.com/4175913/177688129-367db980-2be9-4a51-97c5-2a91e0ee191a.png">