### PR TITLE
Recording extension: Changed audio is full to audio is empty

### DIFF
--- a/libs/audio-recording/_locales/audio-recording-strings.json
+++ b/libs/audio-recording/_locales/audio-recording-strings.json
@@ -12,7 +12,7 @@
   "record.AudioSampleRateScope.Everything|block": "everything",
   "record.AudioSampleRateScope.Playback|block": "playback",
   "record.AudioSampleRateScope.Recording|block": "recording",
-  "record.AudioStatus.BufferFull|block": "full",
+  "record.AudioStatus.BufferEmpty|block": "empty",
   "record.AudioStatus.Playing|block": "playing",
   "record.AudioStatus.Recording|block": "recording",
   "record.AudioStatus.Stopped|block": "stopped",

--- a/libs/audio-recording/recording.ts
+++ b/libs/audio-recording/recording.ts
@@ -72,8 +72,8 @@ namespace record {
         Recording,
         //% block="stopped"
         Stopped,
-        //% block="full"
-        BufferFull,
+        //% block="empty"
+        BufferEmpty,
     }
 
     export enum BlockingState {
@@ -150,8 +150,8 @@ namespace record {
                 return audioIsRecording();
             case AudioStatus.Stopped:
                 return audioIsStopped();
-            case AudioStatus.BufferFull:
-                return _recordingPresent;
+            case AudioStatus.BufferEmpty:
+                return !_recordingPresent;
         }
     }
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -326,7 +326,7 @@ declare namespace input {
      * Get the magnetic force value in ``micro-Teslas`` (``µT``). This function is not supported in the simulator.
      * @param dimension the x, y, or z dimension, eg: Dimension.X
      */
-    //% help=input/magnetic-force weight=51
+    //% help=input/magnetic-force weight=54
     //% blockId=device_get_magnetic_force block="magnetic force (µT)|%NAME" blockGap=8
     //% parts="compass"
     //% advanced=true shim=input::magneticForce
@@ -337,7 +337,7 @@ declare namespace input {
      */
     //% help=input/calibrate-compass advanced=true
     //% blockId="input_compass_calibrate" block="calibrate compass"
-    //% weight=45 shim=input::calibrateCompass
+    //% weight=55 shim=input::calibrateCompass
     function calibrateCompass(): void;
 
     /**


### PR DESCRIPTION
Tracking whether the audio buffer is full is a bit nuanced as it doesn't mean anything to the user. When starting a recording, the previous recording is erased. A user can't add to the current audio buffer.  The metric that might be useful to some users is to check if there is something in the audio buffer at all, which is what `audio is full` was tracking with confusing wording.

Because `audio is full` doesn't really provide value to the user, the block is now `audio is empty` for a usage where the user might want to check if the buffer doesn't have anything in it before recording something. The following is an example program:
<img width="248" alt="image" src="https://github.com/microsoft/pxt-microbit/assets/49178322/afd19442-efa2-41a8-b45b-d4f8fc04f374">

Closes: https://github.com/microsoft/pxt-microbit/issues/5223
