### PR TITLE
Add tour steps for monaco editor

### DIFF
--- a/docs/tours/editor-tour.md
+++ b/docs/tours/editor-tour.md
@@ -20,10 +20,22 @@
 * highlight: toolbox
 * location: right
 
+## Toolbox
+* title: Toolbox
+* description: Drag out snippets of code from the Toolbox categories into the Workspace.
+* highlight: monaco toolbox
+* location: right
+
 ## Workspace
 * title: Workspace
 * description: Snap blocks of code together to build your program.
 * highlight: workspace
+* location: center
+
+## Workspace
+* title: Workspace
+* description: Write code to build your program.
+* highlight: monaco workspace
 * location: center
 
 ## Share

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "typescript": "4.2.3"
     },
     "dependencies": {
-        "pxt-common-packages": "10.4.9",
+        "pxt-common-packages": "10.4.10",
         "pxt-core": "8.6.47"
     }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.4.9",
-        "pxt-core": "8.6.45"
+        "pxt-core": "8.6.47"
     }
 }


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9535

This PR adds the tour steps for JavaScript and Python projects. Only visible elements are added to the tour, so there should be no duplicate toolbox or workspace steps in the tour. 