### PR TITLE
Bumped CODAL to v0.2.66

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -197,7 +197,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.63",
+                    "branch": "v0.2.66",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
Testing the build with a version bump to v0.2.66 for CODAL.

DO NOT MERGE (yet!)