### PR TITLE
Hide step headings in some tutorials

### DIFF
--- a/docs/projects/7-seconds.md
+++ b/docs/projects/7-seconds.md
@@ -1,6 +1,6 @@
 # 7 seconds game
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 The goal of this game is press a button after **exactly** 7 seconds!
 
@@ -8,7 +8,7 @@ The goal of this game is press a button after **exactly** 7 seconds!
 
 This game is inspired from the [flipping panckakes game](https://www.elecfreaks.com/blog/post/flipping-pancakes-microbit-game.html).
 
-## Step 1
+## {Step 1}
 
 The player starts the timer by pressing button **A**. We'll run the code run code when ``||input:button A is pressed||``.
 
@@ -18,7 +18,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 We need to remember the time when the button was pressed so that we can compute the elapsed time later on.
 Add code to store the ``||input:running time||`` in a ``||variables:start||`` variable.
@@ -31,7 +31,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Show something on the screen so that the user knows that the timer has started...
 
@@ -44,7 +44,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 The player stops the timer by pressing button **B**. Add the code to run code when ``||input:button B is pressed||``.
 
@@ -54,7 +54,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Compute the elapsed time as ``||input:running time||`` ``||math:minus||`` ``||variables:start||`` and store it into a new variable ``||variables:elapsed||``.
 
@@ -67,7 +67,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Compute the ``||variables:score||`` of the game as the ``||math:absolute value||`` of the ``||math:difference||`` of ``||variables:elapsed||`` time from 7 seconds, which is 7000 milliseconds.
 
@@ -82,7 +82,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 Display the score on the screen and your game is ready!
 

--- a/docs/projects/coin-flipper.md
+++ b/docs/projects/coin-flipper.md
@@ -1,12 +1,12 @@
 # Coin Flipper
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Let's create a coin flipping program to simulate a real coin toss. We'll use icon images to represent a ``heads`` or ``tails`` result.
 
 ![Simulating coin toss](/static/mb/projects/coin-flipper/coin-flipper.gif)
 
-## Step 1
+## {Step 1}
 
 Let's start with the ``||input:on button A pressed||`` block on the Workspace. We'll put our coin flipping code in here.
 
@@ -15,7 +15,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Grab an ``||logic:if else||`` block and set it inside ``||input:on button A pressed||``. Put a ``||Math:pick random true or false||`` into the ``||logic:if||`` as its condition.
 
@@ -29,7 +29,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Now, put a ``||basic:show icon||`` block inside both the ``||logic:if||`` and the ``||logic:else||``. Pick images to mean ``heads`` and ``tails``.
 
@@ -43,11 +43,11 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Press button **A** in the simulator to try the coin toss code.
 
-## Step 5
+## {Step 5}
 
 You can animate the coin toss to add the feeling of suspense. Place different ``||basic:show icon||`` blocks before the ``||logic:if||`` to show that the coin is flipping.
 
@@ -65,11 +65,11 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 If you have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code.
 
-## Step 7
+## {Step 7}
 
 Press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!
 

--- a/docs/projects/dice.md
+++ b/docs/projects/dice.md
@@ -1,6 +1,6 @@
 # Dice
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Let's turn the @boardname@ into dice!
 (Want to learn how the accelerometer works? [Watch this video](https://youtu.be/byngcwjO51U)).
@@ -19,7 +19,7 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Get a ``||basic:show number||`` block and place it inside the ``||input:on shake||`` block to display a number.
 
@@ -29,7 +29,7 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Put a ``||Math:pick random||`` block in the ``||basic:show number||`` block to pick a random number.
 
@@ -39,7 +39,7 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 A typical dice shows values from `1` to `6`. So, in ``||Math:pick random||``, don't forget to choose the right minimum and maximum values!
 
@@ -49,11 +49,11 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Use the simulator to try out your code. Does it show the number you expected?
 
-## Step 6
+## {Step 6}
 
 If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!
 

--- a/docs/projects/flashing-heart.md
+++ b/docs/projects/flashing-heart.md
@@ -8,13 +8,13 @@ Learn how to use the LEDs and make a flashing heart!
 
 ![Heart shape in the LEDs](/static/mb/projects/flashing-heart/sim.gif)
 
-## Step 1 @fullscreen
+## {Step 1 @fullscreen}
 
 Place the ``||basic:show leds||`` block in the ``||basic:forever||`` block and draw a heart.
 
 ![An animation that shows how to drag a block and paint a heart](/static/mb/projects/flashing-heart/showleds.gif)
 
-## Step 2
+## {Step 2}
 
 Place another ``||basic:show leds||`` block. You can leave it blank and draw what you want.
 
@@ -35,11 +35,11 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Look at the virtual @boardname@, you should see the heart and your drawing blink on the screen.
 
-## Step 4
+## {Step 4}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch the hearts flash!
 

--- a/docs/projects/heads-guess.md
+++ b/docs/projects/heads-guess.md
@@ -1,11 +1,11 @@
 # Heads Guess!
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 This is a simple remake of the famous **Heads Up!** game. The player holds the @boardname@ on the forehead and has 30 seconds to guess words displayed on the screen.
 If the guess is correct, the player tilts the @boardname@ forward; to pass, the player tilts it backwards.
 
-## Step 1
+## {Step 1}
 
 Put in code to ``||game:start a countdown||`` of 30 seconds.
 
@@ -13,7 +13,7 @@ Put in code to ``||game:start a countdown||`` of 30 seconds.
 game.startCountdown(30000)
 ```
 
-## Step 2
+## {Step 2}
 
 Create a ``||arrays:text list||`` of words to guess. You will find **Arrays** under **Advanced**.
 
@@ -23,7 +23,7 @@ text_list = ["PUPPY", "CLOCK", "NIGHT"]
 game.startCountdown(30000)
 ```
 
-## Step 3
+## {Step 3}
 
 Add an event to run code when the @boardname@ ``||input:logo||`` is pointing ``||input:up||``.
 This is the gesture to get a new word.
@@ -33,7 +33,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 The items in ``||arrays:text list||`` are numbered ``0`` to ``length - 1``.
 Add code to pick a ``||math:random||`` ``||variables:index||``.
@@ -47,7 +47,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Add code to ``||basic:show||`` the value of the item stored at ``||variables:index||`` in  ``||arrays:text list||``.
 
@@ -61,7 +61,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Use an event to run code when the @boardname@ ``||input:screen||`` is pointing ``||input:down||``.
 This is the gesture for a correct guess.
@@ -71,7 +71,7 @@ input.onGesture(Gesture.ScreenDown, function () {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 Put in code to add points to the ``||game:score||``.
 
@@ -82,7 +82,7 @@ input.onGesture(Gesture.ScreenDown, function () {
 })
 ```
 
-## Step 8
+## {Step 8}
 
 Add anonther event to run code when the @boardname@ ``||input:screen||`` is pointing ``||input:up||``.
 This is the gesture for a pass.
@@ -92,7 +92,7 @@ input.onGesture(Gesture.ScreenUp, function () {
 })
 ```
 
-## Step 9
+## {Step 9}
 
 For the pass gesture, add code to remove a ``||game:life||`` from the player.
 

--- a/docs/projects/hot-potato.md
+++ b/docs/projects/hot-potato.md
@@ -1,11 +1,11 @@
 # Hot Potato
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 In this game, you will start a timer with a random countdown of a number of seconds. When the timer is off, the game is over and whoever is holding the potato has lost!
 Watch the tutorial on the [MakeCode YouTube channel](https://youtu.be/xLEy1B_gWKY).
 
-## Step 1
+## {Step 1}
 
 Add an event to run code when ``||input:button A is pressed||``.
 
@@ -14,7 +14,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Make a ``||variables:timer||`` variable and ``||variables:set||`` it to
 a ``||math:random value||`` between ``5`` and ``15``.
@@ -29,7 +29,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add code to ``||basic:show||`` that the game started.
 
@@ -42,7 +42,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Put in a loop to repeat code ``||loops:while||``  ``||variables:timer||`` ``||logic:is positive||``. When `timer` is negative, the game is over.
 
@@ -58,7 +58,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Inside the ``||loops:while||`` loop, add code to ``||variables:decrease||`` the timer ``||loops:every second||``.
 
@@ -76,7 +76,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 **After** the ``||loops:while||`` loop is done, add code to ``||basic:show||`` that the game is over.
 
@@ -94,7 +94,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 `|Download|` your code to your @boardname@, tape it to a potato and play the game with your friends!
 

--- a/docs/projects/love-meter.md
+++ b/docs/projects/love-meter.md
@@ -1,12 +1,12 @@
 # Love Meter
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Make a love meter, how sweet! The @boardname@ is feeling the love, then sometimes not so much!
 
 ![Love meter banner message](/static/mb/projects/love-meter/love-meter.gif)
 
-## Step 1
+## {Step 1}
 
 Let's build a **LOVE METER** machine. We'll use an ``||input:on pin pressed||`` block to run code when pin **0** is pressed. Use ``P0`` from the list of pin inputs.
 
@@ -15,7 +15,7 @@ input.onPinPressed(TouchPin.P0, function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Using ``||basic:show number||`` and ``||Math:pick random||`` blocks, show a random number from `0` to `100` when pin **0** is pressed.
 
@@ -24,11 +24,11 @@ input.onPinPressed(TouchPin.P0, function() {
     basic.showNumber(randint(0, 100))
 })
 ```
-## Step 3
+## {Step 3}
 
 Click on pin **0** in the simulator and see which number is chosen.
 
-## Step 4
+## {Step 4}
 
 Show ``"LOVE METER"`` on the screen when the @boardname@ starts.
 
@@ -39,7 +39,7 @@ input.onPinPressed(TouchPin.P0, function() {
 });
 ```
 
-## Step 5
+## {Step 5}
 
 Click ``|Download|`` to transfer your code in your @boardname@. Hold the **GND** pin with one hand and press pin **0** with the other hand to trigger this code.
 

--- a/docs/projects/multi-dice.md
+++ b/docs/projects/multi-dice.md
@@ -1,6 +1,6 @@
 # Multi Dice
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 ![Multiple @boardname@ throwing a dice](/static/mb/projects/multi-dice.png)
 
@@ -8,7 +8,7 @@ Build a multi-player dice game using the **radio**. The **radio** blocks let you
 
 In this game, you shake to "throw the dice" and send the result to the other @boardname@. If you receive a result of a dice throw equal or greater than yours, you lose.
 
-## Dice game
+## {Dice game}
 
 Let's start by rebuilding the **dice** game. If you are unsure about the details, try the **dice** tutorial again.
 
@@ -18,7 +18,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Dice variable
+## {Dice variable}
 
 We need to store the result of the dice cast in a variable. A **variable** is like a place in the memory of the @boardname@ where you save information, like numbers.
 
@@ -34,7 +34,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Send the dice
+## {Send the dice}
 
 Put in a ``||radio:send number||`` and a ``||variables:dice||`` to send the value stored in the ``||variables:dice||`` variable via radio. Make sure to add a ``||radio:set group||`` to ``||basic:on start||`` with the group number set to the group you want to use.
 
@@ -48,7 +48,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Receive the dice
+## {Receive the dice}
 
 Go get an ``||radio:on received number||`` event block. This event runs when a radio message from another @boardname@ arrives. The ``||variables:receivedNumber||`` value is the value of the dice in this game.
 
@@ -57,7 +57,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Check your cast
+## {Check your cast}
 
 Add a ``||logic:if||`` block to test if ``||variables:receivedNumber||`` is greater or equal to ``||variables:dice||``.
 If is, you lost so display a sad face on the screen.
@@ -71,7 +71,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Test it!
+## {Test it!}
 
 Try pressing **SHAKE** in the simulator and see that a second @boardname@ appears. You can play the game on both virtual boards.
 

--- a/docs/projects/name-tag.md
+++ b/docs/projects/name-tag.md
@@ -1,12 +1,12 @@
 # Name Tag
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Tell everyone who you are. Show you name on the LEDs.
 
 ![Name scrolling on the LEDs](/static/mb/projects/name-tag/name-tag.gif)
 
-## Step 1
+## {Step 1}
 
 Place the ``||basic:show string||`` block in the ``||basic:forever||`` block to repeat it. Change the text to your name.
 
@@ -16,11 +16,11 @@ basic.forever(function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Look at the simulator and make sure it shows your name on the screen.
 
-## Step 3
+## {Step 3}
 
 Place more ``||basic:show string||`` blocks to create your own story.
 
@@ -31,7 +31,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code and watch your name scroll!
 

--- a/docs/projects/rock-paper-scissors-v2.md
+++ b/docs/projects/rock-paper-scissors-v2.md
@@ -1,12 +1,12 @@
 # Rock Paper Scissors V2
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 ![Cartoon of the Rock Paper Scissors game](/static/mb/projects/a4-motion-v2.png)
 
 Build a "Rock Paper Scissors" game with ADDED BONUS SOUNDS using the **micro:bit V2** buzzer!
 
-## Step 1 @fullscreen
+## {Step 1 @fullscreen}
 
 Use the ``||input:on shake||`` block in the Workspace to run code when you shake the @boardname@.
 
@@ -16,13 +16,13 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 2 @fullscreen
+## {Step 2 @fullscreen}
 
 Make a new variable called ``hand`` and place the ``||variables:set hand to||`` block in the shake event.
 
 ![A animation that shows how to create a variable](/static/mb/projects/rock-paper-scissors/newvar.gif)
 
-## Step 3 @fullscreen
+## {Step 3 @fullscreen}
 
 Add a ``||math:pick random||`` block to pick a random number from `1` to `3` and store it in the variable named ``hand``.
 
@@ -35,7 +35,7 @@ input.onGesture(Gesture.Shake, function () {
 
 In a later step, each of the possible numbers (`1`, `2`, or `3`) is matched to its own picture. The picture is shown on the LEDs when its matching number is picked.
 
-## Step 4 @fullscreen
+## {Step 4 @fullscreen}
 
 Place an ``||logic:if||`` block under the ``||math:pick random||`` and check whether ``hand`` is equal to ``1``. Add a ``||basic:show leds||`` block that shows a picture of a piece of paper. The number `1` is the value for paper.
 
@@ -57,7 +57,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 5 @fullscreen
+## {Step 5 @fullscreen}
 
 Place a ``||music:play sound||`` block under ``||basic:show leds||`` and edit it to make it sound like paper.
 
@@ -78,14 +78,14 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 6 @fullscreen
+## {Step 6 @fullscreen}
 
 Click on the **SHAKE** button in the simulator. If you try enough times, you should see a picture of paper on the screen.
 
 ![Shaking a @boardname@ simulator](/static/mb/projects/rock-paper-scissors/rpsshake.gif)
 
 
-## Step 7 @fullscreen
+## {Step 7 @fullscreen}
 
 Click the **(+)** button to add an ``||logic:else||`` section.
 
@@ -110,7 +110,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 8 @fullscreen
+## {Step 8 @fullscreen}
 
 Add both a ``||basic:show leds||`` block and a ``||music:play sound||`` block inside the ``||logic:else||``. Make a picture for **scissors** using LEDs and create a scissors sound.
 
@@ -140,13 +140,13 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 9 @fullscreen
+## {Step 9 @fullscreen}
 
 Click the **(+)** button again to add an ``||logic:else if||`` section. Now, add a conditional block for ``||logic:hand = 2||`` to the empty slot in the ``||logic:else if||``. Since ``hand`` can only be `1`, `2`, or `3`, your code is now covering all possible cases!
 
 ![Adding an else if clause](/static/mb/projects/rock-paper-scissors/ifelseif.gif)
 
-## Step 10 @fullscreen
+## {Step 10 @fullscreen}
 
 Get one more ``||basic:show leds||`` block and ``||music:play sound||`` block and put them inside the ``||logic:else if||``. Make a picture of a rock in the LEDs and create a rock-like sound.
 
@@ -185,13 +185,13 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Step 11 @fullscreen
+## {Step 11 @fullscreen}
 
 Click on the **SHAKE** button in the simulator and check to see that each image is showing up.
 
 ![Shaking a @boardname@ simulator](/static/mb/projects/rock-paper-scissors/rpssim3.gif)
 
-## Step 12 @fullscreen
+## {Step 12 @fullscreen}
 
 If you have a @boardname@ V2, click on ``|Download|`` and follow the instructions to get the code
 onto your @boardname@. 

--- a/docs/projects/rock-paper-scissors.md
+++ b/docs/projects/rock-paper-scissors.md
@@ -1,12 +1,12 @@
 # Rock Paper Scissors
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 ![Cartoon of the Rock Paper Scissors game](/static/mb/projects/a4-motion.png)
 
 Use the accelerometer and the screen to build a **Rock Paper Scissors** game that you can play with your friends!
 
-## Step 1 @fullscreen
+## {Step 1 @fullscreen}
 
 Let's use a ``||input:on shake||`` block to run code when you shake the @boardname@.
 
@@ -16,13 +16,13 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 2 @fullscreen
+## {Step 2 @fullscreen}
 
 Add a ``hand`` variable and place the ``||variables:set hand to||`` block in the shake event.
 
 ![A animation that shows how to create a variable](/static/mb/projects/rock-paper-scissors/newvar.gif)
 
-## Step 3 @fullscreen
+## {Step 3 @fullscreen}
 
 Add a ``||math:pick random||`` block to pick a random number from `1` to `3` and store it in the variable named ``hand``.
 
@@ -35,7 +35,7 @@ input.onGesture(Gesture.Shake, function() {
 
 In a later step, each of the possible numbers (`1`, `2`, or `3`) is matched to its own picture. The picture is shown on the LEDs when its matching number is picked.
 
-## Step 4 @fullscreen
+## {Step 4 @fullscreen}
 
 Place an ``||logic:if||`` block under the ``||math:pick random||`` and check whether ``hand`` is equal to ``1``. Add a ``||basic:show leds||`` block that shows a picture of a piece of paper. The number `1` will mean paper.
 
@@ -57,13 +57,13 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 5 @fullscreen
+## {Step 5 @fullscreen}
 
 Click on the **SHAKE** button in the simulator. If you try enough times, you should see a picture of paper on the screen.
 
 ![Shaking a @boardname@ simulator](/static/mb/projects/rock-paper-scissors/rpsshake.gif)
 
-## Step 6 @fullscreen
+## {Step 6 @fullscreen}
 
 Click the **(+)** button to add an ``||logic:else||`` section.
 
@@ -87,7 +87,7 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 7 @fullscreen
+## {Step 7 @fullscreen}
 
 Add a ``||basic:show leds||`` block inside the ``||logic:else||``. Make a picture of a scissors in the LEDs.
 
@@ -115,13 +115,13 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 8 @fullscreen
+## {Step 8 @fullscreen}
 
 Click the ``+`` button again to add an ``||logic:else if||`` section. Now, add a conditional block for ``||logic:hand = 2||`` to the condition in ``||logic:else if||``. Since ``hand`` can only be `1`, `2`, or `3`, your code is covering all possible cases!
 
 ![Adding an else if clause](/static/mb/projects/rock-paper-scissors/ifelseif.gif)
 
-## Step 9 @fullscreen
+## {Step 9 @fullscreen}
 
 Get one more ``||basic:show leds||`` block and put it in the ``||logic:else if||``. Make a picture of a rock in the LEDs.
 
@@ -157,13 +157,13 @@ input.onGesture(Gesture.Shake, function() {
 })
 ```
 
-## Step 10 @fullscreen
+## {Step 10 @fullscreen}
 
 Click on the **SHAKE** button in the simulator and check to see that each image is showing up.
 
 ![Shaking a @boardname@ simulator](/static/mb/projects/rock-paper-scissors/rpssim3.gif)
 
-## Step 11 @fullscreen
+## {Step 11 @fullscreen}
 
 If you have a @boardname@, click on ``|Download|`` and follow the instructions to get the code
 onto your @boardname@. Your game is ready! Gather your friends and play Rock Paper Scissors!

--- a/docs/projects/smiley-buttons.md
+++ b/docs/projects/smiley-buttons.md
@@ -1,13 +1,13 @@
 # Smiley Buttons
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Code the buttons on the @boardname@ to show that it's happy or sad.
 (Want to learn how the buttons works? [Watch this video](https://youtu.be/t_Qujjd_38o)).
 
 ![Pressing the A and B buttons](/static/mb/projects/smiley-buttons/sim.gif)
 
-## Step 1
+## {Step 1}
 
 Use the ``||input:on button pressed||`` block to run code when button **A** is pressed.
 
@@ -16,7 +16,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Place a ``||basic:show leds||`` block inside ``||input:on button pressed||`` to display a smiley on the screen. Press the **A** button in the simulator to see the smiley.
 
@@ -32,7 +32,7 @@ input.onButtonPressed(Button.A, function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add ``||input:on button pressed||`` and ``||basic:show leds||`` blocks to display a frowny when button **B** is pressed.
 
@@ -48,7 +48,7 @@ input.onButtonPressed(Button.B, function() {
 });
 ```
 
-## Step 4
+## {Step 4}
 
 Add a secret mode that happens when **A** and **B** are pressed together. For this case, add multiple ``||basic:show leds||`` blocks to create an animation.
 
@@ -71,11 +71,11 @@ input.onButtonPressed(Button.AB, function() {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 If you have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code. Press button **A** on your @boardname@. Try button **B** and then **A** and **B** together.
 
-## Step 6
+## {Step 6}
 
 Nice! Now go and show it off to your friends!
 

--- a/docs/projects/v2-blow-away.md
+++ b/docs/projects/v2-blow-away.md
@@ -1,6 +1,6 @@
 # Blow Away
 
-## Introduction pt. 1 @unplugged
+## {Introduction pt. 1 @unplugged}
 
 👻 Oh, no! Your @boardname@ is being haunted by a ghost named Haven 👻
 
@@ -8,7 +8,7 @@ For this tutorial, we'll learn how to blow Haven away 🌬️
 
 ![Blow away banner message](/static/mb/projects/blow-away.png)
 
-## Haunted ghost setup
+## {Haunted ghost setup}
 
 A wild Haven has appeared!
 
@@ -23,7 +23,7 @@ basic.showIcon(IconNames.Ghost)
 
 ---
 
-## Loop setup
+## {Loop setup}
 
 ► From the ``||loops:Loops||`` category, find the ``||loops:repeat [4] times||`` loop and snap it into your empty ``||basic:forever||`` container.   
 💡 Why do we need a [__*repeat loop*__](#repeatLoop "repeat code for a given number of times") when we already have a ``forever`` container? Because ``forever`` has an embedded delay that we want to avoid!
@@ -37,7 +37,7 @@ basic.forever(function () {
 })
 ```
 
-## Conditional setup
+## {Conditional setup}
 
 Haven hates noise and will blow away if things get too loud. Let's use an [__*if statement*__](#ifstatement "if this condition is met, do something") to check for sounds.
 
@@ -57,7 +57,7 @@ basic.forever(function () {
 })
 ```
 
-## Blow sound
+## {Blow sound}
 
 We'll be using a [__*sound threshold*__](#soundThreshold "a number for how loud a sound needs to be to trigger an event. 0 = silence to 255 = maximum noise") to act as Haven's ears.
 
@@ -77,7 +77,7 @@ basic.forever(function () {
 })
 ```
 
-## Making variables
+## {Making variables}
 
 Let's create some [__*variables*__](#variable "a holder for information that may change") to keep track of Haven's movement.
 
@@ -85,7 +85,7 @@ Let's create some [__*variables*__](#variable "a holder for information that may
 💡 ``col`` is short for "column".  
 ►  Make **another** variable and name it ``row``.
 
-## Displacing LEDs part 1
+## {Displacing LEDs part 1}
 
 To show Haven is blowing away, we want to move a random set of lights sideways.
 
@@ -106,7 +106,7 @@ basic.forever(function () {
 })
 ```
 
-## Displacing LEDs part 2
+## {Displacing LEDs part 2}
 
 ► Go back into ``||variables:Variables||`` and drag out another ``||variables:set [row] to [0]||``. Place this one below the last one (at **the end**) of your `if then` statement.  
 ► Using the **dropdown menu**, set the new block to read ``||variables:set [col] to [0]||``.  
@@ -127,7 +127,7 @@ basic.forever(function () {
 })
 ```
 
-## Conditioning on one point
+## {Conditioning on one point}
 
 Time to move some lights around!
 
@@ -150,7 +150,7 @@ basic.forever(function () {
 })
 ```
 
-## Unplotting and replotting LEDs
+## {Unplotting and replotting LEDs}
 
 To create the animation effect of Haven blowing away, we will turn off (or ``unplot``) a light that is on and then turn it on again (``plot`` it) in a different spot.
 
@@ -175,7 +175,7 @@ basic.forever(function () {
 })
 ```
 
-## 11. Setting variables
+## {Setting variables}
 
 Notice how you have **three** blocks from the ``||led:Led||`` category. All three have ``||led:x||`` ``[0]`` and ``||led:y||`` ``[0]`` coordinates. In these **two** steps, we will set it so that every ``||led:x||`` is followed by the ``||variables:col||`` variable and every ``||led:y||`` is followed by the ``||variables:row||`` variable.  
 ► From ``||variables:Variables||``, get three copies of ``||variables:col||``, and use them to **replace the ``x`` values** in the following three blocks:  
@@ -202,7 +202,7 @@ basic.forever(function () {
 })
 ```
 
-## 12. Moving LEDs
+## {Moving LEDs}
 
 Right now, we are unplotting and replotting in the same spot. What we want to do  is move the lights we're turning back on just a smidge to the right every time until there's nothing left on the grid.
 
@@ -229,7 +229,7 @@ basic.forever(function () {
 })
 ```
 
-## 13. Testing in the simulator
+## {Testing in the simulator}
 
 Check out the simulator!
 

--- a/docs/projects/v2-cat-napping.md
+++ b/docs/projects/v2-cat-napping.md
@@ -1,12 +1,12 @@
 # Cat Napping
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 Lychee the cat loves the sun and wants to know if your home has a good sunbathing spot. Are you up for the challenge?
 
 ![Cat Tanning banner message, an image of a cat](/static/mb/projects/cat-napping/1_lychee.png)
 
-## Setting logging to false on start
+## {Setting logging to false on start}
 
 First, we want to make sure we know when our micro:bit is collecting data. To do this, let's create a [__*boolean*__](#boolean "something that is only true or false") [__*variable*__](#variable "a holder for information that may change") and use it to track when the @boardname@ is logging data. We'll start with the logging variable set to false.
 
@@ -19,7 +19,7 @@ let logging = false
 logging = false
 ```
 
-## Toggle logging on A press
+## {Toggle logging on A press}
 
 Let's give Lychee some control over when she wants to start and stop logging data on the @boardname@.
 
@@ -35,7 +35,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Visual logging indicators
+## {Visual logging indicators}
 
 It would help to know when the @boardname@ is logging data and when it isn't. For this step, we will be building out a visual indicator using an [__*if then / else*__](#ifthenelse "runs some code if a boolean condition is true and different code if the condition is false") statement.
 
@@ -52,7 +52,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Set the indicator icon
+## {Set the indicator icon}
 
 ► Let's display an image when the @boardname@ is logging data. From the ``||basic:Basic||`` category, grab a ``||basic:show icon []||`` block and snap it into the empty **top container** of your ``||logic:if then / else||`` statement.  
 ► Set it to show the "target" icon (it looks like an empty sun - scroll down to find it!).  This will show whenever your @boardname@ is collecting data.  
@@ -69,7 +69,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Auditory logging indicators
+## {Auditory logging indicators}
 
 Let's now add an auditory indicator that your @boardname@ is logging data!
 
@@ -88,7 +88,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Logging off indicator
+## {Logging off indicator}
 
 ► Let's clear the board when the @boardname@ is not logging data. From the ``||basic:Basic||`` category, grab a ``||basic:clear screen||`` block and snap it into the empty **bottom container** of your ``||logic:if then / else||`` statement.
 
@@ -105,7 +105,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Time interval for data logging
+## {Time interval for data logging}
 
 Let's set up the data logging for Lychee! In order to get Lychee a good amount of data without running out of memory, we should collect one data point for her every minute.
 
@@ -118,7 +118,7 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## Setting up a logging variable
+## {Setting up a logging variable}
 
 Now, let's use an [__*if then*__](#ifthen "runs some code if a boolean condition is true") statement to track when the @boardname@ is logging data.
 
@@ -133,7 +133,7 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## Setting up logging - Part 1
+## {Setting up logging - Part 1}
 
 Lychee loves her sun spots because they provide a nice, sunny and warm place to nap. So, we'll need to measure the **temperature** and **light** in different places around the house.
 
@@ -153,7 +153,7 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## Setting up logging - Part 2
+## {Setting up logging - Part 2}
 
 ► On the right of the ``||input:temperature (°C)||`` input that you just snapped in, there is a ➕ button. Click on it. You should now see a new row that says ``||datalogger:column [""] value [0]||``.  
 ► Click on the empty ``""`` after the word ``column`` and type in "``light``".  
@@ -172,14 +172,14 @@ loops.everyInterval(60000, function () {
 })
 ```
 
-## Time to log data! @unplugged
+## {Time to log data! @unplugged}
 
 You did it! If you have a @boardname@ V2 (the one with the **shiny gold** logo at the top), download this code and try it out!
 
 ► Find a sun spot in your house and press the ``A`` button to start logging data - your display should show an icon and play a sound to indicate that you are logging data.  
 ► After some time (we recommend at least an hour), press the ``A`` button again to stop logging data - your display should clear to indicate that you are not logging data.
 
-## Reviewing your data @unplugged
+## {Reviewing your data @unplugged}
 
 Now that you have logged some data, plug your @boardname@ into a laptop or desktop computer. The @boardname@ will appear like a USB drive called MICROBIT. Look in there and you'll see a file called MY_DATA:
 
@@ -189,7 +189,7 @@ Double-click on MY_DATA to open it in a web browser and you'll see a table with 
 
 ![Image of sample data file](/static/mb/projects/cat-napping/11_datafile.png)
 
-## Lychee's preferences @unplugged
+## {Lychee's preferences @unplugged}
 
 Does your home have a good sunbathing spot for Lychee? Compare the light and temperature levels you record for different areas around your house! The sunniest and warmest spots will likely be her favorite ☀️😻
 

--- a/docs/projects/v2-clap-lights.md
+++ b/docs/projects/v2-clap-lights.md
@@ -1,6 +1,6 @@
 # Clap Lights
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 The new @boardname@s have a microphone to help them detect sound 🎤
 
@@ -8,7 +8,7 @@ Let's learn how to use a clap 👏 to switch your @boardname@'s lights on and of
 
 ![Clap lights banner message](/static/mb/projects/clap-lights.png)
 
-## Setting up the sound input
+## {Setting up the sound input}
 
 ► From the ``||input:Input||`` category, find the ``||input:on [loud] sound||`` container and add it to your workspace.
 
@@ -18,13 +18,13 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## Creating a lightsOn variable
+## {Creating a lightsOn variable}
 
 Let's begin by creating a [__*variable*__](#variable "a holder for information that may change") to keep track of whether the @boardname@'s lights are on or off.
 
 ► In the ``||variables:Variables||`` category, click on ``Make a Variable...`` and make a variable named ``lightsOn``.
 
-## Displaying LEDs part 1
+## {Displaying LEDs part 1}
 
 In this step, we'll be using an [__*if then / else*__](#ifthenelse "runs some code if a Boolean condition is true and different code if the condition is false") statement.
 
@@ -43,7 +43,7 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## Displaying LEDs part 2
+## {Displaying LEDs part 2}
 
 ► From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.  
 ► Set the lights to a pattern you like!  
@@ -66,7 +66,7 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## Clearing the screen
+## {Clearing the screen}
 
 ► From ``||basic:Basic||``, find ``||basic:clear screen||`` and snap it into the **bottom container** of your ``||logic:if then / else||`` section.  
 💡 This will turn the display off if ``lightsOn`` is **not** ``true``.
@@ -89,7 +89,7 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## Setting the lightsOn variable
+## {Setting the lightsOn variable}
 
 Just like we'd toggle a light switch, each time we clap, we want to **flip** the variable ``lightsOn`` to the **opposite** of what it was before.
 
@@ -116,13 +116,13 @@ input.onSound(DetectedSound.Loud, function () {
 })
 ```
 
-## Testing in the simulator
+## {Testing in the simulator}
 
 ► Check out the simulator!  
 ► Click on the pink slider bar beneath the microphone icon and drag it up and down.  
 💡 Right now, your @boardname@ thinks that anything above 128 is loud. Every time the sound goes > 128, your lights should switch on/off.
 
-## Set loud sound threshold
+## {Set loud sound threshold}
 
 Your @boardname@ might detect sounds when you don't want it to. Setting a [__*sound threshold*__](#soundThreshold "a number for how loud a sound needs to be to trigger an event. 0 = silence to 255 = maximum noise") could help 🔉🔊
 
@@ -135,7 +135,7 @@ Your @boardname@ might detect sounds when you don't want it to. Setting a [__*so
 input.setSoundThreshold(SoundThreshold.Loud, 150)
 ```
 
-## Testing, round 2
+## {Testing, round 2}
 
 Don't forget to test your code in the simulator!
 

--- a/docs/projects/v2-countdown.md
+++ b/docs/projects/v2-countdown.md
@@ -1,6 +1,6 @@
 # Countdown
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 🎇3...🎇2...🎇1...  
 🎆GO!🎆
@@ -9,7 +9,7 @@ Let's create a musical countdown using the new @boardname@ with sound!
 
 ![Countdown banner message](/static/mb/projects/countdown.png)
 
-## Setting up the loop
+## {Setting up the loop}
 
 We'll begin by using a [__*for loop*__](#forLoop "repeat code for a given number of times using an index") to recreate the same sound 3 times.
 
@@ -24,7 +24,7 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## Play music
+## {Play music}
 
 ► From ``||music:Music||``, grab ``||music:play tone [Middle C] for [1 beat]||`` and snap it into your empty ``for`` loop.  
 💡 Your simulator might start playing music. You can mute it if distracting.  
@@ -37,7 +37,7 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## Showing a number
+## {Showing a number}
 
 With every tone, we also want to **display** our countdown.
 
@@ -53,7 +53,7 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## Inverting the number
+## {Inverting the number}
 
 If you take a look at your simulator, you'll notice the @boardname@ flashing 0-1-2. We want it to say 3-2-1! Let's learn a trick to change that.
 
@@ -72,7 +72,7 @@ for (let index = 0; index <= 2; index++) {
 }
 ```
 
-## Printing "GO!"
+## {Printing "GO!"}
 
 ► From ``||basic:Basic||``, grab ``||basic:show string ["Hello!"]||`` and snap it into the **very bottom** of your ``||basic:on start||`` container.  
 ► Replace ``Hello!`` with the word ``GO!``
@@ -86,7 +86,7 @@ for (let index = 0; index <= 2; index++) {
 basic.showString("GO!")
 ```
 
-## Adding a "GO!" noise
+## {Adding a "GO!" noise}
 
 ► From the ``||music:Music||`` category, grab ``||music:play tone [Middle C] for [1 beat]||`` and place it **above** your ``||basic:show string ["GO!"]||`` block and **below** your ``||loops:for||`` loop.  
 💡 This will let your @boardname@ play the sound and show ``GO!`` at the same time.  
@@ -103,7 +103,7 @@ music.playTone(392, music.beat(BeatFraction.Whole))
 basic.showString("GO!")
 ```
 
-## 8. Testing in the simulator
+## {Testing in the simulator}
 
 Make sure your speakers are on and check out the simulator!  
 

--- a/docs/projects/v2-morse-chat.md
+++ b/docs/projects/v2-morse-chat.md
@@ -1,6 +1,6 @@
 # Morse Chat
 
-## Introducing Sky @unplugged
+## {Introducing Sky @unplugged}
 
 🐷 Meet Sky, the pig! Sky can only communicate using [__*morse code*__](#morsecode "an alphabet composed of dots (short signals) and dashes (long signals)").
 
@@ -8,7 +8,7 @@ Luckily, you can use your @boardname@ with sound to talk to Sky 👋
 
 ![Morse chat banner message](/static/mb/projects/morse-chat.png)
 
-## Setup
+## {Setup}
 
 ► From the ``||input:Input||`` category in the toolbox, drag an ``||input:on logo [pressed]||`` container into to your workspace.  
 ► From the ``||radio:Radio||`` category, get ``||radio:radio send number [0]||`` and snap it into your empty ``||input:on logo [pressed]||`` container.
@@ -19,7 +19,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Sending different messages pt. 1
+## {Sending different messages pt. 1}
 
 ► From ``||input:Input||``, grab **another** ``||input:on logo [pressed]||`` container and add it to your workspace.  
 💡 This container is greyed out because it matches another. Let's change that!  
@@ -34,7 +34,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Sending different messages pt. 2
+## {Sending different messages pt. 2}
 
 ► From the ``||radio:Radio||`` category, get a ``||radio:radio send number [0]||`` block and snap it into your **empty** ``||input:on logo [long pressed]||`` container.  
 ► Set the number to be ``1``.
@@ -49,7 +49,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Receiving different messages
+## {Receiving different messages}
 
 To ensure Sky gets the right message, we will use an [__*if then / else*__](#ifthenelse "runs some code if a boolean condition is true and different code if the condition is false") conditional statement.
 
@@ -68,7 +68,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Conditioning on the input
+## {Conditioning on the input}
 
 ► From your ``||radio:on radio received [receivedNumber]||`` container, grab the **``receivedNumber``** input and drag out a copy.  
 ► Use your copy of **``receivedNumber``** to replace the ``[0]`` on the **left side** of ``||logic:<[0] [=] [0]>||``.
@@ -84,7 +84,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Displaying a message pt. 1
+## {Displaying a message pt. 1}
 
 ► We want to display a dash if the logo is long pressed.  From ``||basic:Basic||``, grab ``||basic:show leds||`` and snap it into the empty **bottom container** of your ``||logic:if then / else||`` statement.  
 ► Turn on 3 LEDs in a row to be a dash: -
@@ -105,7 +105,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Playing a sound pt. 1
+## {Playing a sound pt. 1}
 
 ► From the ``||music:Music||`` category, grab a ``||music:play tone [Middle C] for [1 beat]||`` block and snap it at the **end** of the **bottom container** in your ``||logic:if then / else||`` statement.
 
@@ -126,7 +126,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Displaying a message pt. 2
+## {Displaying a message pt. 2}
 
 ► We want to display a dot if the logo is pressed. From ``||basic:Basic||``, grab another ``||basic:show leds||`` and snap it into the **top container** of your ``||logic:if then / else||`` statement.  
 ► Turn on a single LED to make a dot: .
@@ -155,7 +155,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Playing a sound pt. 2
+## {Playing a sound pt. 2}
 
 ► From the ``||music:Music||`` category, grab ``||music:play tone [Middle C] for [1 beat]||`` and snap it in at the **end** of the **top container** in your ``||logic:if then / else||`` statement.  
 ► Dots are shorter than dashes! Set the tone to play for ``1/4 beat``.
@@ -185,7 +185,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Clearing the screens
+## {Clearing the screens}
 
 ► From ``||basic:Basic||``, find ``||basic:clear screen||`` and snap it in at the **very bottom** of your ``||radio:on radio received [receivedNumber]||`` container.
 
@@ -215,7 +215,7 @@ radio.onReceivedNumber(function (receivedNumber) {
 })
 ```
 
-## Testing in the simulator - Connect!
+## {Testing in the simulator - Connect!}
 
 Test what you've created. Remember to turn your sound on!
 
@@ -253,7 +253,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Testing in the simulator - Send message
+## {Testing in the simulator - Send message}
 
 ► Touch the logo again to send messages to Sky 🐖  
 **Press** to send a dot.  

--- a/docs/projects/v2-pet-hamster.md
+++ b/docs/projects/v2-pet-hamster.md
@@ -1,10 +1,10 @@
 # Pet Hamster
 
-## Introduction @unplugged
+## {Introduction @unplugged}
 
 ![Pet hamster banner message](/static/mb/projects/pet-hamster.png)
 
-## Cyrus's asleep face
+## {Cyrus's asleep face}
 
 Cyrus is a very sleepy hamster. In fact, Cyrus is almost always sleeping.
 
@@ -15,7 +15,7 @@ Cyrus is a very sleepy hamster. In fact, Cyrus is almost always sleeping.
 basic.showIcon(IconNames.Asleep)
 ```
 
-## Giggly Cyrus
+## {Giggly Cyrus}
 
 Pressing Cyrus's logo tickles them!
 
@@ -28,7 +28,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Tickle sound
+## {Tickle sound}
 
 ► From the ``||music:Music||`` category, get a ``||music:play sound [giggle] until done||`` and add it to the **bottom** of your ``||input:on logo [pressed]||`` container.
 
@@ -40,7 +40,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 })
 ```
 
-## Dizzy Cyrus
+## {Dizzy Cyrus}
 
 Whenever Cyrus is shaken, they get sad 🙁
 
@@ -53,7 +53,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Dizzy sound
+## {Dizzy sound}
 
 ► From the ``||music:Music||`` category, find the ``||music:play sound [giggle] until done||`` block and add it to the **bottom** of your ``||input:on [shake]||`` container.  
 ► Click on the **dropdown** and set it so Cyrus plays a ``||music:sad||`` sound until done.
@@ -66,7 +66,7 @@ input.onGesture(Gesture.Shake, function () {
 })
 ```
 
-## Cyrus's default face pt. 1
+## {Cyrus's default face pt. 1}
 
 Let's ensure that Cyrus will always go back to sleep after being shaken or tickled.
 
@@ -87,7 +87,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 basic.showIcon(IconNames.Asleep)
 ```
 
-## Cyrus's default face pt. 2
+## {Cyrus's default face pt. 2}
 
 ► Duplicate the ``||basic:show icon[-_-]||`` block again and this time snap it in at the **very bottom** of your ``||input:on logo [pressed]||`` container.
 
@@ -106,7 +106,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 basic.showIcon(IconNames.Asleep)
 ```
 
-## Testing in the simulator
+## {Testing in the simulator}
 
 Check out the simulator and make sure your speakers are on 🔊
 


### PR DESCRIPTION
Ghost the step headings in the featured tutorials in order save room for other text to display in description pane.

Closes #5266