### PR TITLE
Improve createSoundEffect code size

### DIFF
--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -368,46 +368,58 @@ namespace music {
     //% expandableArgumentBreaks="3,5"
     //% group="micro:bit (V2)"
     export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): string {
-        const sound = new soundExpression.Sound();
-        sound.wave = waveShape;
-        sound.frequency = startFrequency;
-        sound.volume = ((startVolume / 255) * 1023) | 0;
-        sound.endFrequency = endFrequency;
-        sound.endVolume = ((endVolume / 255) * 1023) | 0;
-        sound.duration = duration;
-        sound.fx = effect;
+        let src = "000000000000000000000000000000000000000000000000000000000000000000000000";
+        src = setValue(src, 0, Math.constrain(waveShape, 0, 4), 1);
+        src = setValue(src, 1, Math.constrain(((startVolume / 255) * 1023) | 0, 0, 1023), 4);
+        src = setValue(src, 5, startFrequency, 4);
+        src = setValue(src, 9, duration, 4);
+        src = setValue(src, 18, endFrequency, 4);
+        src = setValue(src, 26, Math.constrain(((endVolume / 255) * 1023) | 0, 0, 1023), 4);
+        src = setValue(src, 34, Math.constrain(effect, 0, 3), 2);
+
 
         switch (interpolation) {
             case InterpolationCurve.Linear:
-                sound.shape = soundExpression.InterpolationEffect.Linear;
-                sound.steps = 128;
+                src = setValue(src, 13, soundExpression.InterpolationEffect.Linear, 2);
+                src = setValue(src, 30, 128, 4);
                 break;
             case InterpolationCurve.Curve:
-                sound.shape = soundExpression.InterpolationEffect.Curve;
-                sound.steps = 90;
+                src = setValue(src, 13, soundExpression.InterpolationEffect.Curve, 2);
+                src = setValue(src, 30, 90, 4);
                 break;
             case InterpolationCurve.Logarithmic:
-                sound.shape = soundExpression.InterpolationEffect.Logarithmic;
-                sound.steps = 90;
+                src = setValue(src, 13, soundExpression.InterpolationEffect.Logarithmic, 2);
+                src = setValue(src, 30, 90, 4);
                 break;
         }
 
-        switch (sound.fx) {
+        switch (effect) {
             case SoundExpressionEffect.Vibrato:
-                sound.fxnSteps = 512;
-                sound.fxParam = 2;
+                src = setValue(src, 36, 2, 4);
+                src = setValue(src, 40, 512, 4);
                 break;
             case SoundExpressionEffect.Tremolo:
-                sound.fxnSteps = 900;
-                sound.fxParam = 3;
+                src = setValue(src, 36, 3, 4);
+                src = setValue(src, 40, 900, 4);
                 break;
             case SoundExpressionEffect.Warble:
-                sound.fxnSteps = 700;
-                sound.fxParam = 2;
+                src = setValue(src, 36, 2, 4);
+                src = setValue(src, 40, 700, 4);
                 break;
         }
 
-        return sound.src;
+        return src;
+    }
+
+    function setValue(src: string, offset: number, value: number, length: number) {
+        value = Math.constrain(value | 0, 0, Math.pow(10, length) - 1);
+        return src.substr(0, offset) + formatNumber(value, length) + src.substr(offset + length);
+    }
+
+    function formatNumber(num: number, length: number) {
+        let result = num + "";
+        while (result.length < length) result = "0" + result;
+        return result;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4941

Avoiding using the Sound class with all it's getters/setters. It's a nice API, but I guess it generated more code than I expected. The class is still there, but it's not used in this function anymore.

To get much of an improvement beyond this, we'd probably need a new API from codal instead of the string API. Would be great if we could pass the args in a byte array or something so that we don't have to deal with all of the string formatting. I know @jaustin was talking about getting rid of the string representation at some point...

For this program:

https://makecode.microbit.org/_bwgdsdXPbCcK

Code size before this change:
```
generated code sizes (bytes): 7424 (incl. 5624 user, 946 helpers, 450 vtables, 404 lits)
```

Code size after this change:
```
generated code sizes (bytes): 4016 (incl. 2934 user, 808 helpers, 110 vtables, 164 lits)
```

One thing to note: the linked issue mentions 48kb of data, which isn't quite accurate because that's the binary.js size and not the compiled code size. To get an accurate number, you need to download the hex file and open the mbcodal.asm file that appears under the built folder. You can also add `?compiler=size` to the url to get more detailed size information in that file.