### PR TITLE
Set default blocks for block tutorials

### DIFF
--- a/docs/projects/dice.md
+++ b/docs/projects/dice.md
@@ -11,10 +11,10 @@ Let's turn the @boardname@ into a dice!
 
 We need 3 pieces of code: one to detect a throw (shake), another to pick a random number, and then one to show the number.
 
-Place the ``||input:on shake||`` block onto the editor workspace. It runs code when you shake the @boardname@.
+Use the ``||input:on shake||`` block you see in the editor workspace. It runs code when you shake the @boardname@.
 
 ```blocks
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
 
 })
 ```
@@ -24,7 +24,7 @@ input.onGesture(Gesture.Shake, () => {
 Get a ``||basic:show number||`` block and place it inside the ``||input:on shake||`` block to display a number.
 
 ```blocks
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     basic.showNumber(0)
 })
 ```
@@ -34,7 +34,7 @@ input.onGesture(Gesture.Shake, () => {
 Put a ``||Math:pick random||`` block in the ``||basic:show number||`` block to pick a random number.
 
 ```blocks
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     basic.showNumber(randint(0, 10))
 })
 ```
@@ -44,7 +44,7 @@ input.onGesture(Gesture.Shake, () => {
 A typical dice shows values from `1` to `6`. So, in ``||Math:pick random||``, don't forget to choose the right minimum and maximum values!
 
 ```blocks
-input.onGesture(Gesture.Shake, () => {
+input.onGesture(Gesture.Shake, function() {
     basic.showNumber(randint(1, 6))
 })
 ```
@@ -56,3 +56,7 @@ Use the simulator to try out your code. Does it show the number you expected?
 ## Step 6
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!
+
+```template
+input.onGesture(Gesture.Shake, function() {})
+```

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -42,3 +42,7 @@ Look at the virtual @boardname@, you should see the heart and your drawing blink
 ## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!
+
+```template
+basic.forever(function() {})
+```

--- a/docs/projects/love-meter.md
+++ b/docs/projects/love-meter.md
@@ -8,11 +8,11 @@ Make a love meter, how sweet! The @boardname@ is feeling the love, then sometime
 
 ## Step 1
 
-Let's build a **LOVE METER** machine. Place an ``||input:on pin pressed||`` block to run code when pin **0** is pressed. Use ``P0`` from the list of pin inputs.
+Let's build a **LOVE METER** machine. We'll use an ``||input:on pin pressed||`` block to run code when pin **0** is pressed. Use ``P0`` from the list of pin inputs.
 
 ```blocks
-input.onPinPressed(TouchPin.P0, () => {
-});
+input.onPinPressed(TouchPin.P0, function() {
+})
 ```
 
 ## Step 2
@@ -20,9 +20,9 @@ input.onPinPressed(TouchPin.P0, () => {
 Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from `0` to `100` when pin **0** is pressed.
 
 ```blocks
-input.onPinPressed(TouchPin.P0, () => {
-    basic.showNumber(randint(0, 100));
-});
+input.onPinPressed(TouchPin.P0, functions() {
+    basic.showNumber(randint(0, 100))
+})
 ```
 ## Step 3
 
@@ -33,12 +33,16 @@ Click on pin **0** in the simulator and see which number is chosen.
 Show ``"LOVE METER"`` on the screen when the @boardname@ starts.
 
 ```blocks
-basic.showString("LOVE METER");
-input.onPinPressed(TouchPin.P0, () => {
-    basic.showNumber(randint(0, 100));
+basic.showString("LOVE METER")
+input.onPinPressed(TouchPin.P0, function() {
+    basic.showNumber(randint(0, 100))
 });
 ```
 
 ## Step 5
 
 Click ``|Download|`` to transfer your code in your @boardname@. Hold the **GND** pin with one hand and press pin **0** with the other hand to trigger this code.
+
+```template
+input.onPinPressed(TouchPin.P0, function() {})
+```

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -11,9 +11,9 @@ Tell everyone who you are. Show you name on the LEDs.
 Place the ``||basic:show string||`` block in the ``||basic:forever||`` block to repeat it. Change the text to your name.
 
 ```blocks
-basic.forever(() => {
+basic.forever(function() {
     basic.showString("MICRO");
-});
+})
 ```
 
 ## Step 2
@@ -25,12 +25,16 @@ Look at the simulator and make sure it shows your name on the screen.
 Place more ``||basic:show string||`` blocks to create your own story.
 
 ```blocks
-basic.forever(() => {
-    basic.showString("MICRO");
-    basic.showString("<3<3<3");
+basic.forever(function() {
+    basic.showString("MICRO")
+    basic.showString("<3<3<3")
 })
 ```
 
 ## Step 4
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch your name scroll!
+
+```template
+basic.forever(function() {})
+```

--- a/docs/projects/smiley-buttons.md
+++ b/docs/projects/smiley-buttons.md
@@ -9,11 +9,11 @@ Code the buttons on the @boardname@ to show that it's happy or sad.
 
 ## Step 1
 
-Place a ``||input:on button pressed||`` block to run code when button **A** is pressed.
+Use the ``||input:on button pressed||`` block to run code when button **A** is pressed.
 
 ```blocks
-input.onButtonPressed(Button.A, () => { 
-});
+input.onButtonPressed(Button.A, function() { 
+})
 ```
 
 ## Step 2
@@ -21,15 +21,15 @@ input.onButtonPressed(Button.A, () => {
 Place a ``||basic:show leds||`` block inside ``||input:on button pressed||`` to display a smiley on the screen. Press the **A** button in the simulator to see the smiley.
 
 ```blocks
-input.onButtonPressed(Button.A, () => { 
+input.onButtonPressed(Button.A, function() { 
     basic.showLeds(`
         # # . # #
         # # . # #
         . . . . .
         # . . . #
         . # # # .`
-        );
-});
+        )
+})
 ```
 
 ## Step 3
@@ -37,7 +37,7 @@ input.onButtonPressed(Button.A, () => {
 Add ``||input:on button pressed||`` and ``||basic:show leds||`` blocks to display a frowny when button **B** is pressed.
 
 ```blocks
-input.onButtonPressed(Button.B, () => { 
+input.onButtonPressed(Button.B, function() { 
     basic.showLeds(`
         # # . # #
         # # . # #
@@ -53,7 +53,7 @@ input.onButtonPressed(Button.B, () => {
 Add a secret mode that happens when **A** and **B** are pressed together. For this case, add multiple ``||basic:show leds||`` blocks to create an animation.
 
 ```blocks
-input.onButtonPressed(Button.AB, () => {
+input.onButtonPressed(Button.AB, function() {
     basic.showLeds(`
         . . . . .
         # . # . .
@@ -79,3 +79,6 @@ If you have a @boardname@, connect it to USB and click ``|Download|`` to transfe
 
 Nice! Now go and show it off to your friends!
 
+```template
+input.onButtonPressed(Button.A, function() {})
+```


### PR DESCRIPTION
Set the initial block/s for block choice tutorials. This is to not have any unused "on start" or "forever" blocks present by default.

Closes #5167