### PR TITLE
set min version for pxt-maqueen to fix compile

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -589,6 +589,7 @@
             "4tronix/servobit": { "tags": [ "Robotics" ] },
             "dfrobot/pxt-maqueen": {
                 "tags": [ "Robotics" ],
+                "upgrades": [ "min:v1.7.0" ],
                 "preferred": true
             },
             "dfrobot/pxt-dfrobot-microiot": { "tags": [ "Networking" ] },


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/4812#issuecomment-1190785183

I just picked to always update to the current latest as that's been around for a while at this point