### PR TITLE
Bumped CODAL up to v0.2.60-master.1 for testing

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.57",
+                    "branch": "v0.2.60-master.1",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
Reduced the total RAM usage for audio recordings slightly to avoid out-of-memory errors with less compact memory managers.

Just testing this on a branch first before we tag.