### PR TITLE
Recording extension: putting more distance in between gain levels

### DIFF
--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -93,13 +93,12 @@ void erase() {
 void setMicrophoneGain(int gain) {
     switch (gain) {
     case 1:
-        uBit.audio.processor->setGain(0.079f);
         break;
     case 2:
         uBit.audio.processor->setGain(0.2f);
         break;
     case 3:
-        uBit.audio.processor->setGain(0.4f);
+        uBit.audio.processor->setGain(1.0f);
         break;
     }
 }

--- a/libs/audio-recording/recording.cpp
+++ b/libs/audio-recording/recording.cpp
@@ -90,17 +90,8 @@ void erase() {
  * Set sensitity of the microphone input
  */
 //%
-void setMicrophoneGain(int gain) {
-    switch (gain) {
-    case 1:
-        break;
-    case 2:
-        uBit.audio.processor->setGain(0.2f);
-        break;
-    case 3:
-        uBit.audio.processor->setGain(1.0f);
-        break;
-    }
+void setMicrophoneGain(float gain) {
+    uBit.audio.processor->setGain(gain);
 }
 
 /**

--- a/libs/audio-recording/recording.ts
+++ b/libs/audio-recording/recording.ts
@@ -163,8 +163,17 @@ namespace record {
     //% parts="microphone"
     //% weight=30
     export function setMicGain(gain: AudioLevels): void {
-        setMicrophoneGain(gain);
-        return
+        switch (gain) {
+            case AudioLevels.Low:
+                setMicrophoneGain(0.079);
+                break;
+            case AudioLevels.Medium:
+                setMicrophoneGain(0.2);
+                break;
+            case AudioLevels.High:
+                setMicrophoneGain(1.0);
+                break;
+        }
     }
 
     /**

--- a/libs/audio-recording/shims.d.ts
+++ b/libs/audio-recording/shims.d.ts
@@ -29,7 +29,7 @@ declare namespace record {
      * Set sensitity of the microphone input
      */
     //% shim=record::setMicrophoneGain
-    function setMicrophoneGain(gain: int32): void;
+    function setMicrophoneGain(gain: number): void;
 
     /**
      * Get how long the recorded audio clip is

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -326,7 +326,7 @@ declare namespace input {
      * Get the magnetic force value in ``micro-Teslas`` (``µT``). This function is not supported in the simulator.
      * @param dimension the x, y, or z dimension, eg: Dimension.X
      */
-    //% help=input/magnetic-force weight=51
+    //% help=input/magnetic-force weight=54
     //% blockId=device_get_magnetic_force block="magnetic force (µT)|%NAME" blockGap=8
     //% parts="compass"
     //% advanced=true shim=input::magneticForce
@@ -337,7 +337,7 @@ declare namespace input {
      */
     //% help=input/calibrate-compass advanced=true
     //% blockId="input_compass_calibrate" block="calibrate compass"
-    //% weight=45 shim=input::calibrateCompass
+    //% weight=55 shim=input::calibrateCompass
     function calibrateCompass(): void;
 
     /**


### PR DESCRIPTION
With the current iteration of the blocks, It's hard to tell the difference between medium and high mic sensitivity. The changes in this PR create a larger difference. There might be more arguments to make the distance between the levels even greater, but I feel strongly that these are the best values to tell the difference between medium and high sensitivity while also making it so the audio isn't blowing out the speaker completely (high is already on the verge of doing so).

Note: for the low sensitivity level, I just took away setting the gain in the switch statement because the default is already low and I don't really want to touch it. I wasn't sure, though, if I can just take out the case completely. I can take it out if it's safe to do so.

Closes https://github.com/microsoft/pxt-microbit/issues/5063