### PR TITLE
Bump Pxt Core Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.0.1",
-        "pxt-core": "8.2.6"
+        "pxt-core": "8.6.10"
     }
 }


### PR DESCRIPTION
Bumping to 8.6.10 (https://github.com/microsoft/pxt/commit/39bca60c3afd1aeb385fde970f7f2c38d7a07b6d)