### PR TITLE
Patch rule for name vs note mismatch in Italian

### DIFF
--- a/editor/patch.ts
+++ b/editor/patch.ts
@@ -61,33 +61,15 @@ export function patchBlocks(pkgTargetVersion: string, dom: Element) {
 
         // Italian translation error
         /*
-        <block type="device_play_note">
-            <value name="note">
-                <shadow type="device_note">
-                    <field name="note">466</field>
-                </shadow>
-            </value>
-            <value name="duration">
-                <shadow type="device_beat">
-                    <field name="fraction">BeatFraction.Whole</field>
-                </shadow>
-            </value>
-        </block>
+        <shadow type="device_note">
+            <field name="note">466</field>
+        </shadow>
 
         converts to
 
-        <block type="device_play_note">
-            <value name="note">
-                <shadow type="device_note">
-                    <field name="name">466</field>
-                </shadow>
-            </value>
-            <value name="duration">
-                <shadow type="device_beat">
-                    <field name="fraction">BeatFraction.Whole</field>
-                </shadow>
-            </value>
-        </block>
+        <shadow type="device_note">
+            <field name="name">466</field>
+        </shadow>
         */
         pxt.U.toArray(dom.querySelectorAll("shadow[type=device_note]>field[name=note]"))
             .forEach(node => node.setAttribute("name", "name"));

--- a/editor/patch.ts
+++ b/editor/patch.ts
@@ -58,6 +58,39 @@ export function patchBlocks(pkgTargetVersion: string, dom: Element) {
         pxt.U.toArray(dom.querySelectorAll("block[type=basic_show_icon]>field[name=i]"))
             .filter(node => node.textContent === "IconNames.EigthNote")
             .forEach(node => node.textContent = "IconNames.EighthNote");
+
+        // Italian translation error
+        /*
+        <block type="device_play_note">
+            <value name="note">
+                <shadow type="device_note">
+                    <field name="note">466</field>
+                </shadow>
+            </value>
+            <value name="duration">
+                <shadow type="device_beat">
+                    <field name="fraction">BeatFraction.Whole</field>
+                </shadow>
+            </value>
+        </block>
+
+        converts to
+
+        <block type="device_play_note">
+            <value name="note">
+                <shadow type="device_note">
+                    <field name="name">466</field>
+                </shadow>
+            </value>
+            <value name="duration">
+                <shadow type="device_beat">
+                    <field name="fraction">BeatFraction.Whole</field>
+                </shadow>
+            </value>
+        </block>
+        */
+        pxt.U.toArray(dom.querySelectorAll("shadow[type=device_note]>field[name=note]"))
+            .forEach(node => node.setAttribute("name", "name"));
     }
 
     // is this a old script?

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.4.9",
-        "pxt-core": "8.6.32"
+        "pxt-core": "8.6.33"
     }
 }


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9502
Closes https://github.com/microsoft/pxt-microbit/issues/4905

This adds an upgrade rule so that the new check for translation errors doesn't break older projects in Italian. It upgrades the field name from "note" to the correct "name."