### PR TITLE
Teacher Tool: Clean Micro:Bit Catalog

### DIFF
--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -50,6 +50,7 @@
             "use": "on_shake_gesture",
             "template": "Runs code when the micro:bit is shaken",
             "description": "When the user shakes the micro:bit, the code inside this block will run.",
+            "hideInCatalog": true,
             "docPath": "/teachertool"
         },
         {
@@ -65,6 +66,7 @@
             "use": "pick_random_exists",
             "template": "Utilizes the pick random block",
             "description": "The project utilizes the pick random block",
+            "hideInCatalog": true,
             "docPath": "/teachertool"
         },
         {
@@ -72,6 +74,7 @@
             "use": "conditional_exists",
             "template": "Utilizes the if/else block",
             "description": "The project includes at least one conditional block",
+            "hideInCatalog": true,
             "docPath": "/teachertool"
         },
         {
@@ -87,6 +90,7 @@
             "use": "conditional_show_icon",
             "template": "Show an icon on display when a condition is met",
             "description": "The project shows an icon on the display when a condition is met",
+            "hideInCatalog": true,
             "docPath": "/teachertool"
         },
         {

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -62,22 +62,6 @@
             "docPath": "/teachertool"
         },
         {
-            "id": "67FB5A95-57A8-4496-8865-F682923C36F7",
-            "use": "pick_random_exists",
-            "template": "Utilizes the pick random block",
-            "description": "The project utilizes the pick random block",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
-        },
-        {
-            "id": "BBD02C45-8515-4936-B99F-8FF29025C333",
-            "use": "conditional_exists",
-            "template": "Utilizes the if/else block",
-            "description": "The project includes at least one conditional block",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
-        },
-        {
             "id": "499EEFAB-2487-427E-8081-28EE031C7D17",
             "use": "hand_equal_to_number",
             "template": "Checks the value of the variable 'hand'",

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -143,20 +143,6 @@
             "docPath": "/teachertool"
         },
         {
-            "id": "1B331451-081E-4F26-9CB6-F5A649432BF9",
-            "use": "repeat_loop_used",
-            "template": "Repeat loop is used",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
-        },
-        {
-            "id": "A4F05FAB-72F2-48F5-8E33-7AE2CBB6CD43",
-            "use": "forever_used",
-            "template": "Forever loop is used",
-            "hideInCatalog": true,
-            "docPath": "/teachertool"
-        },
-        {
             "id": "5934E4C6-7AE4-46A4-8F92-99101987D064",
             "use": "show_icon_on_start",
             "template": "Show an icon on the LED screen when the program starts",

--- a/docs/teachertool/catalog.json
+++ b/docs/teachertool/catalog.json
@@ -2,8 +2,9 @@
     "criteria": [
         {
             "id": "D285D79B-85E5-4C8D-82D2-5A9E35AB1163",
-            "use": "show_icon_on_screen",
-            "template": "Show an icon on the display",
+            "use": "output_to_led_display",
+            "template": "Outputs to the LED display",
+            "description": "Uses at least one block that lights up LEDs",
             "docPath": "/teachertool"
         },
         {

--- a/docs/teachertool/rubrics/blow-away-mbv2.json
+++ b/docs/teachertool/rubrics/blow-away-mbv2.json
@@ -10,20 +10,50 @@
             "instanceId": "-3sSPpeXd-M2WaHObA1yq"
         },
         {
-            "catalogCriteriaId": "A4F05FAB-72F2-48F5-8E33-7AE2CBB6CD43",
-            "instanceId": "2H_lA-5kA1bpPhHitt_Gs"
+            "catalogCriteriaId": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
+            "instanceId": "2H_lA-5kA1bpPhHitt_Gs",
+            "params": [
+                {
+                    "name": "block",
+                    "value": "device_forever"
+                },
+                {
+                    "name": "count",
+                    "value": "1"
+                }
+            ]
         },
         {
-            "catalogCriteriaId": "1B331451-081E-4F26-9CB6-F5A649432BF9",
-            "instanceId": "Bw5GPuGHqfWG14AWmnvaY"
+            "catalogCriteriaId": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
+            "instanceId": "Bw5GPuGHqfWG14AWmnvaY",
+            "params": [
+                {
+                    "name": "block",
+                    "value": "controls_repeat_ext"
+                },
+                {
+                    "name": "count",
+                    "value": "1"
+                }
+            ]
         },
         {
             "catalogCriteriaId": "B835FAA0-8CA6-4E4A-95B4-7FC6D15231BD",
             "instanceId": "IlpiBn6Tjn0mkjCrVGI0v"
         },
         {
-            "catalogCriteriaId": "850DBBDE-71BA-48D2-A1E4-7AC19716C976",
-            "instanceId": "rvzANbK3nhtd7dPcVBYF4"
+            "catalogCriteriaId": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
+            "instanceId": "rvzANbK3nhtd7dPcVBYF4",
+            "params": [
+                {
+                    "name": "block",
+                    "value": "device_get_sound_level"
+                },
+                {
+                    "name": "count",
+                    "value": "1"
+                }
+            ]
         },
         {
             "catalogCriteriaId": "F82F6BB4-2B1C-4CFF-92BA-65CE63DD6399",

--- a/docs/teachertool/rubrics/rock-paper-scissors.json
+++ b/docs/teachertool/rubrics/rock-paper-scissors.json
@@ -10,12 +10,32 @@
             "instanceId": "FeEhmngBzesVwrOThm8oW"
         },
         {
-            "catalogCriteriaId": "67FB5A95-57A8-4496-8865-F682923C36F7",
-            "instanceId": "qpJlRBbsZYG1q87c2vaV6"
+            "catalogCriteriaId": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
+            "instanceId": "qpJlRBbsZYG1q87c2vaV6",
+            "params": [
+                {
+                    "name": "block",
+                    "value": "device_random"
+                },
+                {
+                    "name": "count",
+                    "value": "1"
+                }
+            ]
         },
         {
-            "catalogCriteriaId": "BBD02C45-8515-4936-B99F-8FF29025C333",
-            "instanceId": "EGMmpeasViCQJVazRky7f"
+            "catalogCriteriaId": "59AAC5BA-B0B3-4389-AA90-1E767EFA8563",
+            "instanceId": "EGMmpeasViCQJVazRky7f",
+            "params": [
+                {
+                    "name": "block",
+                    "value": "controls_if"
+                },
+                {
+                    "name": "count",
+                    "value": "1"
+                }
+            ]
         },
         {
             "catalogCriteriaId": "499EEFAB-2487-427E-8081-28EE031C7D17",

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -268,38 +268,6 @@
             ]
         },
         {
-            ".desc": "'pick random' block is present",
-            "name": "pick_random_exists",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": [
-                        {
-                            "blockId": "device_random",
-                            "count": 1
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            ".desc": "'if/else' block is present",
-            "name": "conditional_exists",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": [
-                        {
-                            "blockId": "controls_if",
-                            "count": 1
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             ".desc": "read value of 'hand' variable",
             "name": "hand_variable_accessed",
             "threshold": 1,

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -17,6 +17,29 @@
             ]
         },
         {
+            ".desc": "Shows something on the LED screen.",
+            "name": "output_to_led_display",
+            "threshold": 1,
+            "checks": [
+                {
+                    "validator": "blocksInSetExist",
+                    "blocks": [
+                        "device_show_number",
+                        "device_show_leds",
+                        "basic_show_icon",
+                        "device_print_message",
+                        "device_plot",
+                        "device_led_toggle",
+                        "device_plot_bar_graph",
+                        "device_plot_brightness",
+                        "device_show_image_offset",
+                        "device_scroll_image"
+                    ],
+                    "count": 1
+                }
+            ]
+        },
+        {
             ".desc": "Read input from a GPIO pin.",
             "name": "read_gpio_pin",
             "threshold": 1,
@@ -408,7 +431,11 @@
                             "count": 1
                         }
                     ],
-                    "childValidatorPlans": ["soundlevel_greater_than_check", "row_variable_set_random", "col_variable_set_random"]
+                    "childValidatorPlans": [
+                        "soundlevel_greater_than_check",
+                        "row_variable_set_random",
+                        "col_variable_set_random"
+                    ]
                 }
             ]
         },
