### PR TITLE
Update Blocks Exist Json Schema for JsonPath Friendliness

### DIFF
--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -7,9 +7,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "basic_show_icon": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "basic_show_icon",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -20,39 +23,57 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_pin_event": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_pin_event",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_pin_is_pressed": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_pin_is_pressed",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_pin_released": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_pin_released",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_get_digital_pin": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_get_digital_pin",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_get_analog_pin": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_get_analog_pin",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "pins_on_pulsed": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "pins_on_pulsed",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -63,9 +84,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_set_group": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_set_group",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -76,9 +100,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_datagram_send_string": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_datagram_send_string",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -89,16 +116,22 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_print_message": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "device_print_message",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["parameter_variable_accessed"]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_show_number": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "device_show_number",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["numeric_parameter_variable_accessed"]
                 }
             ]
@@ -110,9 +143,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "pxt-on-start": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "pxt-on-start",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["set_radio_group"]
                 }
             ]
@@ -124,9 +160,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_button_event": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "device_button_event",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["send_radio_string"]
                 }
             ]
@@ -138,21 +177,30 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_number_drag": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_number_drag",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_value_drag": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_value_drag",
+                            "count": 1
+                        }
+                    ]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_string_drag": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_string_drag",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -163,23 +211,32 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_number_drag": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_number_drag",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["show_parameter_value_on_screen"]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_value_drag": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_value_drag",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["show_parameter_value_on_screen"]
                 },
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "radio_on_string_drag": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "radio_on_string_drag",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["show_parameter_value_on_screen"]
                 }
             ]
@@ -217,9 +274,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "device_random": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "device_random",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -230,9 +290,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "controls_if": 1
-                    }
+                    "blockCounts": [
+                        {
+                            "block_id": "controls_if",
+                            "count": 1
+                        }
+                    ]
                 }
             ]
         },
@@ -270,9 +333,12 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts": {
-                        "controls_if": 1
-                    },
+                    "blockCounts": [
+                        {
+                            "block_id": "controls_if",
+                            "count": 1
+                        }
+                    ],
                     "childValidatorPlans": ["show_icon_on_screen"]
                 }
             ]

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -9,7 +9,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "basic_show_icon",
+                            "blockId": "basic_show_icon",
                             "count": 1
                         }
                     ]
@@ -25,7 +25,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_pin_event",
+                            "blockId": "device_pin_event",
                             "count": 1
                         }
                     ]
@@ -34,7 +34,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_pin_is_pressed",
+                            "blockId": "device_pin_is_pressed",
                             "count": 1
                         }
                     ]
@@ -43,7 +43,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_pin_released",
+                            "blockId": "device_pin_released",
                             "count": 1
                         }
                     ]
@@ -52,7 +52,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_get_digital_pin",
+                            "blockId": "device_get_digital_pin",
                             "count": 1
                         }
                     ]
@@ -61,7 +61,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_get_analog_pin",
+                            "blockId": "device_get_analog_pin",
                             "count": 1
                         }
                     ]
@@ -70,7 +70,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "pins_on_pulsed",
+                            "blockId": "pins_on_pulsed",
                             "count": 1
                         }
                     ]
@@ -86,7 +86,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_set_group",
+                            "blockId": "radio_set_group",
                             "count": 1
                         }
                     ]
@@ -102,7 +102,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_datagram_send_string",
+                            "blockId": "radio_datagram_send_string",
                             "count": 1
                         }
                     ]
@@ -118,7 +118,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_print_message",
+                            "blockId": "device_print_message",
                             "count": 1
                         }
                     ],
@@ -128,7 +128,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_show_number",
+                            "blockId": "device_show_number",
                             "count": 1
                         }
                     ],
@@ -145,7 +145,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "pxt-on-start",
+                            "blockId": "pxt-on-start",
                             "count": 1
                         }
                     ],
@@ -162,7 +162,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_button_event",
+                            "blockId": "device_button_event",
                             "count": 1
                         }
                     ],
@@ -179,7 +179,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_number_drag",
+                            "blockId": "radio_on_number_drag",
                             "count": 1
                         }
                     ]
@@ -188,7 +188,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_value_drag",
+                            "blockId": "radio_on_value_drag",
                             "count": 1
                         }
                     ]
@@ -197,7 +197,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_string_drag",
+                            "blockId": "radio_on_string_drag",
                             "count": 1
                         }
                     ]
@@ -213,7 +213,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_number_drag",
+                            "blockId": "radio_on_number_drag",
                             "count": 1
                         }
                     ],
@@ -223,7 +223,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_value_drag",
+                            "blockId": "radio_on_value_drag",
                             "count": 1
                         }
                     ],
@@ -233,7 +233,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "radio_on_string_drag",
+                            "blockId": "radio_on_string_drag",
                             "count": 1
                         }
                     ],
@@ -276,7 +276,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "device_random",
+                            "blockId": "device_random",
                             "count": 1
                         }
                     ]
@@ -292,7 +292,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "controls_if",
+                            "blockId": "controls_if",
                             "count": 1
                         }
                     ]
@@ -335,7 +335,7 @@
                     "validator": "blocksExist",
                     "blockCounts": [
                         {
-                            "block_id": "controls_if",
+                            "blockId": "controls_if",
                             "count": 1
                         }
                     ],


### PR DESCRIPTION
The structure of the `blockCounts` input for `blocksExist` validator plans was not JsonPath friendly, as the customizable `blockId` was treated as a property and it was also a part of the path for count. This change adjusts the schema so both `blockId` and `count` can be referenced more easily by [JsonPath](https://github.com/json-path/JsonPath), which we will need for parameterized criteria.

Depends on https://github.com/microsoft/pxt/pull/9905.