### PR TITLE
Add a "Light Foreground" Color to the Themepack

### DIFF
--- a/theme/themepacks.less
+++ b/theme/themepacks.less
@@ -3,6 +3,8 @@
         source vars: pxt/theme/themepacks.less
 ******************************************/
 
+@pxt_page_foreground_light: #767676;
+
 @pxt_headerbar_background: @blue;
 @pxt_headerbar_background_glass: rgba(@pxt_headerbar_background, 0.25);
 @pxt_headerbar_foreground: @white;
@@ -37,6 +39,7 @@
 :root {
     /// Page
     --pxt-page-font: @pageFont;
+    --pxt-page-foreground-light: @pxt_page_foreground_light;
     /// Header bar
     --pxt-headerbar-background: @pxt_headerbar_background;
     --pxt-headerbar-background-glass: @pxt_headerbar_background_glass;


### PR DESCRIPTION
This is useful for description text in the catalog:
![image](https://github.com/microsoft/pxt-microbit/assets/69657545/ef92c733-ebf6-45cc-833b-8c2a528879b4)

Confirmed color contrast is okay against a white background using accessibility checker:
![image](https://github.com/microsoft/pxt-microbit/assets/69657545/5e3a97a1-aa37-4dde-9f9f-5044bc981490)
