### PR TITLE
Recording extension: Sleeping in boolean blocks to prevent race condition in tight loops

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -117,6 +117,7 @@ int audioDuration(int sampleRate) {
  */
 //%
 bool audioIsPlaying() {
+    uBit.sleep(0);
     return recording->isPlaying();
 }
 
@@ -125,6 +126,7 @@ bool audioIsPlaying() {
  */
 //%
 bool audioIsRecording() {
+    uBit.sleep(0);
     return recording->isRecording();
 }
 


### PR DESCRIPTION
In the past, programs like the following would freeze the micro:bit board because of a race condition caused by non-preemptive scheduling. 

<img width="217" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/49178322/f8b6fa34-d136-4335-9270-9e1213ca6b59">

The root of the problem is that after the check is called the first time, the sound level will continue to poll for resources and be at the top of the calling queue, putting calls to the check behind the sound level poll and thus never getting further in the program. With the `uBit.sleep(0)` calll, we are saying that after waiting 0 time, put the function call at the top of the queue, which allows the program to continue running as expected.