### PR TITLE
Release electron app v6.0.15

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -866,6 +866,6 @@
         }
     },
     "electronManifest": {
-        "latest": "v5.0.12"
+        "latest": "v6.0.15"
     }
 }


### PR DESCRIPTION
~Would be great if anyone with a mac could download mac64 real quick and just give a quick final check on it installing nicely / no new warnings.~ Richard checked 🥳🦖
* https://makecode.com/api/release/microbit/v6.0.15/win64
* https://makecode.com/api/release/microbit/v6.0.15/mac64

It doesn't really matter, but probably good practice to merge this at the same time as / just after https://github.com/microsoft/pxt-microbit/pull/5296