### PR TITLE
Extension: gator-environment v1.1.2 supports V2

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -435,7 +435,7 @@
             "sparkfun/pxt-weather-bit": { "tags": [ "Science" ] },
             "sparkfun/pxt-gator-environment": {
                 "tags": [ "Science" ],
-                "upgrades": [ "dv:mbcodal" ]
+                "upgrades": [ "min:v1.1.2" ]
             },
             "minodekit/pxt-minode": {
                 "tags": [ "Science" ],


### PR DESCRIPTION
@loricrotser

@abchatra
This changes "dv:mbcodal" to "min:v1.1.2" in the "approvedRepoLib" section.

Is that the right way to enable V2 builds and cause existing projects to upgrade?

Does the "upgrades" section need a similar change?