### PR TITLE
Recording extension: recording, playback fixed

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -32,17 +32,6 @@ static StreamRecording *recording = NULL;
 static SplitterChannel *splitterChannel = NULL;
 static MixerChannel *channel = NULL;
 
-void enableMic() {
-    uBit.audio.activateMic();
-    uBit.audio.mic->enable();
-}
-
-void disableMic() {
-    uBit.audio.mic->disable();
-    uBit.audio.deactivateMic();
-}
-
-
 void checkEnv(int sampleRate = -1) {
     if (recording == NULL) {
         if (sampleRate == -1)
@@ -72,8 +61,7 @@ void checkEnv(int sampleRate = -1) {
 //% promise
 void record() {
     checkEnv();
-    enableMic();
-    recording->record();
+    recording->recordAsync();
 }
 
 /**
@@ -82,8 +70,7 @@ void record() {
 //%
 void play() {
     checkEnv();
-    disableMic();
-    recording->play();
+    recording->playAsync();
 }
 
 /**
@@ -92,7 +79,6 @@ void play() {
 //%
 void stop() {
     checkEnv();
-    disableMic();
     recording->stop();
 }
 
@@ -102,7 +88,6 @@ void stop() {
 //%
 void erase() {
     checkEnv();
-    disableMic();
     recording->erase();
 }
 


### PR DESCRIPTION
The updates to the CODAL `StreamRecording` data type made it that we needed to use `recordAsync` and `playAsync` rather than `play` and `record`. Recording and playback now using these updated codal apis, and thus fixing the problems that we were having with recording earlier today.

Closes https://github.com/microsoft/pxt-microbit/issues/5163
Closes https://github.com/microsoft/pxt-microbit/issues/5162
Closes https://github.com/microsoft/pxt-microbit/issues/5161

For playing if anyone's interested: https://makecode.microbit.org/app/5f07e59c4f47400e1b1ff42f6329d302c150effe-f36946ff57