### PR TITLE
Bumped CODAL to v0.2.56 and the samples repo to v0.2.13

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,12 +197,12 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.55",
+                    "branch": "v0.2.56",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",
                 "githubCorePackage": "lancaster-university/microbit-v2-samples",
-                "gittag": "v0.2.12",
+                "gittag": "v0.2.13",
                 "serviceId": "mbcodal2",
                 "dockerImage": "pext/yotta:latest",
                 "yottaConfigCompatibility": true


### PR DESCRIPTION
Updated to the latest CODAL with bugfixes for some outstanding issues with sound recording, the level detector and other smaller bugs. Assuming this all builds just fine, we would like to take this one directly to live.

This also includes the BLE utility service, but is disabled by default. I'll create a new PR with it enabled for Beta.