### PR TITLE
Add dialog for 'program too large' errors

### DIFF
--- a/editor/dialogs.tsx
+++ b/editor/dialogs.tsx
@@ -13,3 +13,26 @@ export function cantImportAsync(project: pxt.editor.IProjectView) {
         ]
     }).then(() => project.openHome())
 }
+
+
+export async function showProgramTooLargeErrorAsync(variants: string[], confirmAsync: (opts: any) => Promise<number>) {
+    if (variants.length !== 2) return undefined;
+
+    const choice = await confirmAsync({
+        header: lf("Program too large..."),
+        body: lf("Your program is too large to fit on the micro:bit V1! Would you like to try compiling for the micro:bit V2? This hex file will not be able to run on the micro:bit V1"),
+        bigHelpButton: true,
+        agreeLbl: lf("Download for V2")
+    });
+
+    if (choice) {
+        return {
+            recompile: true,
+            useVariants: ["mbcodal"]
+        }
+    }
+    return {
+        recompile: false,
+        useVariants: []
+    }
+}

--- a/editor/dialogs.tsx
+++ b/editor/dialogs.tsx
@@ -19,13 +19,18 @@ export async function showProgramTooLargeErrorAsync(variants: string[], confirmA
     if (variants.length !== 2) return undefined;
 
     const choice = await confirmAsync({
-        header: lf("Program too large..."),
-        body: lf("Your program is too large to fit on the micro:bit V1! Would you like to try compiling for the micro:bit V2? This hex file will not be able to run on the micro:bit V1"),
+        header: lf("Oops, there was a problem downloading your code"),
+        body: lf("Great coding skills! Unfortunately, your program is too large to fit on a micro:bit V1😢. You can go back and try to make your program smaller, or you can download your program onto a micro:bit V2."),
         bigHelpButton: true,
-        agreeLbl: lf("Download for V2")
+        agreeLbl: lf("Go Back"),
+        agreeClass: "cancel",
+        agreeIcon: "cancel",
+        disagreeLbl: lf("Download for V2 only"),
+        disagreeClass: "positive",
+        disagreeIcon: "checkmark"
     });
 
-    if (choice) {
+    if (!choice) {
         return {
             recompile: true,
             useVariants: ["mbcodal"]

--- a/editor/extension.tsx
+++ b/editor/extension.tsx
@@ -41,5 +41,6 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
 
     res.mkPacketIOWrapper = flash.mkDAPLinkPacketIOWrapper;
     res.blocklyPatch = patch.patchBlocks;
+    res.showProgramTooLargeErrorAsync = dialogs.showProgramTooLargeErrorAsync;
     return Promise.resolve<pxt.editor.ExtensionResult>(res);
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.0.1",
-        "pxt-core": "8.0.2"
+        "pxt-core": "8.2.6"
     }
 }


### PR DESCRIPTION
This is the micro:bit side of https://github.com/microsoft/pxt/pull/8991

The build will fail until that PR is merged/released. 

Opening this as a draft PR so that we can discuss what the contents of this dialog should be. This dialog will show whenever a user tries to download a program that is too large for the micro:bit v1's flash. In addition to text, we can also link a help/support page and provide images.

The purpose of this dialog is to provide the user the option to download their program just for the micro:bit v2 which has a much larger flash size than the v1. Because normal hex files from the micro:bit editor work for both v1 and v2 micro:bits, this dialog needs to make it super clear that if you recompile for v2 then the hex file will not work on a v1 micro:bit

@Jaqster @jaustin @BeckHaru 