### PR TITLE
CODAL v0.2.61 - Interim Patch

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.57",
+                    "branch": "v0.2.61",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
We're recommending that we move to using CODAL v0.2.61 for the time being while we investigate ongoing 020 panics due to out-of-memory conditions when recording audio in some circumstances.

This CODAL tag leaves more headroom for MakeCode at the cost of a slightly reduced recording buffer size.

We are working on a proper fix for this issue currently, but to _mostly_ avoid the issue for now, we recommend that this tag should be pushed to beta & live.