### PR TITLE
Recording Extension: using a local stream normalizer to change recording mic gain

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -31,17 +31,7 @@ namespace record {
 static StreamRecording *recording = NULL;
 static SplitterChannel *splitterChannel = NULL;
 static MixerChannel *channel = NULL;
-
-void enableMic() {
-    uBit.audio.activateMic();
-    uBit.audio.mic->enable();
-}
-
-void disableMic() {
-    uBit.audio.mic->disable();
-    uBit.audio.deactivateMic();
-}
-
+static StreamNormalizer *localProcessor = NULL;
 
 void checkEnv(int sampleRate = -1) {
     if (recording == NULL) {
@@ -50,8 +40,8 @@ void checkEnv(int sampleRate = -1) {
         MicroBitAudio::requestActivation();
 
         splitterChannel = uBit.audio.splitter->createChannel();
-
-        recording = new StreamRecording(*splitterChannel);
+        localProcessor = new StreamNormalizer(*splitterChannel);
+        recording = new StreamRecording(localProcessor->output);
 
         channel = uBit.audio.mixer.addChannel(*recording, sampleRate);
 
@@ -72,7 +62,6 @@ void checkEnv(int sampleRate = -1) {
 //% promise
 void record() {
     checkEnv();
-    enableMic();
     recording->record();
 }
 
@@ -82,7 +71,6 @@ void record() {
 //%
 void play() {
     checkEnv();
-    disableMic();
     recording->play();
 }
 
@@ -92,7 +80,6 @@ void play() {
 //%
 void stop() {
     checkEnv();
-    disableMic();
     recording->stop();
 }
 
@@ -102,7 +89,6 @@ void stop() {
 //%
 void erase() {
     checkEnv();
-    disableMic();
     recording->erase();
 }
 
@@ -111,15 +97,16 @@ void erase() {
  */
 //%
 void setMicrophoneGain(int gain) {
+    checkEnv();
     switch (gain) {
     case 1:
-        uBit.audio.processor->setGain(0.079f);
+        localProcessor->setGain(0.5f);
         break;
     case 2:
-        uBit.audio.processor->setGain(0.2f);
+        localProcessor->setGain(1.0f);
         break;
     case 3:
-        uBit.audio.processor->setGain(0.4f);
+        localProcessor->setGain(2.0f);
         break;
     }
 }


### PR DESCRIPTION
**Context**
Before, when setting mic gain for the microphone, the microphone would be effected globally. Therefore, if someone changed the sensitivity of the mic with the audio extension and tried to use a block like `onLoudSound` the threshold would react differently. We don't want to have this side effect, so we are now using a local `StreamNormalizer` in the data pipeline that will only effect the mic for recording. 

**NOTE**
There is still a bug in the code that exists currently, but I wanted to get some progress in. Right now, if you had a program like this 
<img width="318" alt="image" src="https://user-images.githubusercontent.com/49178322/232942621-65e616ed-71d4-4c9f-b16a-b3bfdc3401a7.png">
and you tried to press 'A' a second time, nothing will happen.

I have an inkling that the issue lies with the way that the `StreamRecording` object connects and disconnects to the upstream data source. For context, [this](https://github.com/lancaster-university/codal-core/blob/master/source/streams/StreamRecording.cpp#L139) is where I'm looking. This code should, whenever `record()` in C++ is called, trigger the upstream source and propagate to the mic (the recent changes they did in codal with on-demand data streams). However, this isn't happening. I haven't been able to pin point why; I'm hoping to have another chat with @JohnVidler to fix this. 

That being said, this code works fine upon download or if you just reset the micro:bit program with the button on the back. Because this code is a step in the right direction, I wanted to get a PR up.