### PR TITLE
Remove Unnecessary Left Border on Toolbox

### DIFF
--- a/theme/blockly-toolbox.less
+++ b/theme/blockly-toolbox.less
@@ -22,7 +22,6 @@ span.blocklyTreeLabel {
 
 .blocklyToolboxDiv, .monacoToolboxDiv {
     background-color: white !important;
-    border-left: 1px solid #ecf0f1 !important;
     box-shadow: 4px 0px 2px -4px rgba(0,0,0,0.12), 4px 0px 2px -4px rgba(0,0,0,0.24);
 }
 


### PR DESCRIPTION
We already have a right border on the sim, so this ends up being a double border that looks thicker than the rest of the line. It's a little hard to see in the sim, but I found it quite noticeable while actually using the app. You may be able to notice it in this local serve (which does not have the fix): https://makecode.microbit.org/app/2d29195101272fd7e50ee924b15f5bd9f540fb97-d100f373bc

The other border-left styles in this file don't seem to be doing any harm, so I didn't touch them.

Without Change
![image](https://user-images.githubusercontent.com/69657545/228643917-9cf5b3b9-d17b-4eb0-a991-1005301952af.png)

![image](https://user-images.githubusercontent.com/69657545/228643536-8e0974d2-a2f2-49bf-8f50-120ae350f7e6.png)

With Change
![image](https://user-images.githubusercontent.com/69657545/228642958-ec31ca8c-db03-4d97-8bb7-963dbcdd4762.png)

![image](https://user-images.githubusercontent.com/69657545/228642916-089e7599-678c-4f7f-b7c1-99eafa7357dc.png)
