### PR TITLE
respect muted state when playing audio recording

### DIFF
--- a/sim/state/record-audio.ts
+++ b/sim/state/record-audio.ts
@@ -130,7 +130,7 @@ namespace pxsim.record {
                 b.recordingState.recording.removeEventListener("play", b.recordingState.handleAudioPlaying);
                 b.recordingState.recording.removeEventListener("ended", b.recordingState.handleAudioStopped);
             }
-        })
+        });
     }
 
     export function play(): void {
@@ -143,6 +143,8 @@ namespace pxsim.record {
         setTimeout(async () => {
             if (!b.recordingState.currentlyErasing && b.recordingState.recording) {
                 try {
+                    const volume = AudioContextManager.isMuted() ? 0 : 1;
+                    b.recordingState.recording.volume = volume;
                     await b.recordingState.recording.play();
                 } catch (e) {
                     if (!(e instanceof DOMException)) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5294

This change only checks when it starts, so if you mute while it's going the sound will still continue; the `onStopAll` in `registerSimStop` above is not called in that case, since that's for stopping sound (e.g. via the block or restarting program) vs. just muting them -- I don't see a good place to latch on right away for muted events - for multiplayer I added https://github.com/microsoft/pxt/blob/stable9.0/pxtsim/simlib.ts#L240, and can either use that here or clean it up and reuse, but this feels like a small problem to me (at most a few seconds) for now / can fix more generally in a followup rather than making release wait on it? 

test build / project https://makecode.microbit.org/app/aafb0a471874194c4e2855f8411ab679f0d96b37-630803537c#pub:_TyjP6eLE06b7