### PR TITLE
skip warning when too big to build for v1 if webusb connected v2

### DIFF
--- a/editor/dialogs.tsx
+++ b/editor/dialogs.tsx
@@ -15,8 +15,16 @@ export function cantImportAsync(project: pxt.editor.IProjectView) {
 }
 
 
-export async function showProgramTooLargeErrorAsync(variants: string[], confirmAsync: (opts: any) => Promise<number>) {
+export async function showProgramTooLargeErrorAsync(variants: string[], confirmAsync: (opts: any) => Promise<number>, saveOnly?: boolean) {
     if (variants.length !== 2) return undefined;
+
+    if (pxt.packetio.isConnected() && pxt.packetio.deviceVariant() === "mbcodal" && !saveOnly) {
+        // connected micro:bit V2 will be flashed; don't give warning dialog
+        return {
+            recompile: true,
+            useVariants: ["mbcodal"]
+        }
+    }
 
     const choice = await confirmAsync({
         header: lf("Oops, there was a problem downloading your code"),

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.4.9",
-        "pxt-core": "8.6.43"
+        "pxt-core": "8.6.44"
     }
 }


### PR DESCRIPTION
requires https://github.com/microsoft/pxt/pull/9530 (build will be red till that is included)

if webusb is connected, device is a v2 micro:bit, and the program is too large to flash, skip flashing the dialog & just attempt recompilation