### PR TITLE
Set Margin for Tutorial Mini-Playable Simulator

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -94,3 +94,4 @@
 @sidebarSecondaryColor: @white;
 @sidbarActiveTabIconColor: @primaryColor;
 @tutorialBarBackgroundColor: #ecf0f1;
+@tutorialSimframeMargin: 0.3rem;


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9388.

With the default value, if the new tutorial layout is enabled, it looks like this:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/69657545/218892898-7179a68d-ed48-47f1-a70c-e1cce5f4463d.png">

With this change, it looks like this:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/69657545/218893230-f06a2150-78f9-4295-b430-53fe43b1ee45.png">
