### PR TITLE
Changed bounding box of microbit logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.0.1",
-        "pxt-core": "10.0.15"
+        "pxt-core": "10.0.16"
     }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.0.1",
-        "pxt-core": "10.0.11"
+        "pxt-core": "10.0.15"
     }
 }

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -201,6 +201,11 @@ namespace pxsim {
         screenshotAsync(width?: number): Promise<ImageData> {
             return this.viewHost.screenshotAsync(width);
         }
+
+        kill() {
+            super.kill();
+            this.viewHost.removeEventListeners();
+        }
     }
 
     export function initRuntimeWithDalBoard() {


### PR DESCRIPTION
The svg box for the micro:bit logo was too large. It was interfering with our coordinate tooltips on the LEDs. To fix this, I changed the sim-head svg container to be an ellipse to better fit the shape of the logo and fit the shape closer to the logo. Because of this, some of the interactions with the compass were a bit wonky, so that's where the `moveHeadingOnClick` function comes in. Because we're adding an event listener to the body of the board, we also need to make sure that we remove that event listener when the board is killed, but the BoardView is only accessed within the context of the BoardHost, so I needed to make some modifications to the BoardHost as well (PR below).

Required for this PR: https://github.com/microsoft/pxt/pull/9946
Fixes https://github.com/microsoft/pxt-microbit/issues/5434

Upload target: https://makecode.microbit.org/app/cbd4697446a349f835837d3cb85d0943d5e65bc2-2310ea9f83#editor 
Two things to try: 
1. hover over the first row of LEDs to see that the tooltips are now showing up
2. Play with the compass to make sure that it's interactions are as expected