### PR TITLE
datalogger: Add CODAL flags to enable BLE service with extension.

### DIFF
--- a/libs/datalogger/pxt.json
+++ b/libs/datalogger/pxt.json
@@ -14,21 +14,8 @@
     },
     "yotta": {
         "config": {
-            "codal": {
-                "MICROBIT_BLE_UTILITY_SERVICE": 1,
-                "MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 1
-            }
-        },
-        "userConfigs": [
-            {
-                "description": "Disable Bluetooth Utility Service",
-                "config": {
-                    "codal": {
-                        "MICROBIT_BLE_UTILITY_SERVICE": 0,
-                        "MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 0
-                    }
-                }
-            }
-        ]
+            "MICROBIT_BLE_UTILITY_SERVICE": 1,
+            "MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 1
+        }
     }
 }

--- a/libs/datalogger/pxt.json
+++ b/libs/datalogger/pxt.json
@@ -11,5 +11,24 @@
     "dependencies": {
         "core": "file:../core",
         "flashlog": "file:../flashlog"
+    },
+    "yotta": {
+        "config": {
+            "codal": {
+                "MICROBIT_BLE_UTILITY_SERVICE": 1,
+                "MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 1
+            }
+        },
+        "userConfigs": [
+            {
+                "description": "Disable Bluetooth Utility Service",
+                "config": {
+                    "codal": {
+                        "MICROBIT_BLE_UTILITY_SERVICE": 0,
+                        "MICROBIT_BLE_UTILITY_SERVICE_PAIRING": 0
+                    }
+                }
+            }
+        ]
     }
 }


### PR DESCRIPTION
This PR adds a couple of CODAL flags to the data logging extension, so that the Utility service is enabled when bluetooth is enabled. Similarly to the Events Service.
This Utility Service is used by the iOS app to fetch and display the data logging data in the app.

Test deployment:
- https://makecode.microbit.org/app/8bb9ef7928c091a7a57aff476473c8714f4454da-1e38d1bb41

Due to this issue this PR doesn't work, so setting as a draft PR until it is resolved:
- https://github.com/microsoft/pxt-microbit/issues/5352