### PR TITLE
Accessibility insights: fixed minor color contrast issues

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -375,7 +375,7 @@
             "graphBackground": "#d9d9d9",
             "lineColors": [
                 "#6633cc",
-                "#3891A6",
+                "#2C7485",
                 "#3454D1",
                 "#EF767A",
                 "#F46197",

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -53,7 +53,7 @@
 @simulatorBackground: #FDFDFF;
 @editorToolsBackground: @simulatorBackground;
 @blocklySvgColor: #ecf0f1;
-@cloudCardBackground: #546ece;
+@cloudCardBackground: lighten(@blue, 7);
 
 /*-------------------
    Side Docs

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -9,7 +9,7 @@
 
 @primaryColor: @purple;
 
-@teal: #3891A6;
+@teal: #2C7485;
 @blue: #3454D1;
 @red: #E41B21;
 @pink: #F46197;
@@ -53,7 +53,7 @@
 @simulatorBackground: #FDFDFF;
 @editorToolsBackground: @simulatorBackground;
 @blocklySvgColor: #ecf0f1;
-@cloudCardBackground: lighten(@blue, 9);
+@cloudCardBackground: #546ece;
 
 /*-------------------
    Side Docs


### PR DESCRIPTION
There are still some color contrast issues with blocks categories, but I didn't want to touch those. I just made the "Cloud Projects" card's background color a bit darker and also made the avatar initial color a bit darker. 

The avatar color on live:
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/fc0e1f35-8696-44fc-aaf4-e955b60b5e0d)

The updated avatar color:
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/b7b0e8e2-5560-4238-bbfa-1329ae615a0a)

The cloud projects card color on live:
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/1b3d5fcf-0276-4c03-a5e6-acff76fc7a5f)

The updated cloud projects card color: (edited to the lighten update)
![image](https://github.com/microsoft/pxt-microbit/assets/49178322/4991937a-0181-40ea-b2eb-50251bb35aeb)

