### PR TITLE
bump up max GC allocation for V2

### DIFF
--- a/libs/core/pxtcore.h
+++ b/libs/core/pxtcore.h
@@ -14,14 +14,14 @@ void debuglog(const char *format, ...);
 #define xmalloc malloc
 #define xfree free
 
-#define GC_MAX_ALLOC_SIZE 9000
-
 #define NON_GC_HEAP_RESERVATION 1024
 
 #ifdef CODAL_CONFIG_H
 #define MICROBIT_CODAL 1
+#define GC_MAX_ALLOC_SIZE 11000
 #else
 #define MICROBIT_CODAL 0
+#define GC_MAX_ALLOC_SIZE 9000
 #define GC_BLOCK_SIZE 256
 #endif
 


### PR DESCRIPTION
For both V1 and V2, the maximum GC allocation is 9000 bytes. For supporting frame buffer for arcade shield, bump max alloc for V2 to 11000. 