### PR TITLE
Micro Chat Rubric

### DIFF
--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -17,7 +17,7 @@
             "id": "18C44CC4-497F-45EC-90FA-CE7DB117AD03",
             "use": "set_radio_group_on_start",
             "template": "Sets the radio group on startup",
-            "description": "The 'radio set group' block is called on startup.",
+            "description": "The 'radio set group' block is called in the 'on start' event.",
             "hideInCatalog": true,
             "docPath": "/teachertool"
         },

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -12,6 +12,54 @@
             "template": "Read a GPIO pin",
             "description": "Read input from one or more of the microbit GPIO pins.",
             "docPath": "/teachertool"
+        },
+        {
+            "id": "18C44CC4-497F-45EC-90FA-CE7DB117AD03",
+            "use": "set_radio_group_on_start",
+            "template": "Sets the radio group on startup",
+            "description": "The 'radio set group' block is called on startup.",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "7ECB3AD5-F1C1-4106-9259-802B2E69A7A2",
+            "use": "send_radio_string_on_button_press",
+            "template": "Sends a radio string in response to a button press",
+            "description": "The 'radio send string' block is called inside a button press event",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "FAA97F77-C9F5-4D58-A3D5-47F965F4B6E2",
+            "use": "any_on_radio_received",
+            "template": "Listens for incoming radio messages",
+            "description": "Any 'on radio received' event (string, number, or name+value) is present.",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "D249AB3E-2620-4E33-911E-284303455365",
+            "use": "on_radio_received_and_displayed",
+            "template": "Displays received radio message on the screen",
+            "description": "A 'show' block is called with the received message inside the 'on radio received' event.",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "2DAFFA26-145E-472D-AA39-F46BA7E78F81",
+            "use": "multiple_send_radio_string_on_button_press",
+            "template": "Bonus: sends additional strings on different button events",
+            "description": "More than one 'on button pressed' event is present and sends a string.",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
+        },
+        {
+            "id": "1389B52A-F6E8-40B0-9B65-4C0FD221B7AB",
+            "use": "multiple_set_radio_group",
+            "template": "Bonus: Can send secret messages by changing the radio group",
+            "description": "Logic exists to change the radio group beyond the initial value on startup.",
+            "hideInCatalog": true,
+            "docPath": "/teachertool"
         }
     ]
 }

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -44,22 +44,6 @@
             "description": "A 'show' block is called with the received message inside the 'on radio received' event.",
             "hideInCatalog": true,
             "docPath": "/teachertool"
-        },
-        {
-            "id": "2DAFFA26-145E-472D-AA39-F46BA7E78F81",
-            "use": "multiple_send_radio_string_on_button_press",
-            "template": "Bonus: sends additional strings on different button events",
-            "description": "More than one 'on button pressed' event is present and sends a string.",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
-        },
-        {
-            "id": "1389B52A-F6E8-40B0-9B65-4C0FD221B7AB",
-            "use": "multiple_set_radio_group",
-            "template": "Bonus: Can send secret messages by changing the radio group",
-            "description": "Logic exists to change the radio group beyond the initial value on startup.",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
         }
     ]
 }

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -24,7 +24,7 @@
         {
             "id": "7ECB3AD5-F1C1-4106-9259-802B2E69A7A2",
             "use": "send_radio_string_on_button_press",
-            "template": "Sends a radio string in response to a button press",
+            "template": "Sends a radio string when a button is pressed",
             "description": "The 'radio send string' block is called inside a button press event",
             "hideInCatalog": true,
             "docPath": "/teachertool"
@@ -33,14 +33,14 @@
             "id": "FAA97F77-C9F5-4D58-A3D5-47F965F4B6E2",
             "use": "any_on_radio_received",
             "template": "Listens for incoming radio messages",
-            "description": "Any 'on radio received' event (string, number, or name+value) is present.",
+            "description": "Any 'on radio received' event (string, number, or name + value) is present.",
             "hideInCatalog": true,
             "docPath": "/teachertool"
         },
         {
             "id": "D249AB3E-2620-4E33-911E-284303455365",
             "use": "on_radio_received_and_displayed",
-            "template": "Displays received radio message on the screen",
+            "template": "Displays the received radio message on the screen",
             "description": "A 'show' block is called with the received message inside the 'on radio received' event.",
             "hideInCatalog": true,
             "docPath": "/teachertool"

--- a/docs/teachertool/rubrics/micro-chat.json
+++ b/docs/teachertool/rubrics/micro-chat.json
@@ -1,4 +1,29 @@
 {
     "name": "Micro Chat",
-    "criteria": []
+    "criteria": [
+        {
+            "catalogCriteriaId": "18C44CC4-497F-45EC-90FA-CE7DB117AD03",
+            "instanceId": "CFz2K1V77NHTE7covaEnc"
+        },
+        {
+            "catalogCriteriaId": "7ECB3AD5-F1C1-4106-9259-802B2E69A7A2",
+            "instanceId": "Mr99JIKxrlKtBlPq783jV"
+        },
+        {
+            "catalogCriteriaId": "FAA97F77-C9F5-4D58-A3D5-47F965F4B6E2",
+            "instanceId": "5ZeCpcWCAqLHHvoAftA__"
+        },
+        {
+            "catalogCriteriaId": "D249AB3E-2620-4E33-911E-284303455365",
+            "instanceId": "G7AkPpY5L9Ot3-mtcGYwF"
+        },
+        {
+            "catalogCriteriaId": "2DAFFA26-145E-472D-AA39-F46BA7E78F81",
+            "instanceId": "o45qefdUZd4U4_oGtN_PW"
+        },
+        {
+            "catalogCriteriaId": "1389B52A-F6E8-40B0-9B65-4C0FD221B7AB",
+            "instanceId": "MFeyX6GDVOKjyNYpmpMkR"
+        }
+    ]
 }

--- a/docs/teachertool/rubrics/micro-chat.json
+++ b/docs/teachertool/rubrics/micro-chat.json
@@ -16,14 +16,6 @@
         {
             "catalogCriteriaId": "D249AB3E-2620-4E33-911E-284303455365",
             "instanceId": "G7AkPpY5L9Ot3-mtcGYwF"
-        },
-        {
-            "catalogCriteriaId": "2DAFFA26-145E-472D-AA39-F46BA7E78F81",
-            "instanceId": "o45qefdUZd4U4_oGtN_PW"
-        },
-        {
-            "catalogCriteriaId": "1389B52A-F6E8-40B0-9B65-4C0FD221B7AB",
-            "instanceId": "MFeyX6GDVOKjyNYpmpMkR"
         }
     ]
 }

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -70,19 +70,6 @@
             ]
         },
         {
-            ".desc": "Set the radio group.",
-            "name": "multiple_set_radio_group",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_set_group": 2
-                    }
-                }
-            ]
-        },
-        {
             ".desc": "Send a string over radio.",
             "name": "send_radio_string",
             "threshold": 1,
@@ -139,20 +126,6 @@
                     "validator": "blocksExist",
                     "blockCounts": {
                         "device_button_event": 1
-                    },
-                    "childValidatorPlans": ["send_radio_string"]
-                }
-            ]
-        },
-        {
-            ".desc": "send radio string in button press event.",
-            "name": "multiple_send_radio_string_on_button_press",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_button_event": 2
                     },
                     "childValidatorPlans": ["send_radio_string"]
                 }

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -55,6 +55,161 @@
                     }
                 }
             ]
