### PR TITLE
Extension: add Cutebot Pro

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -689,6 +689,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
   "url":"/pkg/elecfreaks/pxt-cutebot",
   "cardType": "package"
 }, {
+  "name": "Elecfreaks Cutebot Pro",
+  "url":"/pkg/elecfreaks/pxt-cutebot-pro",
+  "cardType": "package"
+}, {
   "name": "Kittenbot RobotBit",
   "url":"/pkg/kittenbot/pxt-robotbit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -785,7 +785,8 @@
             "cytrontechnologies/pxt-motionbit": { "tags": [ "Robotics" ] },
             "joy-it/pxt-rb-joypi-advanced": { "tags": [ "Science" ] },
             "bsiever/pxt-sen55": { "tags": [ "Science" ] },
-            "climate-action-kits/pxt-fwd-edu": {}
+            "climate-action-kits/pxt-fwd-edu": {},
+            "elecfreaks/pxt-cutebot-pro": { "tags": [ "Robotics" ], "preferred": true }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/64164 (private)

@elecfreaks1
Looking at the picture below, I noticed some blocks say "get". For example, I think "get speed" could be simply "speed".

@abchatra
Do you think the Cutebot Pro category has too many blocks?

https://makecode.microbit.org/_cW0bjY0rXEvr

![image](https://github.com/microsoft/pxt-microbit/assets/989126/ad9eeb5d-ae0d-4ec9-b680-cb2ef7364983)


