### PR TITLE
Add teaching bubble colors as site variables to override default colors

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -101,3 +101,10 @@
    Cloud Status
 ----------------------------*/
 @cloudStatusColor: @blue;
+
+/*---------------------------
+   Teaching Bubble
+----------------------------*/
+@teachingBubbleBackgroundColor: @blue;
+@teachingBubbleTextColor: @white;
+@teachingBubbleStepsColor: @lightGrey;


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9478

This refactoring does not change the current colors of the editor tour.