### PR TITLE
unpin beta from v5.0

### DIFF
--- a/docs/beta-ref.json
+++ b/docs/beta-ref.json
@@ -1,3 +1,3 @@
 {
-    "appref": "v5.0"
+    "appref": "v"
 }


### PR DESCRIPTION
this was pinned back in https://github.com/microsoft/pxt-microbit/pull/4766, unpinning so beta picks up new test changes (e.g. catalan language testing for angel). /stable still points at v5.0~