@@ -484,13 +511,13 @@
             "checks": [
                 {
                     "validator": "blocksExist",
-                    "blockCounts":[
+                    "blockCounts": [
                         {
                             "blockId": "controls_if",
                             "count": 1
                         }
                     ],
-                    "childValidatorPlans": ["point_bool_check" , "unplot_vars_used", "plot_vars_used"]
+                    "childValidatorPlans": ["point_bool_check", "unplot_vars_used", "plot_vars_used"]
                 }
             ]
         },
@@ -507,7 +534,7 @@
                             "count": 1
                         }
                     ],
-                    "childValidatorPlans": ["point_condition" , "soundlevel_gt_condition"]
+                    "childValidatorPlans": ["point_condition", "soundlevel_gt_condition"]
                 }
             ]
         },

--- a/docs/teachertool/validator-plans.json
+++ b/docs/teachertool/validator-plans.json
@@ -512,38 +512,6 @@
             ]
         },
         {
-            ".desc": "forever loop is in the program",
-            "name": "forever_used",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": [
-                        {
-                            "blockId": "device_forever",
-                            "count": 1
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            ".desc": "repeat loop is in the program",
-            "name": "repeat_loop_used",
-            "threshold": 1,
-            "checks": [
-                {
-                    "validator": "blocksExist",
-                    "blockCounts": [
-                        {
-                            "blockId": "controls_repeat_ext",
-                            "count": 1
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             ".desc": "show icon on start",
             "name": "show_icon_on_start",
             "threshold": 1,


### PR DESCRIPTION
Now that parameterized criteria are supported in beta, we can reduce some of the duplication in our catalog and sample rubrics.

Kept:
- Show an icon on the display
- Read a GPIO pin

Hid from main catalog but kept for sample rubrics:
- Runs code when the micro:bit is shaken
- Show an icon on display when a condition is met

Removed (can use `${Block} used ${count} times` for all of these):
- Utilizes the pick random block
- Utilizes the if/else block
- Forever loop is used
- Repeat loop is used
- Sound level is detected in the program

Related pxt change: https://github.com/microsoft/pxt/pull/9965

While testing, I noticed a bug where parameters seem to be getting overwritten when we have multiple instances of the same catalog criteria, but I'll look into that separately.