### PR TITLE
Melody Block Updates to Align with Previous Blocks

### DIFF
--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -375,6 +375,7 @@
   "music.PlaybackMode.InBackground|block": "in background",
   "music.PlaybackMode.LoopingInBackground|block": "looping in background",
   "music.PlaybackMode.UntilDone|block": "until done",
+  "music._playDefaultBackground|block": "play $toPlay $playbackMode",
   "music.beat|block": "%fraction|beat",
   "music.builtInMelody|block": "%melody",
   "music.builtInPlayableMelody|block": "melody $melody",

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -377,7 +377,7 @@
   "music.PlaybackMode.UntilDone|block": "until done",
   "music.beat|block": "%fraction|beat",
   "music.builtInMelody|block": "%melody",
-  "music.builtInPlayableMelody|block": "$melody",
+  "music.builtInPlayableMelody|block": "melody $melody",
   "music.builtinPlayableSoundEffect|block": "$soundExpression",
   "music.builtinSoundEffect|block": "$soundExpression",
   "music.changeTempoBy|block": "change tempo by (bpm)|%value",

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -338,7 +338,7 @@ namespace music {
      */
     //% weight=60 help=music/builtin-melody
     //% blockId=device_builtin_melody_playable block="melody $melody"
-    //% toolboxParent=music_playable_play
+    //% toolboxParent=music_playable_play_default_bkg
     //% toolboxParentArgument=toPlay
     //% duplicateShadowOnDrag
     //% group="Melody Advanced"

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -337,7 +337,7 @@ namespace music {
      * @param melody the melody name
      */
     //% weight=60 help=music/builtin-melody
-    //% blockId=device_builtin_melody_playable block="$melody"
+    //% blockId=device_builtin_melody_playable block="melody $melody"
     //% toolboxParent=music_playable_play
     //% toolboxParentArgument=toPlay
     //% duplicateShadowOnDrag

--- a/libs/core/playable.ts
+++ b/libs/core/playable.ts
@@ -86,6 +86,17 @@ namespace music {
         toPlay._play(playbackMode);
     }
 
+    //% blockId="music_playable_play_default_bkg"
+    //% block="play $toPlay $playbackMode"
+    //% toPlay.shadow=music_string_playable
+    //% playbackMode.defl=music.PlaybackMode.InBackground
+    //% group="Melody"
+    //% help="music/play"
+    //% blockHidden
+    export function _playDefaultBackground(toPlay: Playable, playbackMode: PlaybackMode) {
+        return play(toPlay, playbackMode);
+    }
+
     //% blockId="music_string_playable"
     //% block="melody $melody at tempo $bpm|(bpm)"
     //% weight=85 blockGap=8


### PR DESCRIPTION
The goal is to align the new melody blocks added in https://github.com/microsoft/pxt-microbit/pull/5123 (specifically the "built in melody" block) to something that resembles the previous blocks a bit more closely. See https://github.com/microsoft/pxt-microbit/issues/5219 for more details on why.

Specific changes were to include "melody" before the melody name and to change the default to "in background". Since we don't want to change all blocks to use "in background" by default, I created a copy of the play block and used that instead. I don't love this approach, as it makes the javascript look pretty weird, but it gets the job done and a cleaner solution would require more time than we'd like to commit to this change.

Original block (before https://github.com/microsoft/pxt-microbit/pull/5123):
<img width="200" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/69657545/f42a8dad-b4b1-4688-9e6d-a5a67ba68048">

Block after https://github.com/microsoft/pxt-microbit/pull/5123 but without these changes:
<img width="143" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/69657545/c11b6193-bb92-478a-b4af-f08de7f5fc3d">

Block with these changes:
<img width="181" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/69657545/0025eed4-f95a-4e4a-bfe4-caef88e75ca9">
<img width="193" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/69657545/e1df0d36-7062-4991-b079-6d56699c7deb">

Upload target: https://makecode.microbit.org/app/6634ff49a8e295843baba5736a89f2f4861fa8b0-cdb36cab85

Fixes https://github.com/microsoft/pxt-microbit/issues/5219. 