### PR TITLE
Expand timing info for music blocks reference

### DIFF
--- a/docs/reference/music/beat.md
+++ b/docs/reference/music/beat.md
@@ -1,16 +1,10 @@
 # Beat
 
-Returns the duration of a beat in milli-seconds
+Returns the duration of a beat in milliseconds
 
 ```sig
 music.beat(BeatFraction.Whole)
 ```
-
-## ~ hint
-
-**Simulator**: This function only works on the @boardname@ and in some browsers.
-
-## ~
 
 ## Parameters
 

--- a/docs/reference/music/change-tempo-by.md
+++ b/docs/reference/music/change-tempo-by.md
@@ -7,11 +7,13 @@ faster or slower by the amount you say.
 music.changeTempoBy(20)
 ```
 
-## ~ hint
+### ~hint
 
-**Simulator**: This function only works on the @boardname@ and in some browsers.
+#### Simulator
 
-## ~
+``||music:change tempo by||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 

--- a/docs/reference/music/play-tone.md
+++ b/docs/reference/music/play-tone.md
@@ -1,36 +1,49 @@
 # Play Tone
 
-Play a musical tone through pin ``P0`` of the @boardname@ for as long as you say.
-
-## ~ hint
-
-This function only works on the @boardname@ and in some browsers.
-
-## ~
+Play a musical tone on the speaker or at a sound pin of the @boardname@ for as long as you say.
 
 ```sig
 music.playTone(440, 120)
 ```
+The frequency of the tone is set as a number of cycle per second, or Hertz. The [note frequency](/reference/music/note-frequency) block will allow you to use a musical note for the tone instead of a number of Hertz.
+
+The duration of the tone is set as a number of milliseconds. It's typical though to use a number of beats or a beat fraction for the tone duration instead. The ``||music:beat||`` block is used to convert beats to milliseconds. You can also make a custom duration by just setting the tone duration to certain amount of milliseconds.
+
+### ~hint
+
+#### Simulator
+
+The ``||music:play tone||`` block works on the @boardname@ board. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 
-* ``frequency`` is the [number](/types/number) of Hertz (how high or low the tone is).
-* ``ms`` is the [number](/types/number) of milliseconds that the tone lasts
+* **frequency** is the [number](/types/number) of Hertz (how high or low the tone is). You can set this value with a note instead by using the [note frequency](/reference/music/note-frequency) block.
+* **ms** is the [number](/types/number) of milliseconds for the duration of the tone. A [beat](/reference/music/beat) value is used instead as the block's default tone duration. The number of beats is converted to milliseconds for you.
+
 
 ## Example
 
-This example stores the musical note C in the variable `freq`.
-Next, it plays that note for 1000 milliseconds (one second).
+### Tone and beat
+
+Play a `Middle C` for `1 beat`.
 
 ```blocks
-let freq = music.noteFrequency(Note.C)
-music.playTone(freq, 1000)
+music.playTone(music.noteFrequency(Note.C), music.beat(BeatFraction.Whole)))
 ```
 
+### Custom tone frequency and duration
+
+Play a `250` Hertz tone for `1000` milliseconds.
+
+```blocks
+music.playTone(250, 1000)
+```
 
 ## Using other pins
 
-Use [analogSetPitchPin](/reference/pins/analog-set-pitch-pin) to change that pin used to generate music.
+Use [analogSetPitchPin](/reference/pins/analog-set-pitch-pin) to change the pin used to generate music.
 
 ```blocks
 pins.analogSetPitchPin(AnalogPin.P1);

--- a/docs/reference/music/play-tone.md
+++ b/docs/reference/music/play-tone.md
@@ -30,7 +30,7 @@ The ``||music:play tone||`` block works on the @boardname@ board. It might not w
 Play a `Middle C` for `1 beat`.
 
 ```blocks
-music.playTone(music.noteFrequency(Note.C), music.beat(BeatFraction.Whole)))
+music.playTone(music.noteFrequency(Note.C), music.beat(BeatFraction.Whole))
 ```
 
 ### Custom tone frequency and duration
