### PR TITLE
Make pins.map block inline

### DIFF
--- a/libs/core/pins.ts
+++ b/libs/core/pins.ts
@@ -15,6 +15,7 @@ namespace pins {
      */
     //% help=pins/map weight=23
     //% blockId=pin_map block="map %value|from low %fromLow|from high %fromHigh|to low %toLow|to high %toHigh"
+    //% inlineInputMode=inline
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
     }


### PR DESCRIPTION
This block is functionally the same as Math.map block and Math.map is inline.