### PR TITLE
Improve gif quality for thumbnail

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -539,6 +539,7 @@
         "simScreenshot": true,
         "simScreenshotMaxUriLength": 300000,
         "simGif": true,
+        "simGifWidth": 240,
         "qrCode": true,
         "importExtensionFiles": true,
         "nameProjectFirst": true,


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-microbit/issues/5159

This is still not perfect, but I think it's an improvement. The quality can get a little better with larger widths but there is a tradeoff because then there's room for less frames and it seems to take longer to render. Thanks to @jwunderl for helping me find the gif width field.

With the changes:
![gif240](https://github.com/microsoft/pxt-microbit/assets/15070078/015aec08-20c8-4e1e-a151-808528e6895d)

Before:
![gif160](https://github.com/microsoft/pxt-microbit/assets/15070078/395dbdc9-ba01-447d-bacd-df186c00e4ca)
