### PR TITLE
Correct component name: speaker, not microphone

### DIFF
--- a/docs/device/v2.md
+++ b/docs/device/v2.md
@@ -58,7 +58,7 @@ The first thing to know is whether you have a micro:bit v1 or micro:bit v2 at ha
 ![micro:bit v1 and micro:bit v2 front side by side](/static/v2/front.jpg)
 
 * red power LED next to the USB connect
-* large black microphone component centrally located in the back and rotated by 45 degrees
+* large black speaker component centrally located in the back and rotated by 45 degrees
 * slanted radio antenna
 
 ![micro:bit v1 and micro:bit v2 back side by side](/static/v2/back.jpg)


### PR DESCRIPTION
I believe the "large black... component centrally located in the back and rotated by 45 degrees" is a speaker, not a microphone. The microphone is the smaller silver component LABELLED IN SILKSCREEN.  Speakers NEED TO BE large, to move air.  Microphones, not so much.

Pictured here:
https://microbit-micropython.readthedocs.io/en/v2-docs/speaker.html#module-microbit.speaker