### PR TITLE
Temporarily disable upload docs

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -624,5 +624,5 @@
             }
         }
     },
-    "uploadDocs": true
+    "uploadDocs": false
 }


### PR DESCRIPTION
A temporary measure while we upgrade to the v2 apis