+        },
+        {
+            ".desc": "Set the radio group.",
+            "name": "set_radio_group",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_set_group": 1
+                    }
+                }
+            ]
+        },
+        {
+            ".desc": "Set the radio group.",
+            "name": "multiple_set_radio_group",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_set_group": 2
+                    }
+                }
+            ]
+        },
+        {
+            ".desc": "Send a string over radio.",
+            "name": "send_radio_string",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_datagram_send_string": 1
+                    }
+                }
+            ]
+        },
+        {
+            ".desc": "shows a parameter variable value on the screen",
+            "name": "show_parameter_value_on_screen",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "device_print_message": 1
+                    },
+                    "childValidatorPlans": ["parameter_variable_accessed"]
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "device_show_number": 1
+                    },
+                    "childValidatorPlans": ["numeric_parameter_variable_accessed"]
+                }
+            ]
+        },
+        {
+            ".desc": "set radio group on start",
+            "name": "set_radio_group_on_start",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "pxt-on-start": 1
+                    },
+                    "childValidatorPlans": ["set_radio_group"]
+                }
+            ]
+        },
+        {
+            ".desc": "send radio string in button press event.",
+            "name": "send_radio_string_on_button_press",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "device_button_event": 1
+                    },
+                    "childValidatorPlans": ["send_radio_string"]
+                }
+            ]
+        },
+        {
+            ".desc": "send radio string in button press event.",
+            "name": "multiple_send_radio_string_on_button_press",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "device_button_event": 2
+                    },
+                    "childValidatorPlans": ["send_radio_string"]
+                }
+            ]
+        },
+        {
+            ".desc": "one or more of the possible 'on radio received' blocks are present",
+            "name": "any_on_radio_received",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_number_drag": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_value_drag": 1
+                    }
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_string_drag": 1
+                    }
+                }
+            ]
+        },
+        {
+            ".desc": "one or more of the possible 'on radio received' blocks are present and display the received content on the screen.",
+            "name": "on_radio_received_and_displayed",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_number_drag": 1
+                    },
+                    "childValidatorPlans": ["show_parameter_value_on_screen"]
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_value_drag": 1
+                    },
+                    "childValidatorPlans": ["show_parameter_value_on_screen"]
+                },
+                {
+                    "validator": "blocksExist",
+                    "blockCounts": {
+                        "radio_on_string_drag": 1
+                    },
+                    "childValidatorPlans": ["show_parameter_value_on_screen"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Happy to iterate, but I thought just sending the PR would be a good way to capture feedback.

Rubric is here:
![image](https://github.com/microsoft/pxt-microbit/assets/69657545/53201d57-a3c2-4783-aa82-7eafdd4aba68)

I would've liked to add two "bonus" checks as well (see below), but we don't currently have the ability to check for nested blocks when more than 1 block is required, which means we can't support the first check (yet), and it felt weird to have one and not the other.

**Bonus: Sends additional strings on different button events**
The program has more than one "on button pressed" event which sends a string.

**Bonus: Can send secret messages by changing the radio group**
The program contains logic to change the radio group beyond the initial set on startup.

Depends on https://github.com/microsoft/pxt/pull/9896 for parameter checks