### PR TITLE
Update reference of 'plotBarGraph' for new parameter

### DIFF
--- a/docs/reference/led/plot-bar-graph.md
+++ b/docs/reference/led/plot-bar-graph.md
@@ -6,7 +6,7 @@ Display a bar graph for a number value.
 led.plotBarGraph(2, 20);
 ```
 
-A bar graph is a kind of chart that shows numbers as lines with different lengths.
+A bar graph is a kind of chart that shows numbers as lines with different lengths. The value is plotted in LEDs as a ratio of a **value** to the **high** value you set as a maximum range. So, if there are 25 LEDs on the screen, then plotting `9` for the high value of `50` would display about 5 LEDs on the screen.
 
 ## Parameters
 
@@ -16,13 +16,13 @@ A bar graph is a kind of chart that shows numbers as lines with different length
   if the temperature is 0 degrees Celsius.
 * **high**: a [number](/types/number) that is the highest
   possible number (maximum) that the **value** parameter can be. The lines in the bar graph will reach their highest point when **value** reaches this number. If **high** is `0`, then the largest value recently plotted is used as the maximum.
+* **valueToConsole**: a [boolean](/types/boolean) value that when `true` will also send the **value** to the serial port. A value of `false` will prevent the number in **value** from going to the serial output.
 
 ### ~hint
 
 #### Serial Output
 
-The ``||led:plot bar graph||`` block also writes the number from **value** to the [serial](/reference/serial) port as a way to help you record
-values.
+The ``||led:plot bar graph||`` block will also write the number from **value** to the [serial](/reference/serial) port if you set the **valueToConsole** parameter to `true`. This is a way to help you record the values you've plotted.
 
 ### ~
 
@@ -32,12 +32,12 @@ Show a bar graph of the [acceleration](/reference/input/acceleration)
 in the `x` direction of the @boardname@.
 The @boardname@'s `x` direction is from left to right (or right to left).
 The faster you move the @boardname@ in this direction,
-the taller the lines in the bar graph will be. The **high** paramter is `1023` which sets the highest possible value of acceleration to show.
+the taller the lines in the bar graph will be. The **high** paramter is `1023` which sets the highest possible value of acceleration to show. Also, record the acceleration value by sending it to the serial port.
 
 ```blocks
 basic.forever(() => {
     let a = input.acceleration(Dimension.X);
-    led.plotBarGraph(a, 1023)
+    led.plotBarGraph(a, 1023, true)
 })
 ```
 

--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -483,6 +483,7 @@
   "led.plotBarGraph": "Displays a vertical bar graph based on the `value` and `high` value.\nIf `high` is 0, the chart gets adjusted automatically.",
   "led.plotBarGraph|param|high": "maximum value. If 0, maximum value adjusted automatically, eg: 0",
   "led.plotBarGraph|param|value": "current value to plot",
+  "led.plotBarGraph|param|valueToConsole": "if true, prints value to the serial port",
   "led.plotBrightness": "Turn on the specified LED with specific brightness using x, y coordinates (x is horizontal, y is vertical). (0,0) is upper left.",
   "led.plotBrightness|param|brightness": "the brightness from 0 (off) to 255 (bright), eg:255",
   "led.plotBrightness|param|x": "the horizontal coordinate of the LED starting at 0",

--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -470,6 +470,7 @@
   "input.setAccelerometerRange|param|range": "a value describe the maximum strengh of acceleration measured",
   "input.temperature": "Gets the temperature in Celsius degrees (°C).",
   "led": "Control of the LED screen.",
+  "led.barGraphToConsole": "Controls where plotbargraph prints to the console",
   "led.brightness": "Get the screen brightness from 0 (off) to 255 (full bright).",
   "led.displayMode": "Gets the current display mode",
   "led.enable": "Turns on or off the display",

--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -470,7 +470,6 @@
   "input.setAccelerometerRange|param|range": "a value describe the maximum strengh of acceleration measured",
   "input.temperature": "Gets the temperature in Celsius degrees (°C).",
   "led": "Control of the LED screen.",
-  "led.barGraphToConsole": "Controls where plotbargraph prints to the console",
   "led.brightness": "Get the screen brightness from 0 (off) to 255 (full bright).",
   "led.displayMode": "Gets the current display mode",
   "led.enable": "Turns on or off the display",

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -356,7 +356,7 @@
   "input|block": "input",
   "led.brightness|block": "brightness",
   "led.enable|block": "led enable %on",
-  "led.plotBarGraph|block": "plot bar graph of %value up to %high",
+  "led.plotBarGraph|block": "plot bar graph of $value up to $high|| serial write $valueToConsole",
   "led.plotBrightness|block": "plot|x %x|y %y|brightness %brightness",
   "led.plot|block": "plot|x %x|y %y",
   "led.pointBrightness|block": "point|x %x|y %y brightness",

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -23,6 +23,11 @@ namespace led {
     let barGraphHighLast = 0;
 
     /**
+     * Controls where plotbargraph prints to the console
+     **/
+    export let barGraphToConsole = true
+
+    /**
      * Displays a vertical bar graph based on the `value` and `high` value.
      * If `high` is 0, the chart gets adjusted automatically.
      * @param value current value to plot
@@ -35,7 +40,7 @@ namespace led {
     //% valueToConsole.shadow=toggleOnOff
     export function plotBarGraph(value: number, high: number, valueToConsole?: boolean): void {
         if (valueToConsole == undefined) {
-            valueToConsole = false;
+            valueToConsole = barGraphToConsole;
         }
         const now = input.runningTime();
         if (valueToConsole)

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -32,14 +32,14 @@ namespace led {
      * If `high` is 0, the chart gets adjusted automatically.
      * @param value current value to plot
      * @param high maximum value. If 0, maximum value adjusted automatically, eg: 0
-     * @param valueToConsole if true, prints value to the console
+     * @param valueToConsole if true, prints value to the serial port
      */
     //% help=led/plot-bar-graph weight=20
-    //% blockId=device_plot_bar_graph block="plot bar graph of $value up to $high|| console log $valueToConsole" icon="\uf080" blockExternalInputs=true
+    //% blockId=device_plot_bar_graph block="plot bar graph of $value up to $high|| serial write $valueToConsole" icon="\uf080" blockExternalInputs=true
     //% parts="ledmatrix"
     //% valueToConsole.shadow=toggleOnOff
     export function plotBarGraph(value: number, high: number, valueToConsole?: boolean): void {
-        if (valueToConsole == undefined){
+        if (valueToConsole == undefined) {
             valueToConsole = barGraphToConsole;
         }
         const now = input.runningTime();

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -23,11 +23,6 @@ namespace led {
     let barGraphHighLast = 0;
 
     /**
-     * Controls where plotbargraph prints to the console
-     **/
-    export let barGraphToConsole = true
-
-    /**
      * Displays a vertical bar graph based on the `value` and `high` value.
      * If `high` is 0, the chart gets adjusted automatically.
      * @param value current value to plot
@@ -40,7 +35,7 @@ namespace led {
     //% valueToConsole.shadow=toggleOnOff
     export function plotBarGraph(value: number, high: number, valueToConsole?: boolean): void {
         if (valueToConsole == undefined) {
-            valueToConsole = barGraphToConsole;
+            valueToConsole = false;
         }
         const now = input.runningTime();
         if (valueToConsole)

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -38,6 +38,7 @@ namespace led {
     //% blockId=device_plot_bar_graph block="plot bar graph of $value up to $high|| serial write $valueToConsole" icon="\uf080" blockExternalInputs=true
     //% parts="ledmatrix"
     //% valueToConsole.shadow=toggleOnOff
+    //% valueToConsole.defl=true
     export function plotBarGraph(value: number, high: number, valueToConsole?: boolean): void {
         if (valueToConsole == undefined) {
             valueToConsole = barGraphToConsole;


### PR DESCRIPTION
Update the reference page for **led.plotBarGraph()** to include the parameter description for `valueToConsole`. Plus, a few more edits.

Closes #5056

## Suggestions

* Since `console` is still directed to serial output, I'm thinking we might use 'serial' instead of 'console' in reference to this parameter. I did that in the doc update.

See [line 398](https://github.com/microsoft/pxt-microbit/blob/bf61883bd5e660e4dc3e9142b3560d73fcfc39b3/libs/core/control.cpp#L398) in control.cpp as `control.__log()` (called thru `console.log()` et al) sends to serial:

```typescript
    /**
    *
    */
    //%
    void __log(int priority, String text) {
        if (NULL == text) return;
        pxt::sendSerial(text->getUTF8Data(), text->getUTF8Size());
    }
```

Also, the actual `console` namespace is yet to be exposed:

![image](https://user-images.githubusercontent.com/27789908/233220912-1b47fa99-b6a5-4672-8af3-450561ee219c.png)

* I modified the text for the block to use 'serial write' rather than 'console log' due to the reasons above.

* It seems that `barGraphToConsole` has no utility anymore so I removed that and set `valueToConsole` to default to `false`. This seems to have the same effect.

You can hate on any of these changes if you want. They are just suggestions.