### PR TITLE
Check serial baud rate before setting it & only set it if necessary.

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -264,7 +264,19 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         return this.io.isConnecting() || (this.io.isConnected() && !this.initialized)
     }
 
+    private async getBaudRate() {
+        const readSerialSettings = new Uint8Array([0x81])  // get serial settings
+        const serialSettings = await this.dapCmd(readSerialSettings)
+        const baud = (serialSettings[4] << 24)+ (serialSettings[3] << 16) + (serialSettings[2] << 8) + serialSettings[1]
+        return baud
+    }
+
     private async setBaudRate() {
+        const currentBaudRate = await this.getBaudRate()
+        if (currentBaudRate === 115200) {
+            log(`baud rate already set to 115200`)
+            return
+        }
         log(`set baud rate to 115200`)
         const baud = new Uint8Array(5)
         baud[0] = 0x82 // set baud


### PR DESCRIPTION
Setting the WebUSB serial baud rate makes DAPLink send a "break signal", which basically resets the target.

We can avoid this reset in some occasions by checking first the DAPLink serial settings and only set the baud rate if necessary.

For devices with DAPLink 0257 and newer (V2.2 factory image and future DAPLink releases for all boards) the default baud rate is set to 115200 already, so with this change they will never have to set the baud rate and it won't reset due to this on WebUSB connection.
Devices with older DAPLink versions have a default baud rate of 9600, so MakeCode will set the baud rate on first connection (triggering a reset), but won't have to set it again until the device is unplugged.

Tested with V1 with DAPLink 0249 and V2.00 with 0258-beta.1.