### PR TITLE
fix webusb flashing when disablesVariant has been used

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -242,6 +242,10 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
     }
 
     get binName() {
+        return `${this.devVariant}-${pxtc.BINARY_HEX}`;
+    }
+
+    get devVariant() {
         if (this.usesCODAL === undefined)
             console.warn('try to access codal information before it is computed')
         return (this.usesCODAL ? "mbcodal-" : "mbdal-") + pxtc.BINARY_HEX;
@@ -467,7 +471,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
                         pxt.tickEvent('hid.flash.full.error.open', { res: res[1] })
                         throw new Error(lf("Download failed, please try again"));
                     }
-                    const binFile = resp.outfiles[this.binName];
+                    const binFile = this.getBinFile(resp);
                     log(`bin file ${this.binName} in ${Object.keys(resp.outfiles).join(', ')}, ${binFile?.length || -1}b`)
                     const hexUint8 = pxt.U.stringToUint8Array(binFile);
                     log(`hex ${hexUint8?.byteLength || -1}b, ~${(hexUint8.byteLength / chunkSize) | 0} chunks of ${chunkSize}b`)
@@ -543,10 +547,20 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             });
     }
 
+    private getBinFile(resp: pxtc.CompileResult) {
+        const multiVariantBinFile = resp.outfiles[this.binName];
+        if (multiVariantBinFile)
+            return multiVariantBinFile;
+
+        const dvBin = resp.builtVariants?.find(el => el === this.devVariant) && resp.outfiles[pxtc.BINARY_HEX];
+        if (dvBin)
+            return resp.outfiles[pxtc.BINARY_HEX];
+
+        throw new Error(`unable to find ${this.binName} in outfiles ${Object.keys(resp.outfiles).join(', ')}`);
+    }
+
     private computeFlashChecksum(resp: pxtc.CompileResult) {
-        const binFile = resp.outfiles[this.binName];
-        if (!binFile)
-            throw new Error(`unable to find ${this.binName} in outfiles ${Object.keys(resp.outfiles).join(', ')}`);
+        const binFile = this.getBinFile(resp);
 
         return this.getFlashChecksumsAsync()
             .then(checksums => {

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -248,7 +248,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
     get devVariant() {
         if (this.usesCODAL === undefined)
             console.warn('try to access codal information before it is computed')
-        return (this.usesCODAL ? "mbcodal-" : "mbdal-") + pxtc.BINARY_HEX;
+        return this.usesCODAL ? "mbcodal" : "mbdal";
     }
 
     unsupportedParts() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-microbit",
-    "version": "5.1.30",
+    "version": "5.1.29",
     "description": "micro:bit target for Microsoft MakeCode (PXT)",
     "keywords": [
         "JavaScript",
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.4.9",
-        "pxt-core": "8.6.39"
+        "pxt-core": "8.6.41"
     }
 }


### PR DESCRIPTION
requires https://github.com/microsoft/pxt/pull/9524 for compileresult to attach the list of successfully built variants (that's why build is red)

Right now if you have a program that has a variant disabled (either pxt.json or from it being too big like https://makecode.microbit.org/_L92VubLgaWU6 and getting rebuilt only for codal) it fails to find the hexfile as we only use the unique names when building multivariant files. This change grabs the correct file in that case.

I don't know if there was a separate bug for this somewhere but thomas mentioned running into it to me over teams while he was testing music changes / it was mentioned in this comment https://github.com/microsoft/pxt-microbit/issues/4788#issuecomment-1425704556 -- so this is a mitigation for that, though other work remains in that issue.

build https://makecode.microbit.org/app/b51df1fe81ae69b332e39f54acebeadba9ac2009-60d9578ef1

If there's time, as a separate fix next week I'll look at making it so we do the v2 only build silently (without the pop up warning) when too big + a microbit v2 is fully connected if i have time (though I'll aim for progress bar first)