### PR TITLE
Extension: add FlexFX

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -932,6 +932,10 @@ Check out [the accessories pages on microbit.org](https://microbit.org/buy/acces
 ## Utilities
 ```codecard
 [{
+  "name": "FlexFX",
+  "url": "/pkg/GrandpaBond/pxt-flexfx",
+  "cardType": "package"
+}, {
   "name": "Meter",
   "url": "/pkg/GrandpaBond/pxt-meter",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -454,7 +454,8 @@
             "grandpabond/pxt-meter": { "tags": [ "Software" ] },
             "microsoft/microbit-robot": { "tags": [ "Robotics" ] },
             "4tronix/mars-rover": { "tags": [ "Robotics" ] },
-            "monkmakes/plant-monitor-makecode": { "tags": [ "Science" ] }
+            "monkmakes/plant-monitor-makecode": { "tags": [ "Science" ] },
+            "grandpabond/pxt-flexfx": { "tags": [ "Software" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/66637 (private)

@abchatra 
Is FLEXFX_ACTIVITY_ID = 9050 and appropriate ID value for control.raiseEvent/waitForEvent?
https://github.com/GrandpaBond/pxt-flexfx/blob/master/flexFX.ts#L302

As it's a V2 only extension, I think @GrandpaBond is going to ensure the "Playing (micro:bit V2)" heading on the main blocks page shows.

We also noticed the capital in "compose Tune:" and "extend Tune:"

Extension: https://github.com/GrandpaBond/pxt-flexfx
All blocks: https://makecode.microbit.org/_Rg91DR8pJ2pR
![image](https://github.com/microsoft/pxt-microbit/assets/989126/fbad32d5-1ef8-4320-8807-d587e1eb8a6b)
