### PR TITLE
Extension: add KittenBot TabbyBot

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -517,6 +517,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "KittenBot TabbyBot",
+  "url":"/pkg/KittenBot/pxt-tabbyrobot",
+  "cardType": "package"
+}, {
   "name": "Gcube",
   "url":"/pkg/roborisen/gcube",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -460,7 +460,8 @@
             "grandpabond/pxt-faces": { "tags": [ "Software" ] },
             "joylabz/code-a-key-extension": {},
             "eb8ga/pxt-roversa-2": { "tags": [ "Robotics" ] },
-            "roborisen/gcube": { "tags": [ "Robotics" ] }
+            "roborisen/gcube": { "tags": [ "Robotics" ] },
+            "kittenbot/pxt-tabbyrobot": { "tags": [ "Robotics" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/75469 (private)
@smfox10
@abchatra 

Extension: https://github.com/KittenBot/pxt-tabbyrobot
All blocks: https://makecode.microbit.org/_44vV0FHRa1ga
![image](https://github.com/microsoft/pxt-microbit/assets/989126/070dfdfc-cdf8-4d2f-bfb5-b1dbe315e681)
