### PR TITLE
Remove duplicated last step from Python version of 'Smiley Buttons'

### DIFF
--- a/docs/projects/python/smiley-buttons.md
+++ b/docs/projects/python/smiley-buttons.md
@@ -55,7 +55,3 @@ input.on_button_pressed(Button.AB, on_button_pressed_a3)
 ## Step 5
 
 Click ``|Download|`` to transfer your code to your @boardname@ (if you have one). Try buttons **A**, **B** and then **A** and **B** together.
-
-## Step 6
-
-If you have a @boardname@ connected, click ``|Download|`` and transfer your code to the @boardname@!

--- a/docs/projects/python/smiley-buttons.md
+++ b/docs/projects/python/smiley-buttons.md
@@ -2,14 +2,14 @@
 
 ### @explicitHints true
 
-## Introduction @unplugged
+## Code a micro:bit emoji! @unplugged
 
 Code the buttons on the @boardname@ to show that it's happy or sad.
 (Want to learn how the buttons works? [Watch this video](https://youtu.be/t_Qujjd_38o)).
 
 ![Pressing the A and B buttons](/static/mb/projects/smiley-buttons/sim.gif)
 
-## Step 1
+## {Step 1}
 
 Put in an ``||input:on button pressed||`` event to run code when button **A** is pressed.
 
@@ -19,7 +19,7 @@ def on_button_pressed_a():
 input.on_button_pressed(Button.A, on_button_pressed_a)
 ```
 
-## Step 2
+## {Step 2}
 
 Use ``||basic:show icon||`` to display a **Happy** face on the screen.
 
@@ -31,7 +31,7 @@ def on_button_pressed_a():
 input.on_button_pressed(Button.A, on_button_pressed_a)
 ```
 
-## Step 3
+## {Step 3}
 
 Use another ``||input:on button pressed||`` with a ``||basic:show icon||`` inside to display a **Sad** face when button **B** is pressed.
 
@@ -41,7 +41,7 @@ def on_button_pressed_a2():
 input.on_button_pressed(Button.B, on_button_pressed_a2)
 ```
 
-## Step 4
+## {Step 4}
 
 Add a secret mode that happens when **A** and **B** are pressed together. For this case, use ``||basic:show icon||`` multiple times to create an animation.
 
@@ -52,6 +52,6 @@ def on_button_pressed_a3():
 input.on_button_pressed(Button.AB, on_button_pressed_a3)
 ```
 
-## Step 5
+## {Step 5}
 
 Click ``|Download|`` to transfer your code to your @boardname@ (if you have one). Try buttons **A**, **B** and then **A** and **B** together.


### PR DESCRIPTION
The last step duplicates the download instructions. Scratched. Also, the numbered step headings are now hidden.

Closes #5544 