### PR TITLE
Recording extension: simulator errors fixed

### DIFF
--- a/sim/state/record-audio.ts
+++ b/sim/state/record-audio.ts
@@ -6,7 +6,6 @@ namespace pxsim  {
         chunks: Blob[];
         audioURL: string;
         recording: HTMLAudioElement;
-        playPromise: Promise<any>;
         audioPlaying: boolean = false;
         recordTimeoutID: any;
         currentlyErasing: boolean;
@@ -147,11 +146,17 @@ namespace pxsim.record {
         if (!b) return;
         stopAudio();
         b.recordingState.audioPlaying = true;
-        setTimeout(() => {
+        setTimeout(async () => {
             if (!b.recordingState.currentlyErasing && b.recordingState.recording) {
-                b.recordingState.playPromise = createPlayPromise(b, b.recordingState.recording);
+                try {
+                    await b.recordingState.recording.play();
+                } catch (e) {
+                    if (!(e instanceof DOMException)) {
+                        throw e;
+                    }
+                }
             } else {
-                    b.recordingState.audioPlaying = false;
+                b.recordingState.audioPlaying = false;
             }
         }, 10)
     }

--- a/sim/state/record-audio.ts
+++ b/sim/state/record-audio.ts
@@ -32,6 +32,7 @@ namespace pxsim.record {
     function init() {
         if (!_initialized) {
             registerSimStop();
+            _initialized = true;
         }
     }
 


### PR DESCRIPTION
There were a couple of errors happening when recording that we want to avoid. 

The first was `The play() request was interrupted by a call to pause`. This would basically cause recording ability to crash, and maybe the whole simulator which isn't great. I was neglecting the fact that a call to `play` would return a promise, and thus wouldn't make sure that play is resolving which is largely what the `createPlayPromise` logic handles. There is some weirdness here, though, where we really shouldn't mind that the play call gets interrupted by pause, so, in those cases, we just resolve and continue about our day.

Another was a race condition between playing and erasing that is now resolved by making sure to wait for the erase to finish before creating another recording to reference. With spamming, the calls to erase, record, and playback would get really jumbled and there were some times when a call to play would trigger after the resources for that recording to be played were getting removed. This would cause an error on a network request for the blob url. This isn't great because we can't just catch those errors, even though they likely won't cause a problem to the user but are kinda scary to see in the console. With awaits and a couple of null checks, this error is removed.

I also caught an error in Mozilla where the recorder would be nullish when trying to remove it. I added a null check to prevent this as well.

Just a note, I'm satisfied at where this implementation is in terms of not erroring, cleaning up state, and giving feedback to the user. However, as of now, the simulator implementation and micro:bit behavior differ when you spam click buttons. I haven't been able to investigate if I can get it closer to micro:bit implementation, but I think the fact that there are timeouts in the simulator code will make it difficult to get the simulator closer to the micro:bit behavior. 

Closes https://github.com/microsoft/pxt-microbit/issues/5268