### PR TITLE
Setting sample rate: got rid of memory leak

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -48,11 +48,6 @@ void checkEnv(int sampleRate = -1) {
         uBit.audio.mixer.setVolume(1000);
         uBit.audio.setSpeakerEnabled(true);
     }
-
-    if (recording != NULL && sampleRate != -1) {
-        channel = uBit.audio.mixer.addChannel(*recording, sampleRate);
-        channel->setVolume(75.0);
-    }
 }
 
 /**
@@ -156,7 +151,11 @@ void setInputSampleRate(int sampleRate) {
  */
 //%
 void setOutputSampleRate(int sampleRate) {
-    checkEnv(sampleRate);
+    if (recording == NULL) {
+        checkEnv(sampleRate);
+    } else {
+        channel->setSampleRate(sampleRate);
+    }
 }
 
 /**
@@ -164,7 +163,11 @@ void setOutputSampleRate(int sampleRate) {
 */
 //%
 void setBothSamples(int sampleRate) {
-    checkEnv(sampleRate);
+    if (recording == NULL) {
+        checkEnv(sampleRate);
+    } else {
+        channel->setSampleRate(sampleRate);
+    }
     splitterChannel->requestSampleRate(sampleRate);
 }
 

--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -163,11 +163,7 @@ void setOutputSampleRate(int sampleRate) {
 */
 //%
 void setBothSamples(int sampleRate) {
-    if (recording == NULL) {
-        checkEnv(sampleRate);
-    } else {
-        channel->setSampleRate(sampleRate);
-    }
+    setOutputSampleRate(sampleRate);
     splitterChannel->requestSampleRate(sampleRate);
 }
 


### PR DESCRIPTION
In trying to set the output sample rate, I added a new channel to the data pipeline every time that `checkEnv()` was called, thus causing programs to explode in size. With the new CODAL apis, I can set the sample rate of the existing channel and thus avoid a memory leak.

Closes https://github.com/microsoft/pxt-microbit/issues/5131

Note: This change in functionality is now activating the mic on the hardware. This is something we might want to change. 