### PR TITLE
[Stable6.0] Bump pxt-core to 9.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "11.0.1",
-        "pxt-core": "9.0.17"
+        "pxt-core": "9.0.19"
     }
 }


### PR DESCRIPTION
Grabbing the crowdin changes and the partner telemetry flag