### PR TITLE
Bump CODAL from 0.2.40 to 0.2.46

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -165,7 +165,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.40",
+                    "branch": "v0.2.46",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
# **DO NOT MERGE**

Creating this PR to (hopefully!) invoke a build action for prototype builds of PXT against newer versions of CODAL.