### PR TITLE
Hide "Replace my Code" unless we're in a skillmap

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -572,7 +572,8 @@
             "editor": "/tours/editor-tour"
         },
         "tutorialSimSidebarLayout": true,
-        "preferWebUSBDownload": true
+        "preferWebUSBDownload": true,
+        "hideReplaceMyCode": true
     },
     "queryVariants": {
         "hidemenu": {
@@ -600,6 +601,11 @@
                         "order": 3
                     }
                 }
+            }
+        },
+        "skillsMap=1": {
+            "appTheme": {
+                "hideReplaceMyCode": false
             }
         }
     },


### PR DESCRIPTION
This addresses the issue mentioned in this comment: https://github.com/microsoft/pxt-microbit/issues/5167#issuecomment-1555362780

Makes use of the existing hideReplaceMyCode flag: https://github.com/microsoft/pxt/blob/master/webapp/src/components/tutorial/TutorialContainer.tsx#L273

We don't have any skillmaps for micro:bit at the moment, so the skillmaps variant is a bit unnecessary here, but I thought I should add it anyway in case we do ever create some. Otherwise "Replace my Code" would be missing.