### PR TITLE
Restate timing info in 'pause' ref page

### DIFF
--- a/docs/reference/basic/pause.md
+++ b/docs/reference/basic/pause.md
@@ -1,6 +1,6 @@
 # Pause
 
-Pause the program for the number of milliseconds you say. 
+Pause the program for a duration of the number milliseconds you say. 
 You can use this function to slow your program down.
 
 ```sig
@@ -9,24 +9,23 @@ basic.pause(400)
 
 ## Parameters
 
-* ``ms`` is the number of milliseconds that you want to pause (100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second).
+* **ms** is the number of milliseconds (duration) of your pause time. To convert from seconds: 100 milliseconds = 1/10 second and 1000 milliseconds = 1 second.
 
-## Example: diagonal line
+## Example
 
-This example draws a diagonal line by turning on LED `0, 0` (top left) through LED `4, 4` (bottom right). 
-The program pauses 500 milliseconds after turning on each LED. 
-Without `pause`, the program would run so fast that you would not have time to see each LED turning on.
+Randomly turn on and off the LED pixels on the screen.
 
 ```blocks
-for (let i = 0; i < 5; i++) {
-    led.plot(i, i)
-    basic.pause(500)
-}
+let duration = 500
+basic.forever(function () {
+    led.toggle(randint(0, 4), randint(0, 4))
+    basic.pause(duration)
+})
 ```
 
 ## Advanced
 
-If `ms` is `NaN` (not a number), it will default to `20` ms.
+If **ms** is an invalid number (`NaN`, not a number), the pause will default to `20` ms.
 
 ## See also
 

--- a/docs/reference/basic/pause.md
+++ b/docs/reference/basic/pause.md
@@ -9,7 +9,7 @@ basic.pause(400)
 
 ## Parameters
 
-* **ms** is the number of milliseconds (duration) of your pause time. To convert from seconds: 100 milliseconds = 1/10 second and 1000 milliseconds = 1 second.
+* **ms**: the number of milliseconds (duration) of your pause time. To convert from seconds: 100 milliseconds = 1/10 second and 1000 milliseconds = 1 second.
 
 ## Example
 


### PR DESCRIPTION
Associate the term 'duration' with the time parameter, `ms` in the pause block reference page.

**Note**: The convention for parm names under **Parameters** section is to use the parameter name from the Javascript function for the block.

![image](https://user-images.githubusercontent.com/27789908/212160270-cb62c675-30bb-4b2a-8e84-914646936b90.png)

Closes #4908