### PR TITLE
Is playing now working, moved block to micro:bit v2 group

### DIFF
--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -67,12 +67,17 @@ void setBuiltInSpeakerEnabled(bool enabled) {
 * Check whether any sound is being played, no matter the source
 */
 //% blockId=music_sound_is_playing block="sound is playing"
-//% group="Volume"
+//% group="micro:bit (V2)"
 //% help=music/volume
 //% weight=0
 bool isSoundPlaying() {
 #if MICROBIT_CODAL
-    uBit.audio.isPlaying();
+    if (uBit.audio.mixer.getSilenceStartTime() == 0) {
+        return false;
+    } else {
+        return uBit.audio.isPlaying();
+    }
+
 #else
     target_panic(PANIC_VARIANT_NOT_SUPPORTED);
 #endif

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -681,7 +681,7 @@ declare namespace music {
      * Check whether any sound is being played, no matter the source
      */
     //% blockId=music_sound_is_playing block="sound is playing"
-    //% group="Volume"
+    //% group="micro:bit (V2)"
     //% help=music/volume
     //% weight=0 shim=music::isSoundPlaying
     function isSoundPlaying(): boolean;


### PR DESCRIPTION
As I was testing the new CODAL that was recently pushed, I noticed that the `is sound playing` block was not working. It was not working on live, either, though, so no issue with the CODAL updates. 

There were two issues:
1. I wasn't returning anything from the original function so the returned boolean should always be falsey.
2. The `uBit.audio.isplaying()` function has functionality that checks silence start and end from the Mixer that is used to control audio playback (seen [here](https://github.com/lancaster-university/codal-microbit-v2/blob/e1bc3e625b572f1e03add25370e8b5645c5e7c1d/source/MicroBitAudio.cpp#L259)). However, the silence start on the mixer is going to be zero until something makes a pull request for data to the mixer. The `on sound` blocks use the LevelSPL which should, as far as I understood it, connect to the mixer and thus say that the silence start/end began whenever the `on sound` block started executing. However, this is not happening. If an audio source is not playing or something has not triggered data pulling from the Mixer at the beginning of the program, the silence start is always zero when `isPlaying` gets called. This is a problem because, due to short circuiting and the way that `isPlaying` is written, if start is zero, `isPlaying` will return true. So we just needed to add a check to see if the silence start time is 0, and return false if that is the case-- because if silence start is 0, that means that no sounds have played yet.

While I was at it, I moved the block to the `micro:bit (v2) group in the music category based on https://github.com/microsoft/pxt-microbit/pull/5218/files#r1220565036. This is what the group looks like now.

![image](https://github.com/microsoft/pxt-microbit/assets/49178322/63ca332c-449f-42d7-aabd-bf6f0de0f3ca)
