### PR TITLE
Remove overrides for orientation, display

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.4.9",
-        "pxt-core": "8.6.33"
+        "pxt-core": "8.6.34"
     }
 }

--- a/webmanifest.json
+++ b/webmanifest.json
@@ -1,7 +1,5 @@
 {
 	"name": "makecode.microbit.org",
-	"display": "fullscreen",
-	"orientation": "portrait",
 	"icons": [
 		{
 			"src": "/static/icons/android-chrome-36x36.png",


### PR DESCRIPTION
see https://github.com/microsoft/pxt/pull/9504; I've moved fullscreen as the default & forcing portrait mode for installed app is not correct behavior.

fix https://github.com/microsoft/pxt-microbit/issues/4629