### PR TITLE
guard against NaN in music.playTone

### DIFF
--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -199,6 +199,7 @@ namespace music {
     //% useEnumVal=1
     //% group="Tone"
     export function playTone(frequency: number, ms: number): void {
+        if (isNaN(frequency) || isNaN(ms)) return;
         if (_playTone) _playTone(frequency, ms);
         else pins.analogPitch(frequency, ms);
     }
@@ -292,6 +293,7 @@ namespace music {
     //% weight=100
     export function changeTempoBy(bpm: number): void {
         init();
+        if (isNaN(bpm)) return;
         setTempo(beatsPerMinute + bpm);
     }
 
@@ -306,6 +308,7 @@ namespace music {
     //% weight=99
     export function setTempo(bpm: number): void {
         init();
+        if (isNaN(bpm)) return;
         if (bpm > 0) {
             beatsPerMinute = Math.max(1, bpm);
         }

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -127,7 +127,7 @@ namespace pxsim.pins {
     export function analogPitch(frequency: number, ms: number) {
         // update analog output
         const b = board();
-        if (!b) return;
+        if (!b || isNaN(frequency) || isNaN(ms)) return;
         const ec = b.edgeConnectorState;
         const pins = ec.pins;
         const pin = ec.pitchEnabled && (pins.filter(pin => !!pin && pin.pitch)[0] || pins[0]);


### PR DESCRIPTION
Jacdac is susceptible to produce NaNs, which crash this API. Ignore NaNs.