### PR TITLE
Compact the step descriptions for v2 tutorials

### DIFF
--- a/docs/projects/v2-blow-away.md
+++ b/docs/projects/v2-blow-away.md
@@ -1,6 +1,6 @@
 # Blow Away
 
-## 1. Introduction pt. 1 @unplugged
+## Introduction pt. 1 @unplugged
 
 👻 Oh, no! Your @boardname@ is being haunted by a ghost named Haven 👻
 
@@ -8,16 +8,11 @@ For this tutorial, we'll learn how to blow Haven away 🌬️
 
 ![Blow away banner message](/static/mb/projects/blow-away.png)
 
-## 2. Haunted ghost setup
-
-🏚️ **BooOooOoo** 🏚️
+## Haunted ghost setup
 
 A wild Haven has appeared!
 
----
-
-► From the ``||basic:Basic||`` category, find ``||basic:show icon [ ]||`` and add it to your ``||basic:on start||`` container.
-
+► From the ``||basic:Basic||`` category, find ``||basic:show icon [ ]||`` and add it to your ``||basic:on start||`` container.  
 ► Click the heart icon and set it to show a ghost.  
 💡 In the ``show icon`` dropdown menu options, you can hover to see what each design is called.
 
@@ -28,11 +23,7 @@ basic.showIcon(IconNames.Ghost)
 
 ---
 
