### PR TITLE
swap to v2 sim when v2 hardware plugged in

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -573,7 +573,8 @@
         },
         "tutorialSimSidebarLayout": true,
         "preferWebUSBDownload": true,
-        "hideReplaceMyCode": true
+        "hideReplaceMyCode": true,
+        "matchWebUSBDeviceInSim": true
     },
     "queryVariants": {
         "hidemenu": {

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -173,6 +173,9 @@ namespace pxsim {
             document.body.innerHTML = ""; // clear children
             document.body.appendChild(this.view = this.viewHost.getView());
 
+            if (msg.theme === "mbcodal") {
+                this.ensureHardwareVersion(2);
+            }
             return Promise.resolve();
         }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4724, requires https://github.com/microsoft/pxt/pull/9530

I only did it to swap to v2 if plugged in, not trying to swap back to v1 if you're using v1 blocks. Not sure we want that, it already gives a warning when you try and download while plugged in anyways