### PR TITLE
get rid of old, unused pxtarget field

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -448,68 +448,6 @@
         ],
         "hasReferenceDocs": true,
         "usbDocs": "/device/usb",
-        "usbHelp": [
-            {
-                "name": "connection",
-                "os": "*",
-                "browser": "*",
-                "path": "/static/mb/device/usb-generic.jpg"
-            },
-            {
-                "name": "connection",
-                "os": "mac",
-                "browser": "*",
-                "path": "/static/mb/device/usb-mac.jpg"
-            },
-            {
-                "name": "save",
-                "os": "windows",
-                "browser": "firefox",
-                "path": "/static/mb/device/usb-windows-firefox-1.png"
-            },
-            {
-                "name": "save",
-                "os": "mac",
-                "browser": "firefox",
-                "path": "/static/mb/device/usb-osx-firefox-1.jpg"
-            },
-            {
-                "name": "save",
-                "os": "mac",
-                "browser": "chrome",
-                "path": "/static/mb/device/usb-osx-chrome.png"
-            },
-            {
-                "name": "save",
-                "os": "windows",
-                "browser": "edge",
-                "path": "/static/mb/device/usb-windows-edge-1.png"
-            },
-            {
-                "name": "save",
-                "os": "windows",
-                "browser": "ie",
-                "path": "/static/mb/device/usb-windows-ie11-1.png"
-            },
-            {
-                "name": "save",
-                "os": "windows",
-                "browser": "chrome",
-                "path": "/static/mb/device/usb-windows-chrome.png"
-            },
-            {
-                "name": "copy",
-                "os": "mac",
-                "browser": "*",
-                "path": "/static/mb/device/usb-osx-dnd.png"
-            },
-            {
-                "name": "copy",
-                "os": "windows",
-                "browser": "*",
-                "path": "/static/mb/device/usb-windows-sendto.jpg"
-            }
-        ],
         "hideHomeDetailsVideo": true,
         "invertedMenu": true,
         "coloredToolbox": true,


### PR DESCRIPTION
These were added with https://github.com/microsoft/pxt-microbit/pull/250 for user with https://github.com/microsoft/pxt/pull/330, but we've redone that dialog 3 or 4+ times since then so these images only remain in docs images :)