### PR TITLE
Pulling the audio testing branch of CODAL to get build messages

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.57",
+                    "branch": "v0.2.61-master.0",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
DO NOT MERGE

Test build with debugging enabled to analyse the memory usage of audio recordings.