### PR TITLE
Reverting CODAL, v0.2.54 breaks recording, sound level

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -189,7 +189,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.54",
+                    "branch": "v0.2.53",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
Reverting CODAL to v0.2.53 for now. I should have done some testing on the branch before merging v0.2.54 as it breaks recording playback and sound level in a program like the following: 
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/1a001b89-95b1-4051-956c-923c38918427)

`on loud sound` still having problems in both v0.2.53 and v0.2.54.