@@ -46,7 +46,7 @@ music.playTone(250, 1000)
 Use [analogSetPitchPin](/reference/pins/analog-set-pitch-pin) to change the pin used to generate music.
 
 ```blocks
-pins.analogSetPitchPin(AnalogPin.P1);
+pins.analogSetPitchPin(AnalogPin.P1)
 ```
 
 ## See also

--- a/docs/reference/music/rest.md
+++ b/docs/reference/music/rest.md
@@ -1,29 +1,47 @@
 # Rest
 
-Rest (play no sound) through pin `PO` for the amount of time you say.
+Play no sound (rest) on the speaker or at a sound pin for the amount of time you say.
 
 ```sig
 music.rest(400)
 ```
 
-### ~ hint
+The duration of the rest is set as a number milliseconds. Instead, it's typical to use a number of beats or a beat fraction for a rest. The ``||music:beat||`` block is used to convert beats to milliseconds. You can also make a custom rest by setting the rest duration to certain amount of milliseconds.
 
-**Simulator**: This function only works on the @boardname@ and in some browsers.
+### ~hint
 
-## ~
+#### Simulator
+
+The ``||music:rest||`` block works on the @boardname@ board. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 
-* ``ms`` is a [number](/types/number) saying how many
-  milliseconds the @boardname@ should rest. One second is 1000
-  milliseconds.
+* **ms** is the [number](/types/number) of milliseconds for the duration of the rest. A [beat](/reference/music/beat) value is used instead as the block's default rest duration. The number of beats is converted to milliseconds for you.
 
 ## Example
 
+### Middle C loop
+
+Continuously play a `Middle C` tone for `1` beat and rest for `2` beats.
+
 ```blocks
-let frequency = music.noteFrequency(Note.C)
-music.playTone(frequency, 1000)
-music.rest(1000)
+basic.forever(function () {
+    music.playTone(262, music.beat(BeatFraction.Whole))
+    music.rest(music.beat(BeatFraction.Double))
+})
+```
+
+### Custom rest time
+
+Continuously play a `Middle C` note followed by a random rest time.
+
+```blocks
+basic.forever(function () {
+    music.playTone(262, music.beat(BeatFraction.Whole))
+    music.rest(randint(500, 2000))
+})
 ```
 
 ## See also

--- a/docs/reference/music/ring-tone.md
+++ b/docs/reference/music/ring-tone.md
@@ -1,22 +1,23 @@
 # Ring Tone
 
-Play a musical tone through pin `P0` with the pitch as high or low as you say.
-The tone will keep playing until you tell it not to.
+Play a musical tone on the speaker or at a sound pin of the @boardname@ with the pitch as high or low as you say. The tone will keep playing until you tell it not to.
 
 ```sig
 music.ringTone(440)
 ```
 
-## ~ hint
+### ~hint
 
-**Simulator**: This function only works on the @boardname@ and in some browsers.
+#### Simulator
 
-## ~
+The ``||music:ring tone||`` block works on the @boardname@ board. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 
 * ``frequency`` is a [number](/types/number) that says
-how high-pitched or low-pitched the tone is.  This
+how high-pitched or low-pitched the tone is. This
 number is in **Hz** (**Hertz**), which is a measurement of frequency
 or pitch.
 

--- a/docs/reference/music/set-tempo.md
+++ b/docs/reference/music/set-tempo.md
@@ -5,11 +5,15 @@ Makes the tempo (speed of a piece of music) as fast or slow as you say.
 ```sig
 music.setTempo(60)
 ```
-## ~ hint
 
-**Simulator**: This function only works on the @boardname@ and in some browsers.
+### ~hint
 
-## ~
+#### Simulator
+
+``||music:set tempo||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
+
 
 ## Parameters
 


### PR DESCRIPTION
Add some clarifying info for the timing parameters in the older music blocks reference pages.

**Note**: The convention is to use the JavaScript parameter names in listings under **Parameters** on the ref pages. The term "duration" is used in the descriptions to associate that with the parameter.

Closes #4907