-## 3. Loop setup
-
-➰ **Looping around** ➰
-
----
+## Loop setup
 
 ► From the ``||loops:Loops||`` category, find the ``||loops:repeat [4] times||`` loop and snap it into your empty ``||basic:forever||`` container.   
 💡 Why do we need a [__*repeat loop*__](#repeatLoop "repeat code for a given number of times") when we already have a ``forever`` container? Because ``forever`` has an embedded delay that we want to avoid!
@@ -46,18 +37,12 @@ basic.forever(function () {
 })
 ```
 
-## 4. Conditional setup
-
-🤔 **Conditioning and comparing** 🤔
+## Conditional setup
 
 Haven hates noise and will blow away if things get too loud. Let's use an [__*if statement*__](#ifstatement "if this condition is met, do something") to check for sounds.
 
----
-
-► From ``||logic:Logic||``, grab an ``||logic:if <true> then||`` statement and snap it into your empty ``||loops:repeat [4] times do||`` loop.
-
-► Go back to ``||logic:Logic||`` to get a ``||logic:<[0] [=] [0]>||`` comparison.
-
+► From ``||logic:Logic||``, grab an ``||logic:if <true> then||`` statement and snap it into your empty ``||loops:repeat [4] times do||`` loop.  
+► Go back to ``||logic:Logic||`` to get a ``||logic:<[0] [=] [0]>||`` comparison.  
 ► Snap ``||logic:<[0] [=] [0]>||`` in to **replace** the ``||logic:<true>||`` condition for your ``||logic:if then||`` statement.
 
 ```blocks
@@ -72,18 +57,12 @@ basic.forever(function () {
 })
 ```
 
-## 5. Blow sound
-
-👂 **Haven's ears** 👂
+## Blow sound
 
 We'll be using a [__*sound threshold*__](#soundThreshold "a number for how loud a sound needs to be to trigger an event. 0 = silence to 255 = maximum noise") to act as Haven's ears.
 
----
-
-► From the ``||input:Input||`` category, drag ``||input:sound level||`` in to **replace** the **_left_ ``0``** of your ``||logic:<[0] [=] [0]>||`` comparison.
-
-► Using the dropdown in the **middle** of ``||logic:[sound level] [=] [0]||``, change the comparison to be **``>``** (greater than).
-
+► From the ``||input:Input||`` category, drag ``||input:sound level||`` in to **replace** the **_left_ ``0``** of your ``||logic:<[0] [=] [0]>||`` comparison.  
+► Using the dropdown in the **middle** of ``||logic:[sound level] [=] [0]||``, change the comparison to be **``>``** (greater than).  
 ► Finally, have the **right side** of the comparison say ``128`` so your full comparison reads: **``sound level > 128``**.  
 💡 This means Haven will hear any sound above ``128``.
 
@@ -98,31 +77,20 @@ basic.forever(function () {
 })
 ```
 
-## 6. Making variables
-
-☀️ **Variable weather** 🌨️
+## Making variables
 
 Let's create some [__*variables*__](#variable "a holder for information that may change") to keep track of Haven's movement.
 
----
-
 ►  In the ``||variables:Variables||`` category, click on ``Make a Variable...`` and make a variable named ``col``.  
-💡 ``col`` is short for "column".
-
+💡 ``col`` is short for "column".  
 ►  Make **another** variable and name it ``row``.
 
-## 7. Displacing LEDs part 1
-
-🔀 **Random chance** 🔀
+## Displacing LEDs part 1
 
 To show Haven is blowing away, we want to move a random set of lights sideways.
 
----
-
-► Your ``||variables:Variables||`` category should now have the option to ``||variables:set [row] to [0]||``. Drag that block into your empty ``||logic:if then||`` statement.
-
-► From the ``||math:Math||`` category, find ``||math:pick random [0] to [10]||`` and snap that in to **replace** the ``[0]`` in your ``||variables:set [row] to [0]||`` block.
-
+► Your ``||variables:Variables||`` category should now have the option to ``||variables:set [row] to [0]||``. Drag that block into your empty ``||logic:if then||`` statement.  
+► From the ``||math:Math||`` category, find ``||math:pick random [0] to [10]||`` and snap that in to **replace** the ``[0]`` in your ``||variables:set [row] to [0]||`` block.  
 ► Change the maximum number from ``10`` to **``4``**.  
 💡 We are setting the maximum random value to 4 because the lights on the @boardname@ are numbered 0, 1, 2, 3, and 4 for columns and rows.
 
@@ -138,14 +106,11 @@ basic.forever(function () {
 })
 ```
 
-## 8. Displacing LEDs part 2
+## Displacing LEDs part 2
 
-► Go back into ``||variables:Variables||`` and drag out another ``||variables:set [row] to [0]||``. Place this one below the last one (at **the end**) of your `if then` statement.
-
-► Using the **dropdown menu**, set the new block to read ``||variables:set [col] to [0]||``.
-
-► From the ``||math:Math||`` category, grab another ``||math:pick random [0] to [10]||`` and snap that in to **replace** the ``[0]`` in your ``||variables:set [col] to [0]||`` block.
-
+► Go back into ``||variables:Variables||`` and drag out another ``||variables:set [row] to [0]||``. Place this one below the last one (at **the end**) of your `if then` statement.  
+► Using the **dropdown menu**, set the new block to read ``||variables:set [col] to [0]||``.  
+► From the ``||math:Math||`` category, grab another ``||math:pick random [0] to [10]||`` and snap that in to **replace** the ``[0]`` in your ``||variables:set [col] to [0]||`` block.  
 ► Change the maximum number from ``10`` to **``4``**.  
 
 ```blocks
@@ -162,16 +127,11 @@ basic.forever(function () {
 })
 ```
 
-## 9. Conditioning on one point
-
-✨ **Ooh, sparkly** ✨
+## Conditioning on one point
 
 Time to move some lights around!
 
----
-
-► From ``||logic:Logic||``, grab another ``||logic:if <true> then||`` and snap it at the **inside and at the bottom of** your ``||loops:repeat [4] times do||`` loop, right below your ``||logic:if [sound level] [>] [128]||`` statement.
-
+► From ``||logic:Logic||``, grab another ``||logic:if <true> then||`` and snap it at the **inside and at the bottom of** your ``||loops:repeat [4] times do||`` loop, right below your ``||logic:if [sound level] [>] [128]||`` statement.  
 ► From the ``||led:Led||`` category, find ``||led:point x [0] y [0]||`` and drag it in to **replace** the ``||logic:<true>||`` condition in the **new** ``||logic:if then||`` statement.  
 💡 This block will test if the light is on at the the given ``x`` and ``y`` coordinate points.
 
@@ -190,14 +150,11 @@ basic.forever(function () {
 })
 ```
 
-## 10. Unplotting and replotting LEDs
+## Unplotting and replotting LEDs
 
 To create the animation effect of Haven blowing away, we will turn off (or ``unplot``) a light that is on and then turn it on again (``plot`` it) in a different spot.
 
----
-
-► From ``||led:Led||``, grab ``||led:unplot x [0] y [0]||`` and snap it inside the **empty** ``||logic:if <point x [0] y [0]> then||`` statement.
-
+► From ``||led:Led||``, grab ``||led:unplot x [0] y [0]||`` and snap it inside the **empty** ``||logic:if <point x [0] y [0]> then||`` statement.  
 ► Go back to ``||led:Led||`` and get ``||led:plot x [0] y [0]||``. Snap that in **beneath** the ``||led:unplot x [0] y [0]||`` block that you just added.
 
 ```blocks
@@ -220,17 +177,11 @@ basic.forever(function () {
 
 ## 11. Setting variables
 
-📃 **Columns and rows** 📃
-
-Notice how you have **three** blocks from the ``||led:Led||`` category. All three have ``||led:x||`` ``[0]`` and ``||led:y||`` ``[0]`` coordinates. In these **two** steps, we will set it so that every ``||led:x||`` is followed by the ``||variables:col||`` variable and every ``||led:y||`` is followed by the ``||variables:row||`` variable.
-
----
-
+Notice how you have **three** blocks from the ``||led:Led||`` category. All three have ``||led:x||`` ``[0]`` and ``||led:y||`` ``[0]`` coordinates. In these **two** steps, we will set it so that every ``||led:x||`` is followed by the ``||variables:col||`` variable and every ``||led:y||`` is followed by the ``||variables:row||`` variable.  
 ► From ``||variables:Variables||``, get three copies of ``||variables:col||``, and use them to **replace the ``x`` values** in the following three blocks:  
 **1.** ``||led:point x [0] y [0]||``  
 **2.** ``||led:unplot x [0] y [0]||``  
-**3.** ``||led:plot x [0] y [0]||``
-
+**3.** ``||led:plot x [0] y [0]||``  
 ► Go into ``||variables:Variables||``, get three copies of ``||variables:row||``, and use them to **replace the ``y`` values** in the same three blocks.
 
 ```blocks
@@ -253,17 +204,11 @@ basic.forever(function () {
 
 ## 12. Moving LEDs
 
-➕ **Math makes the lights go swoosh** ➗
-
 Right now, we are unplotting and replotting in the same spot. What we want to do  is move the lights we're turning back on just a smidge to the right every time until there's nothing left on the grid.
 
----
-
 ► From ``||math:Math||``, find the ``||math:[0] [+] [0]||`` operation and use it to **replace** ``||variables:col||`` in your ``||led:plot x [col] y [row]||`` block.  
-💡 If you move your entire ``||basic:forever||`` container, you should find a greyed out ``col`` variable in your workspace.
-
-► Take the greyed out ``||variables:col||`` variable (or get a new one) and use it to **replace** the **_first_ ``[0]``** so the operation reads ``||math:[col] [+] [0]||``.
-
+💡 If you move your entire ``||basic:forever||`` container, you should find a greyed out ``col`` variable in your workspace.  
+► Take the greyed out ``||variables:col||`` variable (or get a new one) and use it to **replace** the **_first_ ``[0]``** so the operation reads ``||math:[col] [+] [0]||``.  
 ► Replace the **_second_ ``[0]``** with **``[1]``** so the operation reads ``||math:[col] [+] [1]||``.
 
 ```blocks
@@ -286,14 +231,9 @@ basic.forever(function () {
 
 ## 13. Testing in the simulator
 
-🌬️ **Test what you've created** 👻
-
 Check out the simulator!
 
----
-
-► Click on the pink bar underneath the microphone icon. Drag it above the sound number you chose (we used ``128``!) to blow Haven away.
-
+► Click on the pink bar underneath the microphone icon. Drag it above the sound number you chose (we used ``128``!) to blow Haven away.  
 ► If you have a new @boardname@ (the one with the **shiny gold** logo at the top), download this code and try it out!  
 💡 Blow close to the @boardname@ and watch Haven swoosh away 💨  
 💡 Use your @boardname@'s reset button (it's on the back!) to bring Haven back 👻

--- a/docs/projects/v2-cat-napping.md
+++ b/docs/projects/v2-cat-napping.md
@@ -1,23 +1,17 @@
 # Cat Napping
 
-## 1. Introduction @unplugged
+## Introduction @unplugged
 
 Lychee the cat loves the sun and wants to know if your home has a good sunbathing spot. Are you up for the challenge?
 
 ![Cat Tanning banner message, an image of a cat](/static/mb/projects/cat-napping/1_lychee.png)
 
-## 2. Setting logging to false on start
-
-📋 **Variable data** 📋
+## Setting logging to false on start
 
 First, we want to make sure we know when our micro:bit is collecting data. To do this, let's create a [__*boolean*__](#boolean "something that is only true or false") [__*variable*__](#variable "a holder for information that may change") and use it to track when the @boardname@ is logging data. We'll start with the logging variable set to false.
 
----
-
-► In the ``||variables:Variables||`` category, click on ``Make a Variable...`` and make a variable named ``logging``.
-
-► From the ``||variables:Variables||`` category, grab the ``||variables:set [logging] to [0]||`` block and snap it into the empty ``||basic:on start||`` container.
-
+► In the ``||variables:Variables||`` category, click on ``Make a Variable...`` and make a variable named ``logging``.  
+► From the ``||variables:Variables||`` category, grab the ``||variables:set [logging] to [0]||`` block and snap it into the empty ``||basic:on start||`` container.  
 ► From the ``||logic:Logic||`` category, grab a ``||logic:<false>||`` argument and snap it in to **replace** the ``||variables:[0]||`` value in your ``||variables:set [logging] to [0]||`` statement.
 
 ```blocks
@@ -25,21 +19,12 @@ let logging = false
 logging = false
 ```
 
-## 3. Toggle logging on A press
-
-▶️ **Starting and stopping** ⏸️
+## Toggle logging on A press
 
 Let's give Lychee some control over when she wants to start and stop logging data on the @boardname@.
 
----
-
-► From the ``||input:Input||`` category, grab a ``||input:on button [A] pressed||`` container and drag it into your workspace.
-
-► From the ``||variables:Variables||`` category, grab a ``||variables:set [logging] to [0]||`` block and snap it inside of your ``||input:on button [A] pressed||`` container.
-
-► From the ``||logic:Logic||`` category, grab a ``||logic:<not []>||`` argument and snap it in to **replace** the ``0`` argument.
-
-► From the ``||variables:Variables||`` category, grab a ``||variables:logging||`` variable and snap it in to **replace** the empty ``||logic:<>||`` in the ``||logic:not <>||`` statement.
+► From the ``||input:Input||`` category, grab a ``||input:on button [A] pressed||`` container and drag it into your workspace. Then, grab a ``||variables:set [logging] to [0]||`` block from ``||variables:Varables||`` and snap it inside of your ``||input:on button [A] pressed||`` container.  
+► From the ``||logic:Logic||`` category, grab a ``||logic:<not []>||`` argument and snap it in to **replace** the ``0`` argument. Go back to the ``||variables:Variables||`` category, grab a ``||variables:logging||`` variable and snap it in to **replace** the empty ``||logic:<>||`` in the ``||logic:not <>||`` statement.
 
 ✋🛑 Take a moment to help Lychee answer the following question: _What is happening every time she presses the A button?_
 
@@ -50,21 +35,27 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## 4. Visual logging indicators
-
-👀 **Visual indicators** 👀
+## Visual logging indicators
 
 It would help to know when the @boardname@ is logging data and when it isn't. For this step, we will be building out a visual indicator using an [__*if then / else*__](#ifthenelse "runs some code if a boolean condition is true and different code if the condition is false") statement.
 
----
+► From the ``||logic:Logic||`` category, grab an ``||logic:if <true> then / else||`` statement and snap it in at the **bottom** of your ``||input:on button [A] pressed||`` container.  
+► From ``||variables:Variables||``, grab a ``||variables:logging||`` variable and snap it in to **replace** the ``||logic:<true>||`` condition in your ``||logic:if then / else||`` statement.  
 
-► From the ``||logic:Logic||`` category, grab an ``||logic:if <true> then / else||`` statement and snap it in at the **bottom** of your ``||input:on button [A] pressed||`` container.
+```blocks
+let logging = false
+input.onButtonPressed(Button.A, function () {
+    logging = !(logging)
+    if (logging) {
+    } else {
+    }
+})
+```
 
-► From ``||variables:Variables||``, grab a ``||variables:logging||`` variable and snap it in to **replace** the ``||logic:<true>||`` condition in your ``||logic:if then / else||`` statement.
+## Set the indicator icon
 
-► Let's display an image when the @boardname@ is logging data. From the ``||basic:Basic||`` category, grab a ``||basic:show icon []||`` block and snap it into the empty **top container** of your ``||logic:if then / else||`` statement.
-
-► Set it to show the "target" icon (it looks like an empty sun - scroll down to find it!).  This will show whenever your @boardname@ is collecting data. <br />
+► Let's display an image when the @boardname@ is logging data. From the ``||basic:Basic||`` category, grab a ``||basic:show icon []||`` block and snap it into the empty **top container** of your ``||logic:if then / else||`` statement.  
+► Set it to show the "target" icon (it looks like an empty sun - scroll down to find it!).  This will show whenever your @boardname@ is collecting data.  
 💡 In the ``show icon`` dropdown menu options, you can hover to see what each design is called.
 
 ```blocks
@@ -78,15 +69,26 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## 4. Auditory logging indicators
+## Auditory logging indicators
 
 Let's now add an auditory indicator that your @boardname@ is logging data!
 
----
-
-► From the ``||music:Music||`` category, grab a ``||music:play sound [giggle] [until done]||`` block and snap it into the **bottom** of the **top container** of your ``||logic:if then / else||`` statement.
-
+► From the ``||music:Music||`` category, grab a ``||music:play sound [giggle] [until done]||`` block and snap it into the **bottom** of the **top container** of your ``||logic:if then / else||`` statement.  
 ► Click on the ``giggle`` dropdown and select ``hello``. Your block should now say ``||music:play sound [hello] [until done]||``.
+
+```blocks
+let logging = false
+input.onButtonPressed(Button.A, function () {
+    logging = !(logging)
+    if (logging) {
+        basic.showIcon(IconNames.Target)
+        music.playSoundEffect(music.builtinSoundEffect(soundExpression.hello), SoundExpressionPlayMode.UntilDone)
+    } else {
+    }
+})
+```
+
+## Logging off indicator
 
 ► Let's clear the board when the @boardname@ is not logging data. From the ``||basic:Basic||`` category, grab a ``||basic:clear screen||`` block and snap it into the empty **bottom container** of your ``||logic:if then / else||`` statement.
 
@@ -103,16 +105,11 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## 5. Time interval for data logging
-
-📈 **A data point a minute** 📈
+## Time interval for data logging
 
 Let's set up the data logging for Lychee! In order to get Lychee a good amount of data without running out of memory, we should collect one data point for her every minute.
 
----
-
-► From the ``||loops:Loops||`` category, grab a ``||loops:every [500] ms||`` container and add it to your workspace.
-
+► From the ``||loops:Loops||`` category, grab a ``||loops:every [500] ms||`` container and add it to your workspace.  
 ► Click on the the ``500`` dropdown and select ``1 minute``. <br />
 💡 1 minute is equivalent to 60000ms, which is what the number will automatically change to.
 
@@ -121,14 +118,11 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## 6. Setting up a logging variable
+## Setting up a logging variable
 
 Now, let's use an [__*if then*__](#ifthen "runs some code if a boolean condition is true") statement to track when the @boardname@ is logging data.
 
----
-
-► From the ``||logic:Logic||`` category, grab a ``||logic:if <true> then||`` statement and snap it into your ``||loops:every [600000] ms||`` container.
-
+► From the ``||logic:Logic||`` category, grab a ``||logic:if <true> then||`` statement and snap it into your ``||loops:every [600000] ms||`` container.  
 ► From the ``||variables:Variables||`` category, drag out a ``||variables:logging||`` variable and snap it in to **replace** the ``||logic:<true>||`` argument in the ``||logic:if <true> then||`` statement.
 
 ```blocks
@@ -139,18 +133,12 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## 7. Setting up logging - Part 1
-
-🏁 **Ready...set...log!** 🏁
+## Setting up logging - Part 1
 
 Lychee loves her sun spots because they provide a nice, sunny and warm place to nap. So, we'll need to measure the **temperature** and **light** in different places around the house.
 
----
-
-► From the ``||datalogger:Data Logger||`` category, grab a ``||datalogger:log data [column [""] value [0]] +||`` block and snap it **inside** the ``||logic:if [logging] then||`` statement.
-
-► Click on the ``""`` after the word ``column`` and type in "``temp``".
-
+► From the ``||datalogger:Data Logger||`` category, grab a ``||datalogger:log data [column [""] value [0]] +||`` block and snap it **inside** the ``||logic:if [logging] then||`` statement.  
+► Click on the ``""`` after the word ``column`` and type in "``temp``".  
 ► From the ``||input:Input||`` category, select the ``||input:temperature (°C)||`` parameter and drag it in to **replace** the ``0`` after the word ``value``.
 
 ```blocks
@@ -165,12 +153,10 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## 8. Setting up logging - Part 2
+## Setting up logging - Part 2
 
-► On the right of the ``||input:temperature (°C)||`` input that you just snapped in, there is a ➕ button. Click on it. You should now see a new row that says ``||datalogger:column [""] value [0]||``.
-
-► Click on the empty ``""`` after the word ``column`` and type in "``light``".
-
+► On the right of the ``||input:temperature (°C)||`` input that you just snapped in, there is a ➕ button. Click on it. You should now see a new row that says ``||datalogger:column [""] value [0]||``.  
+► Click on the empty ``""`` after the word ``column`` and type in "``light``".  
 ► From the ``||input:Input||`` category, select the ``||input:light level||`` parameter and drag it in to **replace** the ``0`` parameter after the word ``value``.
 
 ```blocks
@@ -186,21 +172,14 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## 9. Time to log data! @unplugged
-
-🎉 **Time to log data!** 🎉
+## Time to log data! @unplugged
 
 You did it! If you have a @boardname@ V2 (the one with the **shiny gold** logo at the top), download this code and try it out!
 
----
-
-► Find a sun spot in your house and press the ``A`` button to start logging data - your display should show an icon and play a sound to indicate that you are logging data.
-
+► Find a sun spot in your house and press the ``A`` button to start logging data - your display should show an icon and play a sound to indicate that you are logging data.  
 ► After some time (we recommend at least an hour), press the ``A`` button again to stop logging data - your display should clear to indicate that you are not logging data.
 
-## 10. Reviewing your data @unplugged
-
-🕵️ **Reviewing your data** 🕵️
+## Reviewing your data @unplugged
 
 Now that you have logged some data, plug your @boardname@ into a laptop or desktop computer. The @boardname@ will appear like a USB drive called MICROBIT. Look in there and you'll see a file called MY_DATA:
 
@@ -210,7 +189,7 @@ Double-click on MY_DATA to open it in a web browser and you'll see a table with 
 
 ![Image of sample data file](/static/mb/projects/cat-napping/11_datafile.png)
 
-## 11. Lychee's preferences @unplugged
+## Lychee's preferences @unplugged
 
 Does your home have a good sunbathing spot for Lychee? Compare the light and temperature levels you record for different areas around your house! The sunniest and warmest spots will likely be her favorite ☀️😻
 

--- a/docs/projects/v2-clap-lights.md
+++ b/docs/projects/v2-clap-lights.md
@@ -1,6 +1,6 @@
 # Clap Lights
 
-## 1. Introduction @unplugged
+## Introduction @unplugged
 
 The new @boardname@s have a microphone to help them detect sound 🎤
 
@@ -8,11 +8,7 @@ Let's learn how to use a clap 👏 to switch your @boardname@'s lights on and of
 
 ![Clap lights banner message](/static/mb/projects/clap-lights.png)
 
-## 2. Setting up the sound input
-
-🔊 **Reacting to sound** 🔊
-
----
+## Setting up the sound input
 
 ► From the ``||input:Input||`` category, find the ``||input:on [loud] sound||`` container and add it to your workspace.
 
@@ -22,26 +18,17 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## 3. Creating a lightsOn variable
-
-🤿 **Diving right in** 🤿
+## Creating a lightsOn variable
 
 Let's begin by creating a [__*variable*__](#variable "a holder for information that may change") to keep track of whether the @boardname@'s lights are on or off.
 
----
-
 ► In the ``||variables:Variables||`` category, click on ``Make a Variable...`` and make a variable named ``lightsOn``.
 
-## 4. Displaying LEDs part 1
-
-🔆 **On or not?** 🌑
+## Displaying LEDs part 1
 
 In this step, we'll be using an [__*if then / else*__](#ifthenelse "runs some code if a Boolean condition is true and different code if the condition is false") statement.
 
----
-
-► From the ``||logic:Logic||`` category, grab an ``||logic:if <true> then / else||`` block and snap it into your ``||input:on [loud] sound||`` container.
-
+► From the ``||logic:Logic||`` category, grab an ``||logic:if <true> then / else||`` block and snap it into your ``||input:on [loud] sound||`` container.  
 ► Look in the ``||variables:Variables||`` category. Find the new ``||variables:lightsOn||`` variable and snap it in to **replace** the ``||logic:<true>||`` value in your ``||logic:if <true> then / else||`` statement.
 
 ```blocks
@@ -56,14 +43,9 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## 5. Displaying LEDs part 2
+## Displaying LEDs part 2
 
-🌞 **Lighting the display** 🌞
-
----
-
-► From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.
-
+► From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.  
 ► Set the lights to a pattern you like!  
 💡 In the hint, we chose to turn on all of the outside lights. Feel free to make your own design 🎨
 
@@ -84,7 +66,7 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## 6. Clearing the screen
+## Clearing the screen
 
 ► From ``||basic:Basic||``, find ``||basic:clear screen||`` and snap it into the **bottom container** of your ``||logic:if then / else||`` section.  
 💡 This will turn the display off if ``lightsOn`` is **not** ``true``.
@@ -107,18 +89,12 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## 7. Setting the lightsOn variable
-
-🎬 **Lights, camera, _action_** ✨
+## Setting the lightsOn variable
 
 Just like we'd toggle a light switch, each time we clap, we want to **flip** the variable ``lightsOn`` to the **opposite** of what it was before.
 
----
-
-► From ``||variables:Variables||``, locate ``||variables:set [lightsOn] to [0]||`` and snap it in at the **very top** of your ``||input:on [loud] sound||`` container.
-
-► From the ``||logic:Logic||`` category, find the ``||logic:not <>||`` operator and use it to **replace the ``[0]``** in ``||variables:set [lightsOn] to [0]||``.
-
+► From ``||variables:Variables||``, locate ``||variables:set [lightsOn] to [0]||`` and snap it in at the **very top** of your ``||input:on [loud] sound||`` container.  
+► From the ``||logic:Logic||`` category, find the ``||logic:not <>||`` operator and use it to **replace the ``[0]``** in ``||variables:set [lightsOn] to [0]||``.  
 ► From ``||variables:Variables||``, grab ``||variables:lightsOn||`` and snap it into the **empty part** of the ``||logic:not <>||`` operator.
 
 ```blocks
@@ -140,25 +116,17 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## 8. Testing in the simulator
+## Testing in the simulator
 
-💡 **Test what you've created** 💡
-
----
-
-► Check out the simulator!
-
+► Check out the simulator!  
 ► Click on the pink slider bar beneath the microphone icon and drag it up and down.  
 💡 Right now, your @boardname@ thinks that anything above 128 is loud. Every time the sound goes > 128, your lights should switch on/off.
 
-## 8. Set loud sound threshold
+## Set loud sound threshold
 
 Your @boardname@ might detect sounds when you don't want it to. Setting a [__*sound threshold*__](#soundThreshold "a number for how loud a sound needs to be to trigger an event. 0 = silence to 255 = maximum noise") could help 🔉🔊
 
----
-
-► Click on the ``||input:Input||`` category. A new category should show up beneath it called ``||input:...more||``.
-
+► Click on the ``||input:Input||`` category. A new category should show up beneath it called ``||input:...more||``.  
 ► From ``||input:...more||``, grab ``||input:set [loud] sound threshold to [128]||`` and snap it into your **empty** ``||basic: on start||`` container.  
 💡 Try to change the value of your sound threshold so that every time you clap, your lights will turn on if they are off and vice versa.
 
@@ -167,9 +135,7 @@ Your @boardname@ might detect sounds when you don't want it to. Setting a [__*so
 input.setSoundThreshold(SoundThreshold.Loud, 150)
 ```
 
-## 9. Testing, round 2
-
-👏 **YOU DID IT!** 👏
+## Testing, round 2
 
 Don't forget to test your code in the simulator!
 

--- a/docs/projects/v2-countdown.md
+++ b/docs/projects/v2-countdown.md
@@ -1,6 +1,6 @@
 # Countdown
 
-## 1. Introduction @unplugged
+## Introduction @unplugged
 
 🎇3...🎇2...🎇1...  
 🎆GO!🎆
@@ -9,16 +9,11 @@ Let's create a musical countdown using the new @boardname@ with sound!
 
 ![Countdown banner message](/static/mb/projects/countdown.png)
 
-## 2. Setting up the loop
-
-➰ **All looped up** ➰
+## Setting up the loop
 
 We'll begin by using a [__*for loop*__](#forLoop "repeat code for a given number of times using an index") to recreate the same sound 3 times.
 
----
-
-► From the ``||loops:Loops||`` category in your toolbox, find the ``||loops:for [index] from 0 to [4]||`` loop and add it to your ``||basic:on start||`` container.
-
+► From the ``||loops:Loops||`` category in your toolbox, find the ``||loops:for [index] from 0 to [4]||`` loop and add it to your ``||basic:on start||`` container.  
 ► Change your loop to count from ``0`` to **``2``**.  
 💡 This means the loop will count 0-1-2 instead of what we want, which is 3-2-1. We will worry about this later!
 
@@ -29,15 +24,10 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## 3. Play music
-
-🎵 **Musical loops** 🎵
-
----
+## Play music
 
 ► From ``||music:Music||``, grab ``||music:play tone [Middle C] for [1 beat]||`` and snap it into your empty ``for`` loop.  
-💡 Your simulator might start playing music. You can mute it if distracting.
-
+💡 Your simulator might start playing music. You can mute it if distracting.  
 ► 1 beat is a little long. Use the **dropdown** to set the tone to play for ``||music:1/4 beat||``.
 
 ```blocks
@@ -47,18 +37,12 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## 4. Showing a number
-
-✨ **Razzle dazzle down** ✨
+## Showing a number
 
 With every tone, we also want to **display** our countdown.
 
----
-
-► From ``||basic:Basic||``, find ``||basic:show number [0]||`` and snap it in at the **bottom** of your ``for`` loop.
-
-► From your ``||loops:for [index] from 0 to [2]||`` loop condition, click and drag out the **red** ``||variables:index||`` variable.
-
+► From ``||basic:Basic||``, find ``||basic:show number [0]||`` and snap it in at the **bottom** of your ``for`` loop.  
+► From your ``||loops:for [index] from 0 to [2]||`` loop condition, click and drag out the **red** ``||variables:index||`` variable.  
 ► Use the ``||variables:index||`` that you dragged out to **replace** the ``0`` in ``||basic:show number [0]||``.
 
 ```blocks
@@ -69,18 +53,14 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## 5. Inverting the number
+## Inverting the number
 
 If you take a look at your simulator, you'll notice the @boardname@ flashing 0-1-2. We want it to say 3-2-1! Let's learn a trick to change that.
 
----
-
 ► From the ``||math:Math||`` category, snap ``||math:[0] - [0]||`` in to **replace** ``||variables:index||`` in your ``||basic:show number [index]||`` block.  
-💡 You should now have a greyed out ``index`` variable in your workspace. We'll use that in the next step.
-
+💡 You should now have a greyed out ``index`` variable in your workspace. We'll use that in the next step.  
 ► Pick up the greyed out ``||variables:index||`` variable and snap it in to the **right side** of your ``||math:[0] - [0]||`` operator.  
-💡 Can't find ``||variables:index||``? Try moving your ``||basic:on start||`` container to see if ``||variables: index||`` is hiding behind it!
-
+💡 Can't find ``||variables:index||``? Try moving your ``||basic:on start||`` container to see if ``||variables: index||`` is hiding behind it!  
 ► Set the **left side** of your ``||math:[0]-[index]||`` operator to **``3``**.  
 💡 Why does this work? Every time we loop, our ``index`` variable will grow by 1 and our @boardname@ will output: 3-0 = **3** ➡️ 3-1 = **2** ➡️ 3-2 = **1**!
 
@@ -92,14 +72,9 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## 6. Printing "GO!"
+## Printing "GO!"
 
-🏁 **You had me at "GO!"** 🏁
-
----
-
-► From ``||basic:Basic||``, grab ``||basic:show string ["Hello!"]||`` and snap it into the **very bottom** of your ``||basic:on start||`` container.
-
+► From ``||basic:Basic||``, grab ``||basic:show string ["Hello!"]||`` and snap it into the **very bottom** of your ``||basic:on start||`` container.  
 ► Replace ``Hello!`` with the word ``GO!``
 
 ```blocks
@@ -111,15 +86,10 @@ for (let index = 0; index <= 2; index++) {
 basic.showString("GO!")
 ```
 
-## 7. Adding a "GO!" noise
-
-🏇 **And we're off!** 🏇
-
----
+## Adding a "GO!" noise
 
 ► From the ``||music:Music||`` category, grab ``||music:play tone [Middle C] for [1 beat]||`` and place it **above** your ``||basic:show string ["GO!"]||`` block and **below** your ``||loops:for||`` loop.  
-💡 This will let your @boardname@ play the sound and show ``GO!`` at the same time.
-
+💡 This will let your @boardname@ play the sound and show ``GO!`` at the same time.  
 ► Set the ``||music:tone||`` to be ``Middle G``.  
 💡 ``Middle G`` is also tone ``392``.
 
@@ -134,8 +104,6 @@ basic.showString("GO!")
 ```
 
 ## 8. Testing in the simulator
-
-🚦 **Test what you've created** 🚦
 
 Make sure your speakers are on and check out the simulator!  
 

--- a/docs/projects/v2-morse-chat.md
+++ b/docs/projects/v2-morse-chat.md
@@ -1,6 +1,6 @@
 # Morse Chat
 
-## 1. Introducing Sky @unplugged
+## Introducing Sky @unplugged
 
 🐷 Meet Sky, the pig! Sky can only communicate using [__*morse code*__](#morsecode "an alphabet composed of dots (short signals) and dashes (long signals)").
 
@@ -8,14 +8,9 @@ Luckily, you can use your @boardname@ with sound to talk to Sky 👋
 
 ![Morse chat banner message](/static/mb/projects/morse-chat.png)
 
-## 2. Setup
+## Setup
 
-⚙️ **Communication works best when set up properly** ⚙️
-
----
-
-► From the ``||input:Input||`` category in the toolbox, drag an ``||input:on logo [pressed]||`` container into to your workspace.
-
+► From the ``||input:Input||`` category in the toolbox, drag an ``||input:on logo [pressed]||`` container into to your workspace.  
 ► From the ``||radio:Radio||`` category, get ``||radio:radio send number [0]||`` and snap it into your empty ``||input:on logo [pressed]||`` container.
 
 ```blocks
@@ -24,15 +19,10 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## 3. Sending different messages pt. 1
-
-💬 **Sending Sky two _different_ messages** 💬
-
----
+## Sending different messages pt. 1
 
 ► From ``||input:Input||``, grab **another** ``||input:on logo [pressed]||`` container and add it to your workspace.  
-💡 This container is greyed out because it matches another. Let's change that!
-
+💡 This container is greyed out because it matches another. Let's change that!  
 ► On the greyed-out ``||input:on logo [pressed]||`` container, click on the **``pressed``** dropdown and set it to ``||input:long pressed||``.
 
 ```blocks
@@ -44,10 +34,9 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## 4. Sending different messages pt. 2
+## Sending different messages pt. 2
 
 ► From the ``||radio:Radio||`` category, get a ``||radio:radio send number [0]||`` block and snap it into your **empty** ``||input:on logo [long pressed]||`` container.  
-
 ► Set the number to be ``1``.
 
 ```blocks
@@ -60,16 +49,12 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## 5. Receiving different messages
+## Receiving different messages
 
 To ensure Sky gets the right message, we will use an [__*if then / else*__](#ifthenelse "runs some code if a boolean condition is true and different code if the condition is false") conditional statement.
 
----
-
-► From ``||radio:Radio||``, find the ``||radio:on radio received [receivedNumber]||`` container and add it to your workspace.
-
-► From ``||logic:Logic||``, grab an ``||logic:if <true> then / else||`` statement and snap it into your **new** ``||radio:on radio received [receivedNumber]||`` container.
-
+► From ``||radio:Radio||``, find the ``||radio:on radio received [receivedNumber]||`` container and add it to your workspace.  
+► From ``||logic:Logic||``, grab an ``||logic:if <true> then / else||`` statement and snap it into your **new** ``||radio:on radio received [receivedNumber]||`` container.  
 ► Go back to the ``||logic:Logic||`` category, grab ``||logic:<[0] [=] [0]>||``, and click it in to **replace** the ``||logic:<true>||`` argument in your ``||logic:if <true> then / else||`` statement.
 
 ```blocks
@@ -83,10 +68,9 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 6. Conditioning on the input
+## Conditioning on the input
 
-► From your ``||radio:on radio received [receivedNumber]||`` container, grab the **``receivedNumber``** input and drag out a copy.
-
+► From your ``||radio:on radio received [receivedNumber]||`` container, grab the **``receivedNumber``** input and drag out a copy.  
 ► Use your copy of **``receivedNumber``** to replace the ``[0]`` on the **left side** of ``||logic:<[0] [=] [0]>||``.
 
 ```blocks
@@ -100,12 +84,9 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 7. Displaying a message pt. 1
+## Displaying a message pt. 1
 
-📃 **Dashing through the lights** 📃
-
-► We want to display a dash if the logo is long pressed.  From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the empty **bottom container** of your ``||logic:if then / else||`` statement.
-
+► We want to display a dash if the logo is long pressed.  From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the empty **bottom container** of your ``||logic:if then / else||`` statement.  
 ► Turn on 3 LEDs in a row to be a dash: -
 
 ```blocks
@@ -124,11 +105,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 8. Playing a sound pt. 1
-
-🎵 **Adding sound** 🎵
-
----
+## Playing a sound pt. 1
 
 ► From the ``||music:Music||`` category, grab a ``||music:play tone [Middle C] for [1 beat]||`` block and snap it at the **end** of the **bottom container** in your ``||logic:if then / else||`` statement.
 
@@ -149,14 +126,9 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 9. Displaying a message pt. 2
+## Displaying a message pt. 2
 
-⚫ **Dot dot dot** ⚫
-
----
-
-► We want to display a dot if the logo is pressed. From ``||basic:Basic||``, grab another ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.
-
+► We want to display a dot if the logo is pressed. From ``||basic:Basic||``, grab another ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.  
 ► Turn on a single LED to make a dot: .
 
 ```blocks
@@ -183,10 +155,9 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 10. Playing a sound pt. 2
+## Playing a sound pt. 2
 
-► From the ``||music:Music||`` category, grab ``||music:play tone [Middle C] for [1 beat]||`` and snap it in at the **end** of the **top container** in your ``||logic:if then / else||`` statement.
-
+► From the ``||music:Music||`` category, grab ``||music:play tone [Middle C] for [1 beat]||`` and snap it in at the **end** of the **top container** in your ``||logic:if then / else||`` statement.  
 ► Dots are shorter than dashes! Set the tone to play for ``1/4 beat``.
 
 ```blocks
@@ -214,11 +185,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 11. Clearing the screens
-
-🗨️ **Clear the lights once the messages are sent** 🗨️
-
----
+## Clearing the screens
 
 ► From ``||basic:Basic||``, find ``||basic:clear screen||`` and snap it in at the **very bottom** of your ``||radio:on radio received [receivedNumber]||`` container.
 
@@ -248,21 +215,49 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## 12. Testing in the simulator
+## Testing in the simulator - Connect!
 
-🐷 **Test what you've created** 💬
+Test what you've created. Remember to turn your sound on!
 
-Remember to turn your sound on!
-
----
-
-► Touch the gold **micro:bit logo** at the top of your @boardname@ on the simulator. You'll notice that a second @boardname@ appears.  
+► Touch the gold **micro:bit logo** at the top of your @boardname@ on the simulator. You'll notice that a second @boardname@ appears. This is the @boardname@ for Sky 🐖  
 💡 If your screen is too small, you might not be able to see it.
+
+```blocks
+radio.onReceivedNumber(function (receivedNumber) {
+    if (receivedNumber == 0) {
+        basic.showLeds(`
+            . . . . .
+            . . . . .
+            . . # . .
+            . . . . .
+            . . . . .
+            `)
+        music.playTone(262, music.beat(BeatFraction.Quarter))
+    } else {
+        basic.showLeds(`
+            . . . . .
+            . . . . .
+            . # # # .
+            . . . . .
+            . . . . .
+            `)
+        music.playTone(262, music.beat(BeatFraction.Whole))
+    }
+    basic.clearScreen()
+})
+input.onLogoEvent(TouchButtonEvent.LongPressed, function () {
+    radio.sendNumber(1)
+})
+input.onLogoEvent(TouchButtonEvent.Pressed, function () {
+    radio.sendNumber(0)
+})
+```
+
+## Testing in the simulator - Send message
 
 ► Touch the logo again to send messages to Sky 🐖  
 **Press** to send a dot.  
-**Long press** (count to 3!) to send a dash.
-
+**Long press** (count to 3!) to send a dash.  
 ► If you have multiple @boardname@s with sound (they have **shiny gold** logos at the top), download this code and try it out!
 
 ```blocks

--- a/docs/projects/v2-pet-hamster.md
+++ b/docs/projects/v2-pet-hamster.md
@@ -1,41 +1,26 @@
 # Pet Hamster
 
-## 1. Introduction @unplugged
-
-👋 Meet your new pet hamster, Cyrus 🐹
+## Introduction @unplugged
 
 ![Pet hamster banner message](/static/mb/projects/pet-hamster.png)
 
-## 2. Cyrus's asleep face
-
-😴 **Sleeping on the job** 😴
+## Cyrus's asleep face
 
 Cyrus is a very sleepy hamster. In fact, Cyrus is almost always sleeping.
 
----
-
-► From the ``||basic:Basic||`` category, find ``||basic:show icon [ ]||`` and snap it into your ``||basic:on start||`` container.
-
-► Set it to show the asleep ``-_-`` face.  
+► From the ``||basic:Basic||`` category, find ``||basic:show icon [ ]||`` and snap it into your ``||basic:on start||`` container. Set it to show the asleep ``-_-`` face.  
 💡 In the ``show icon`` dropdown menu options, you can hover to see what each design is called!
 
 ```blocks
 basic.showIcon(IconNames.Asleep)
 ```
 
-## 3. Giggly Cyrus
-
-🤣 **That tickles** 🤣
+## Giggly Cyrus
 
 Pressing Cyrus's logo tickles them!
 
----
-
-► From ``||input:Input||``, find the ``||input:on logo [pressed]||`` container and drag it into your workspace.
-
-► Go to ``||basic:Basic||`` and grab **another** ``||basic:show icon [ ]||``. Snap it into your **empty** ``||input:on logo [pressed]||`` container.
-
-► Set the icon (Cyrus's face) to happy ``:)``.
+► From ``||input:Input||``, find the ``||input:on logo [pressed]||`` container and drag it into your workspace.  
+► Go to ``||basic:Basic||`` and grab **another** ``||basic:show icon [ ]||``. Snap it into your **empty** ``||input:on logo [pressed]||`` container. Set the icon (Cyrus's face) to happy ``:)``.
 
 ```blocks
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
@@ -43,11 +28,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## 4. Tickle sound
-
-🎶 **The sounds of Cyrus** 🎶
-
----
+## Tickle sound
 
 ► From the ``||music:Music||`` category, get a ``||music:play sound [giggle] until done||`` and add it to the **bottom** of your ``||input:on logo [pressed]||`` container.
 
@@ -59,19 +40,12 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## 5. Dizzy Cyrus
-
-😵 **All shaken up** 💫
+## Dizzy Cyrus
 
 Whenever Cyrus is shaken, they get sad 🙁
 
----
-
-► From ``||input:Input||``, find ``||input:on [shake]||`` and drag it into your workspace.
-
-► From the ``||basic:Basic||`` category, grab ``||basic:show icon [ ]||`` and snap it into your **new** ``||input:on [shake]||`` container.
-
-► Set the icon (Cyrus's face) to sad ``:(``.
+► From ``||input:Input||``, find ``||input:on [shake]||`` and drag it into your workspace.  
+► From the ``||basic:Basic||`` category, grab ``||basic:show icon [ ]||`` and snap it into your **new** ``||input:on [shake]||`` container. Set the icon (Cyrus's face) to sad ``:(``.
 
 ```blocks
 input.onGesture(Gesture.Shake, function () {
@@ -79,10 +53,9 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## 6. Dizzy sound
+## Dizzy sound
 
-► From the ``||music:Music||`` category, find the ``||music:play sound [giggle] until done||`` block and add it to the **bottom** of your ``||input:on [shake]||`` container.
-
+► From the ``||music:Music||`` category, find the ``||music:play sound [giggle] until done||`` block and add it to the **bottom** of your ``||input:on [shake]||`` container.  
 ► Click on the **dropdown** and set it so Cyrus plays a ``||music:sad||`` sound until done.
 
 ```blocks
@@ -93,16 +66,11 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## 7. Cyrus's default face pt. 1
-
-💤 **Back to sleep** 💤
+## Cyrus's default face pt. 1
 
 Let's ensure that Cyrus will always go back to sleep after being shaken or tickled.
 
----
-
-► Right click the ``||basic:show icon[-_-]||`` block in your workspace (inside the ``||basic:on start||`` container) and choose **Duplicate**.
-
+► Right click the ``||basic:show icon[-_-]||`` block in your workspace (inside the ``||basic:on start||`` container) and choose **Duplicate**.  
 ► Snap your copied block in at the **very bottom** of your ``||input:on [shake]||`` container.
 
 ```blocks
@@ -119,7 +87,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 basic.showIcon(IconNames.Asleep)
 ```
 
-## 8. Cyrus's default face pt. 2
+## Cyrus's default face pt. 2
 
 ► Duplicate the ``||basic:show icon[-_-]||`` block again and this time snap it in at the **very bottom** of your ``||input:on logo [pressed]||`` container.
 
@@ -138,9 +106,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 basic.showIcon(IconNames.Asleep)
 ```
 
-## 9. Testing in the simulator
-
-🐾 **Test what you've created** 🐾
+## Testing in the simulator
 
 Check out the simulator and make sure your speakers are on 🔊
 


### PR DESCRIPTION
Compact the instructions and spacing in the V2 tutorials for a better appearance in the new tutorial display.

Note: These will require just a slight bit of scroll to view the entire step info. If it's desired to use no scrolling, then a second pass with more steps and compacting is needed. See if it's OK.

Closes #5168