### PR TITLE
Add some edits to clarify parms for audio settings

### DIFF
--- a/libs/audio-recording/docs/reference/record/audio-status.md
+++ b/libs/audio-recording/docs/reference/record/audio-status.md
@@ -1,12 +1,12 @@
 # audio Status
 
-Check to see if an audio buffer status is true or not.
+Check to see if a certain audio status is true or not.
 
 ```sig
 record.audioStatus(record.AudioStatus.Playing)
 ```
 
-The audio buffer has several status conditions that you can check. It will return `true` or `false` to tell you if the audio is playing, recording, stopped or the buffer has nothing in it.
+The audio status is related to what operation is happening to the audio [buffer](/types/buffer) at the current moment. The audio buffer has several status conditions that you can check. It will return `true` or `false` to tell you if the audio is playing, recording, stopped, or the buffer has nothing in it.
 
 ## Parameters
 

--- a/libs/audio-recording/docs/reference/record/set-sample-rate.md
+++ b/libs/audio-recording/docs/reference/record/set-sample-rate.md
@@ -12,7 +12,7 @@ When playing back, the sample rate sets the speed at which the sound is taken fr
 
 ## Parameters
 
-* **hz**: the [number](/types/number) of samples per second for record or playback.
+* **hz**: the [number](/types/number) of samples per second for recording or playback.
 * **scope**: an optional operation scope for the sample rate.
 >* `everything`: (default) set the same sample rate for both recording and playback.
 >* `playback`: set the sample rate only for audio playback.

--- a/libs/audio-recording/docs/reference/record/set-sample-rate.md
+++ b/libs/audio-recording/docs/reference/record/set-sample-rate.md
@@ -12,11 +12,11 @@ When playing back, the sample rate sets the speed at which the sound is taken fr
 
 ## Parameters
 
-* **hz**: the [number](/types/number) of samples per second to record or play back.
+* **hz**: the [number](/types/number) of samples per second for record or playback.
 * **scope**: an optional operation scope for the sample rate.
->* `everything`: (default) both recording and playback are at the same rate.
->* `playback`: audio playback is at this sample rate.
-> * `recording`: audio recording is at this sample rate.
+>* `everything`: (default) set the same sample rate for both recording and playback.
+>* `playback`: set the sample rate only for audio playback.
+> * `recording`: set the sample rate only for audio recording.
 
 ## Example
 


### PR DESCRIPTION
Add a few edits as requested in the comments for #5261.

Related to https://github.com/microsoft/pxt-microbit/pull/5261#discussion_r1269720366, the reason for the two copies of the extension main page is to satisfy the link for the "Learn More":

![image](https://github.com/microsoft/pxt-microbit/assets/27789908/9d1cf346-540f-40bd-b899-7ba266be6a3b)

...which will use "./audio-recording" from the extension name while the reference doc space will use the "./record" path as per the namespace.

I don't think a _audio-recording-ref.json_ will work here with something like:

```json
{
    "redirect": "./record"
}
```