### PR TITLE
Bumped CODAL version to v0.2.63

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.61",
+                    "branch": "v0.2.63",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
Bumping CODAL to v0.2.63, with patches for some memory and sleep errors.

Changelog: https://github.com/lancaster-university/codal-microbit-v2/blob/master/Changelog.md