### PR TITLE
Bumping codal to 0.2.49

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -165,7 +165,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.40",
+                    "branch": "v0.2.49",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
## **Do Not Merge (yet)**

Moved PXT-Microbit to 0.2.49 for a new test cloud build.