### PR TITLE
Make pins.map block inline

### DIFF
--- a/libs/core/pins.ts
+++ b/libs/core/pins.ts
@@ -41,6 +41,7 @@ namespace pins {
      */
     //% help=pins/map weight=23
     //% blockId=pin_map block="map %value|from low %fromLow|from high %fromHigh|to low %toLow|to high %toHigh"
+    //% inlineInputMode=inline
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
     }


### PR DESCRIPTION
I accidentially closed previous pull request (https://github.com/microsoft/pxt-microbit/pull/5697).

@abchatra 
Could you review this simple pull request? Or could you let me know why it should not be inline?