### PR TITLE
Recording extension: Moved extension card to be less prominent in the extension list

### DIFF
--- a/libs/audio-recording/pxt.json
+++ b/libs/audio-recording/pxt.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "core": "file:../core"
     },
+    "weight": 10,
     "files": [
         "recording.ts",
         "recording.cpp",


### PR DESCRIPTION
The recording extension is no longer the first extension in the list of built-in extensions. 

How it looks on different sized screens: 
My 27" monitor: 
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/b9beee1c-f2dd-4823-80c5-3cc7dfc1b0a1)

1920px wide:
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/98a85730-e6dd-4265-92c7-0184aa98ae8d)

1366px wide: 
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/4b61c975-83b4-4c12-bf0d-7dc6a0d24ca2)


Closes https://github.com/microsoft/pxt-microbit/issues/5194