### PR TITLE
Approve tutorials from Micro:bit Educational Foundation

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -787,7 +787,8 @@
             "joy-it/pxt-rb-joypi-advanced": { "tags": [ "Science" ] },
             "bsiever/pxt-sen55": { "tags": [ "Science" ] },
             "climate-action-kits/pxt-fwd-edu": {},
-            "elecfreaks/pxt-cutebot-pro": { "tags": [ "Robotics" ], "preferred": true }
+            "elecfreaks/pxt-cutebot-pro": { "tags": [ "Robotics" ], "preferred": true },
+            "microbit-foundation/makecode-tutorials": {}
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
These first tutorials from the micro:bit First Lessons content on microbit.org will also be accompanied with teacher PD and resources on microbit.org

@jwunderl is this the right set of steps for approving tutorial repos? I think this is the first time we've done it.

(And not to do now, but is it technically possible to pull these into a gallery from an extension? Or is that only for local tutorials/Yotube?)