### PR TITLE
Remove/change links to deprecated 'led' pages

### DIFF
--- a/docs/reference/basic/show-arrow.md
+++ b/docs/reference/basic/show-arrow.md
@@ -25,5 +25,5 @@ for (let index = 0; index <= 7; index++) {
 
 ## See also
 
-[showIcon](/reference/basic/show-icon),
-[showLeds](/reference/basic/show-leds)
+[show icon](/reference/basic/show-icon),
+[show leds](/reference/basic/show-leds)

--- a/docs/reference/basic/show-leds.md
+++ b/docs/reference/basic/show-leds.md
@@ -49,5 +49,4 @@ on and `.` means an LED that is turned off.
 
 ## See also
 
-[plot leds](/reference/basic/plot-leds), [show animation](/reference/basic/show-animation)
-
+[show icon](/reference/basic/show-icon)

--- a/docs/reference/basic/show-number.md
+++ b/docs/reference/basic/show-number.md
@@ -43,10 +43,9 @@ If `value` is `NaN` (not a number), `?` is displayed.
 
 ## Other show functions
 
-* Use [show string](/reference/basic/show-string) to show a [String](/types/string) with letters on the screen.
-* Use [show animation](/reference/basic/show-animation) to show a group of pictures on the screen, one after another.
+Use [show string](/reference/basic/show-string) to show a [String](/types/string) with letters on the screen.
 
 ## See also
 
-[show string](/reference/basic/show-string), [show animation](/reference/basic/show-animation), [Number](/types/number), [math](/blocks/math)
+[show string](/reference/basic/show-string), [Number](/types/number), [math](/blocks/math)
 

--- a/docs/reference/basic/show-string.md
+++ b/docs/reference/basic/show-string.md
@@ -28,10 +28,8 @@ basic.showString(s)
 
 ## Other show functions
 
-* Use [show number](/reference/basic/show-number) to show a number on the [LED screen](/device/screen).
-* Use [show animation](/reference/basic/show-animation) to show a group of pictures on the screen, one after another.
+Use [show number](/reference/basic/show-number) to show a number on the [LED screen](/device/screen).
 
 ## See also
 
-[String](/types/string), [show number](/reference/basic/show-number), [show animation](/reference/basic/show-animation)
-
+[String](/types/string), [show number](/reference/basic/show-number)

--- a/docs/reference/game/clear.md
+++ b/docs/reference/game/clear.md
@@ -35,5 +35,5 @@ input.onButtonPressed(Button.A, () => {
 
 ## See also
 
-[Image](/reference/images/image), [show animation](/reference/basic/show-animation), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image), [create image](/reference/images/create-image)
+[Image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image), [create image](/reference/images/create-image)
 

--- a/docs/reference/images/create-big-image.md
+++ b/docs/reference/images/create-big-image.md
@@ -49,4 +49,4 @@ input.onButtonPressed(Button.B, () => {
 [image](/reference/images/image),
 [create image](/reference/images/create-image),
 [show image](/reference/images/show-image),
-[scroll image](/reference/images/scroll-image), [show animation](/reference/basic/show-animation)
+[scroll image](/reference/images/scroll-image)

--- a/docs/reference/images/create-image.md
+++ b/docs/reference/images/create-image.md
@@ -32,7 +32,7 @@ input.onButtonPressed(Button.A, () => {
         # . # . #
         . . # . .
         . . # . .
-        `).showImage(0);
+        `).showImage(0)
 });
 input.onButtonPressed(Button.B, () => {
     images.createImage(`
@@ -41,8 +41,8 @@ input.onButtonPressed(Button.B, () => {
         # . # . #
         . # # # .
         . . # . .
-        `).showImage(0);
-});
+        `).showImage(0)
+})
 ```
 
 ## See also
@@ -50,5 +50,4 @@ input.onButtonPressed(Button.B, () => {
 [image](/reference/images/image),
 [create big image](/reference/images/create-big-image),
 [show image](/reference/images/show-image),
-[scroll image](/reference/images/scroll-image), [show animation](/reference/basic/show-animation)
-
+[scroll image](/reference/images/scroll-image)

--- a/docs/reference/images/plot-frame.md
+++ b/docs/reference/images/plot-frame.md
@@ -33,5 +33,5 @@ img.plotFrame(1)
 
 ## See also
 
-[create image](/reference/images/create-image), [show animation](/reference/basic/show-animation), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
+[create image](/reference/images/create-image), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
 

--- a/docs/reference/images/plot-image.md
+++ b/docs/reference/images/plot-image.md
@@ -33,5 +33,5 @@ img.plotImage(0)
 
 ## See also
 
-[create image](/reference/images/create-image), [show animation](/reference/basic/show-animation), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
+[create image](/reference/images/create-image), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
 

--- a/docs/reference/images/scroll-image.md
+++ b/docs/reference/images/scroll-image.md
@@ -46,5 +46,4 @@ basic.forever(() => {
 
 ## See also
 
-[show image](/reference/images/show-image), [image](/reference/images/image), [create image](/reference/images/create-image), [show animation](/reference/basic/show-animation)
-
+[show image](/reference/images/show-image), [image](/reference/images/image), [create image](/reference/images/create-image)

--- a/docs/reference/images/show-frame.md
+++ b/docs/reference/images/show-frame.md
@@ -33,5 +33,5 @@ img.showFrame(1)
 
 ## See also
 
-[create image](/reference/images/create-image), [show animation](/reference/basic/show-animation), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
+[create image](/reference/images/create-image), [image](/reference/images/image), [show image](/reference/images/show-image), [scroll image](/reference/images/scroll-image)
 

--- a/docs/reference/images/show-image.md
+++ b/docs/reference/images/show-image.md
@@ -44,4 +44,4 @@ input.onButtonPressed(Button.B, () => {
 [image](/reference/images/image),
 [create image](/reference/images/create-image),
 [create big image](/reference/images/create-big-image),
-[scroll image](/reference/images/scroll-image), [show animation](/reference/basic/show-animation)
+[scroll image](/reference/images/scroll-image)

--- a/docs/reference/images/width.md
+++ b/docs/reference/images/width.md
@@ -52,5 +52,4 @@ for (let i = 0; i < img2.width() / 5; i++) {
 
 ## See also
 
-[show image](/reference/images/show-image), [image](/reference/images/image), [create image](/reference/images/create-image), [scroll image](/reference/images/scroll-image), [show animation](/reference/basic/show-animation)
-
+[show image](/reference/images/show-image), [image](/reference/images/image), [create image](/reference/images/create-image), [scroll image](/reference/images/scroll-image)


### PR DESCRIPTION
Remove or change links to reference pages for the 'show' and 'led' blocks that are deprecated/hidden.

RE: #3934 

Closes #5722