### PR TITLE
Extension: add MonkMakes Plant Monitor

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -176,6 +176,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 
 ```codecard
 [{
+ "name": "MonkMakes Plant Monitor",
+  "url":"/pkg/monkmakes/plant-monitor-makecode",
+  "cardType": "package"
+}, {
  "name": "SGBotic Ultimate SR04",
   "url":"/pkg/SGBotic/pxt-SGBotic-Ultimate-SR04-RGB",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -453,7 +453,8 @@
             "microbit-foundation/makecode-tutorials": {},
             "grandpabond/pxt-meter": { "tags": [ "Software" ] },
             "microsoft/microbit-robot": { "tags": [ "Robotics" ] },
-            "4tronix/mars-rover": { "tags": [ "Robotics" ] }
+            "4tronix/mars-rover": { "tags": [ "Robotics" ] },
+            "monkmakes/plant-monitor-makecode": { "tags": [ "Science" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/68299 (private)
@simonmonk
@abchatra 

https://github.com/monkmakes/plant-monitor-makecode
https://makecode.microbit.org/_XuFgDfF9kimX
![image](https://github.com/microsoft/pxt-microbit/assets/989126/8222bc81-1980-43eb-aa77-9be7f974d528)

I have mentioned the following problems:-

It might be better if "start" was called as needed by the other blocks.
https://github.com/monkmakes/plant-monitor-makecode/blob/2f92edbed33a42cc6aeee48a849adc36ecbf392c/custom.ts#L43

The README blocks example should use embedded editor elements, but it is a PNG and shows a previous version of the blocks with capitalised text. The connecting diagram is great, but it seems quite large and is 1.3MB.
https://github.com/monkmakes/plant-monitor-makecode/tree/master#readme

There are some JavaScript APIs that don't conform to https://makecode.com/extensions/naming-conventions.
https://github.com/monkmakes/plant-monitor-makecode/blob/2f92edbed33a42cc6aeee48a849adc36ecbf392c/custom.ts#L99
https://github.com/monkmakes/plant-monitor-makecode/blob/2f92edbed33a42cc6aeee48a849adc36ecbf392c/custom.ts#L107

The extension name "Plant Monitor" and namespace "PlantMonitor" also do not conform to the conventions.
https://github.com/monkmakes/plant-monitor-makecode/blob/2f92edbed33a42cc6aeee48a849adc36ecbf392c/pxt.json#L2
https://github.com/monkmakes/plant-monitor-makecode/blob/2f92edbed33a42cc6aeee48a849adc36ecbf392c/custom.ts#L13

