### PR TITLE
Enable the windows app deprecation banner.

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -601,7 +601,7 @@
             "incompatibleHardwareImage": "/static/download/incompatible.png"
         },
         "winAppDeprImage": "/static/winapp.PNG",
-        "showWinAppDeprBanner": false
+        "showWinAppDeprBanner": true
     },
     "queryVariants": {
         "hidemenu": {


### PR DESCRIPTION
Enable the WinApp deprecation banner. The contents of the banner will be updated in https://github.com/microsoft/pxt/pull/9238.