### PR TITLE
Bumped codal version to v0.2.62

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.61",
+                    "branch": "v0.2.62",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
- A patch to prevent out-of-memory errors in certain situations when using the audio recording API

Once this PR is built and tested, I'll mark this for review to go to beta and live.