### PR TITLE
Extension: add Cytron MOTION:BIT

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -493,6 +493,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
+  "name": "Cytron MOTION:BIT",
+  "url":"/pkg/CytronTechnologies/pxt-motionbit",
+  "cardType": "package"
+}, {
   "name": "MAKE&LEARN Didacbot",
   "url":"/pkg/MakeAndLearn/pxt-didacbot",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -775,7 +775,8 @@
             "sparkfun/pxt-gator-uv": { "tags": [ "Science" ] },
             "dfrobot/pxt-dfrobot_bosonkit": { "tags": [ "Science" ] },
             "resolute-support/pxt-apprentice_car": { "tags": [ "Robotics" ] },
-            "makeandlearn/pxt-didacbot": { "tags": [ "Robotics" ] }
+            "makeandlearn/pxt-didacbot": { "tags": [ "Robotics" ] },
+            "cytrontechnologies/pxt-motionbit": { "tags": [ "Robotics" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/60301 (private)

@waiweng83

@abchatra The extension duplicates the Neopixel extension code because it is required to use Neopixels at the same time as Bluetooth. There are only 2 Neopixels on the board and their extensive tests have not found any problems. Is there a better way to reuse the Neopixel code?

https://makecode.microbit.org/_M809MrTK4Pjf

![image](https://user-images.githubusercontent.com/989126/219389577-fadbddb7-42f4-4c46-8bb7-0913dd8ce99c.png)
