### PR TITLE
Recording extension: greater difference between microphone gain

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -116,10 +116,10 @@ void setMicrophoneGain(int gain) {
         uBit.audio.processor->setGain(0.079f);
         break;
     case 2:
-        uBit.audio.processor->setGain(0.2f);
+        uBit.audio.processor->setGain(0.3f);
         break;
     case 3:
-        uBit.audio.processor->setGain(0.4f);
+        uBit.audio.processor->setGain(0.8f);
         break;
     }
 }

--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -116,10 +116,10 @@ void setMicrophoneGain(int gain) {
         uBit.audio.processor->setGain(0.079f);
         break;
     case 2:
-        uBit.audio.processor->setGain(0.3f);
+        uBit.audio.processor->setGain(0.2f);
         break;
     case 3:
-        uBit.audio.processor->setGain(0.8f);
+        uBit.audio.processor->setGain(1.2f);
         break;
     }
 }

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -114,6 +114,7 @@
   "IconNames.Cow|block": "cow",
   "IconNames.Diamond|block": "diamond",
   "IconNames.Duck|block": "duck",
+  "IconNames.EighthNote|block": "eighth note",
   "IconNames.EigthNote|block": "eigth note",
   "IconNames.Fabulous|block": "fabulous",
   "IconNames.Ghost|block": "ghost",


### PR DESCRIPTION
We want to make sure that the different gain selections actually sound different to users, so the differences between medium and high have been increased. I've found in my testing that anything above a 0.1f gain value has a decent amount of interference, so the gap between medium and high are larger than that between low and medium. 

Please play with it here and let me know if you can tell a difference between the levels: https://makecode.microbit.org/app/b0641ceafb772707ea5213d20f40a158ef8df6f2-a7767ee627

Draft pull request because there might be other changes to be made depending on possible pipeline changes that I will be discussing with the micro:bit team.

EDIT: There will be more changes here when we get APIs to change the mic gain on the mixer channel. We won't have to create another channel and the `localProcessor` will not be needed.

Closes https://github.com/microsoft/pxt-microbit/issues/5063