### PR TITLE
Extension: add Apprentice Car

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -493,6 +493,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
+  "name": "Resolute Apprentice Car",
+  "url":"/pkg/resolute-support/pxt-apprentice_Car",
+  "cardType": "package"
+}, {
   "name": "Elecfreaks XGO",
   "url":"/pkg/elecfreaks/pxt-xgo",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -773,7 +773,8 @@
             "joy-it/pxt-ads1115": { "tags": [ "Science" ] },
             "bsiever/microbit-pxt-rotate": { "tags": [ "Software" ] },
             "sparkfun/pxt-gator-uv": { "tags": [ "Science" ] },
-            "dfrobot/pxt-dfrobot_bosonkit": { "tags": [ "Science" ] }
+            "dfrobot/pxt-dfrobot_bosonkit": { "tags": [ "Science" ] },
+            "resolute-support/pxt-apprentice_car": { "tags": [ "Robotics" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
cc @resolute-support

@abchatra I have suggested:
- changing parameters in blocks to lower case, though there are already extensions with Capitalised parameters.
- making some of the JavaScript names more meaningful

I don't know why the JavaScript function PH() is highlighted in green.

Many of the JavaScript mode tooltips have sometimes said (+1 overload), but that went away in a new project. Maybe it's a caching issue after updating the extension version in an existing project?

Here's a project with all the blocks, not necessarily in a sensible order.
https://makecode.microbit.org/_0KsTxhEchMTR
![image](https://user-images.githubusercontent.com/989126/202706428-71c68440-549e-4250-9a89-3698853bc494.png)
