### PR TITLE
turtle square - avoid drawing first side twice

### DIFF
--- a/docs/projects/turtle-square.md
+++ b/docs/projects/turtle-square.md
@@ -47,7 +47,7 @@ Did you notice the pattern of repeated blocks needed to draw a square? Try using
 
 ```blocks
 input.onButtonPressed(Button.A, function() {
-    for(let index = 0; index <= 4; index++) {
+    for(let index = 0; index <= 3; index++) {
         turtle.forward(1)
         turtle.turnRight()
     }
@@ -61,7 +61,7 @@ The turtle holds a **pen** that can turn on LEDs. If you add the ``||turtle:pen|
 ```blocks
 input.onButtonPressed(Button.A, function() {
     turtle.pen(TurtlePenMode.Down)
-    for(let index = 0; index <= 4; index++) {
+    for(let index = 0; index <= 3; index++) {
         turtle.forward(1)
         turtle.turnRight()
     }


### PR DESCRIPTION
Problem reported in ticket https://support.microbit.org/helpdesk/tickets/60660 (private). 

The for loop running from 0 to 4, means 5 sides are drawn. Suggested change is to use 0 to 3.
