### PR TITLE
Extension: add DFRobot Boson Kit

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -319,7 +319,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 ```codecard
 [{
   "name": "DFRobot IoT Cloud Kit",
-  "url":"/pkg/dfrobot/pxt-dfrobot_boson_kit",
+  "url":"/pkg/DFRobot/pxt-DFRobot_IoT_Cloud_Kit",
   "cardType": "package"
 }, {
   "name": "iClass IoT",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -423,6 +423,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "name": "Minode Kit",
   "url":"/pkg/minodekit/pxt-minode",
   "cardType": "package"
+}, {
+  "name": "DFRobot Boson Kit",
+  "url":"/pkg/DFRobot/pxt-DFRobot_Boson_Kit",
+  "cardType": "package"
 }]
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -425,7 +425,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "cardType": "package"
 }, {
   "name": "DFRobot Boson Kit",
-  "url":"/pkg/DFRobot/pxt-DFRobot_Boson_Kit",
+  "url":"/pkg/dfrobot/pxt-dfrobot_boson_kit",
   "cardType": "package"
 }]
 ```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -319,7 +319,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 ```codecard
 [{
   "name": "DFRobot IoT Cloud Kit",
-  "url":"/pkg/DFRobot/pxt-DFRobot_IoT_Cloud_Kit",
+  "url":"/pkg/dfrobot/pxt-dfrobot_boson_kit",
   "cardType": "package"
 }, {
   "name": "iClass IoT",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -425,7 +425,7 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "cardType": "package"
 }, {
   "name": "DFRobot Boson Kit",
-  "url":"/pkg/dfrobot/pxt-dfrobot_boson_kit",
+  "url":"/pkg/dfrobot/pxt-dfrobot_bosonkit",
   "cardType": "package"
 }]
 ```

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -773,7 +773,7 @@
             "joy-it/pxt-ads1115": { "tags": [ "Individual sensors" ] },
             "bsiever/microbit-pxt-rotate": { "tags": [ "Software" ] },
             "sparkfun/pxt-gator-uv": { "tags": [ "Science" ] },
-            "dfrobot/pxt-dfrobot_boson_kit": { "tags": [ "Science" ] }
+            "dfrobot/pxt-dfrobot_bosonkit": { "tags": [ "Science" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -772,7 +772,8 @@
             "bsiever/microbit-pxt-clicks": { "tags": [ "Software" ] },
             "joy-it/pxt-ads1115": { "tags": [ "Individual sensors" ] },
             "bsiever/microbit-pxt-rotate": { "tags": [ "Software" ] },
-            "sparkfun/pxt-gator-uv": { "tags": [ "Science" ] }
+            "sparkfun/pxt-gator-uv": { "tags": [ "Science" ] },
+            "dfrobot/pxt-dfrobot_boson_kit": { "tags": [ "Science" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
From support ticket https://support.microbit.org/helpdesk/tickets/57632 (private)
Extension URL: https://github.com/DFRobot/pxt-DFRobot_Boson_Kit

@zhang-tang Please confirm the choice of gallery (https://makecode.microbit.org/extensions) section "Kits", and extension dialog tag "Science", and signal when you have completed the last few changes.

@abchatra ​The rules in the links below seem to specify the namespace as camel case, and the name in pxt.json as lowercase, but there are existing extensions that break those rules. Is "BosonKit" for both OK?

https://makecode.com/extensions/naming-conventions
https://makecode.com/extensions/pxt-json.md