### PR TITLE
Codal v0.2.58 beta build

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -202,7 +202,7 @@
                 },
                 "codalBinary": "MICROBIT",
                 "githubCorePackage": "lancaster-university/microbit-v2-samples",
-                "gittag": "v0.2.13",
+                "gittag": "pxt-beta",
                 "serviceId": "mbcodal2",
                 "dockerImage": "pext/yotta:latest",
                 "yottaConfigCompatibility": true

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.57",
+                    "branch": "v0.2.58",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
A CI build test variant for the following CODAL configuration via the `pxt-beta` samples repo branch:

```
"DEVICE_BLE": 1,
"MICROBIT_BLE_ENABLED" : 1,
"MICROBIT_BLE_PAIRING_MODE": 1,
"MICROBIT_BLE_DFU_SERVICE": 1,
"MICROBIT_BLE_DEVICE_INFORMATION_SERVICE": 1,
"MICROBIT_BLE_EVENT_SERVICE" : 1,
"MICROBIT_BLE_PARTIAL_FLASHING" : 1,
"MICROBIT_BLE_SECURITY_LEVEL": "SECURITY_MODE_ENCRYPTION_NO_MITM",
"DEVICE_TRIPLE_RESET_TO_PAIR": 1,
"MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 1
```

DO NOT MERGE (yet!)