### PR TITLE
Hide numbered step headings in remaining tutorials

### DIFF
--- a/docs/projects/level.md
+++ b/docs/projects/level.md
@@ -1,13 +1,13 @@
 # Level
 
-## Introduction @unplugged
+## Is it level? @unplugged
 
 Is your table flat? Use the @boardname@ as a level!
 
 ![A level drawing](/static/mb/projects/level.png)
 
 
-## Step 1
+## {Step 1}
 
 Make a variable ``||variables:x||`` and store the ``||input:acceleration x||`` value
 in the ``||basic:forever||`` loop.
@@ -19,7 +19,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Make another variable ``||variables:y||`` and store the ``||input:acceleration y||`` value.
 
@@ -31,7 +31,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add a code to test ``||logic:if||`` the ``||Math:absolute value||`` of ``||variables:x||`` is ``||logic:greater than||`` ``32``. 
 If it is true, ``||basic:show an icon||`` to tell you that the @boardname@ is not flat, ``||logic:else||`` show nothing, for now.
@@ -49,7 +49,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Add an ``||logic:else if||`` to check that the ``||Math:absolute value||`` of ``||variables:y||`` is ``||logic:greater than||`` ``32``. 
 If it is true, ``||basic:show an icon||`` that tells you the @boardname@ is not flat.
@@ -69,7 +69,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 The code under the ``||logic:else||`` will run if both acceleration ``x`` and ``y`` are small, which happens when the @boardname@ is laying flat. Add code to ``||basic:show a happy image||``.
 
@@ -88,7 +88,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code!
 Try it out on a table, counter, or window sill in your house!

--- a/docs/projects/spy/7-seconds.md
+++ b/docs/projects/spy/7-seconds.md
@@ -2,15 +2,15 @@
 
 ### @explicitHints true
 
-## Introduction @unplugged
+## Can you react at the right time? @unplugged
 
 The goal of this game is press a button after **exactly** 7 seconds!
 
 ![A micro:bit looking at a 7 second stopwatch](/static/mb/projects/7-seconds.png)
 
-This game is inspired from the [flipping panckakes game](https://www.elecfreaks.com/blog/post/flipping-pancakes-microbit-game.html).
+This game is inspired from the [flipping pancakes game](https://www.elecfreaks.com/blog/post/flipping-pancakes-microbit-game.html).
 
-## Step 1
+## {Step 1}
 
 The player starts the timer by pressing button **A**. Add the code to run code when
 ``||input:button A is pressed||``.
@@ -21,7 +21,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 We need to remember the time when the button was pressed so that we can compute the elapsed
 time later on. Add code to store the ``||input:running time||`` in a ``||variables:start||``
@@ -35,7 +35,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Show something on the screen so that the user knows that the timer has started...
 
@@ -48,7 +48,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 The player stops the timer by pressing button **B**. Add another event to run code when
 ``||input:button B is pressed||``.
@@ -59,7 +59,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Compute the elapsed time as ``||input:running time||`` ``||math:minus||`` ``||variables:start||`` and
 store it in a new local variable (a variable only inside the event) called ``||variables:elapsed||``.
@@ -72,7 +72,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Compute the ``||variables:score||`` of the game as the ``||math:absolute value||`` of the
 ``||math:difference||`` of ``||variables:elapsed||`` time from 7 seconds, which is `7000`
@@ -87,7 +87,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 Display the score on the screen and your game is ready!
 

--- a/docs/projects/spy/coin-flipper.md
+++ b/docs/projects/spy/coin-flipper.md
@@ -2,13 +2,13 @@
 
 ### @explicitHints true
 
-## Introduction @unplugged
+## Heads or Tails? @unplugged
 
 Let's create a coin flipping program to simulate a real coin toss. We'll use icon images to represent a ``heads`` or ``tails`` result.
 
 ![Simulating coin toss](/static/mb/projects/coin-flipper/coin-flipper.gif)
 
-## Step 1
+## {Step 1}
 
 Add an event to run code when ``||input:button A pressed||``. We'll put our coin flipping
 code in here.
@@ -18,7 +18,7 @@ input.onButtonPressed(Button.A, () => {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Inside the event for ``||input:button A pressed||``, put in code to check ``||logic:if||`` a ``||math:random boolean||`` value is `true` or `false`.
 
@@ -33,7 +33,7 @@ input.onButtonPressed(Button.A, () => {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Now, ``||basic:show icon||`` for a `skull` ``||logic:if||`` the ``||math:random boolean||`` value is ``true``. This means ``heads``. ``||basic:show icon||`` of a ``square`` when ``false`` to mean
 ``tails``.
@@ -48,7 +48,7 @@ input.onButtonPressed(Button.A, () => {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Press button **A** in the simulator to try the coin toss code.
 
@@ -72,10 +72,10 @@ input.onButtonPressed(Button.A, () => {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 If you have a @boardname@, connect it to USB and click ``|Download|`` to transfer your code.
 
-## Step 7
+## {Step 7}
 
 Press button **A** for a flip. Test your luck and guess ``heads`` or ``tails`` before the toss is over!

--- a/docs/projects/spy/compass.md
+++ b/docs/projects/spy/compass.md
@@ -1,12 +1,12 @@
 # Compass
 
-## Introduction @unplugged
+## Find your direction! @unplugged
 
 This tutorial will show you how to program a script that displays which direction the @boardname@ is pointing. Let's get started!
 
 ![A cartoon of a compass](/static/mb/projects/a5-compass.png)
 
-## Step 1
+## {Step 1}
 
 Store the ``||input:compass heading||`` of the @boardname@ in a variable called ``||variables:degrees||`` in the ``||basic:forever||`` loop.
 
@@ -16,7 +16,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 ``||logic:If||`` ``||variables:degrees||`` is ``||logic:less than||`` `45`, 
 then the compass heading is mostly pointing toward **North**. ``||basic:Show||`` `N` on the @boardname@.
@@ -30,7 +30,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 ``||logic:If||`` ``||variables:degrees||`` is less than `135`, the @boardname@ is mostly pointing **East**. ``||basic:Show||`` `E` on the @boardname@.
 
@@ -46,11 +46,11 @@ basic.forever(function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Go to the simulator and rotate the @boardname@ logo to simulate changes in the compass heading.
 
-## Step 5
+## {Step 5}
 
 ``||logic:If||`` ``||variables:degrees||`` is less than `225`, the @boardname@ is mostly pointing **South**. ``||basic:Show||`` `S` on the @boardname@.
 
@@ -69,7 +69,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 ``||logic:If||`` ``||variables:degrees||`` is less than `315`, the @boardname@ is mostly pointing **West**. ``||basic:Show||`` `W` on the @boardname@.
 
@@ -89,7 +89,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 ``||logic:If||`` none of these conditions returned true, then the @boardname@ must be pointing **North** again. Display `N` on the @boardname@.
 
@@ -114,7 +114,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 8 @unplugged
+## Download @unplugged
 
 If you have a @boardname@, click `|Download|` and follow the screen instructions. 
 You will have to follow the screen instructions to calibrate your compass.

--- a/docs/projects/spy/heads-guess.md
+++ b/docs/projects/spy/heads-guess.md
@@ -2,12 +2,12 @@
 
 ### @explicitHints true
 
-## Introduction @unplugged
+## Make a Heads Up guessing game! @unplugged
 
 This is a simple remake of the famous **Heads Up!** game. The player holds the @boardname@ on the forehead and has 30 seconds to guess words displayed on the screen.
 If the guess is correct, the player tilts the @boardname@ forward; to pass, the player tilts it backwards.
 
-## Step 1
+## {Step 1}
 
 Put in code to ``||game:start a countdown||`` of 30 seconds.
 
@@ -15,7 +15,7 @@ Put in code to ``||game:start a countdown||`` of 30 seconds.
 game.startCountdown(30000)
 ```
 
-## Step 2
+## {Step 2}
 
 Create an ``||arrays:array||`` called `text_list` of words to guess. Arrays are also called lists.
 
@@ -25,7 +25,7 @@ text_list = ["PUPPY", "CLOCK", "NIGHT"]
 game.startCountdown(30000)
 ```
 
-## Step 3
+## {Step 3}
 
 Add an event to run code when a ``||input:gesture||`` points the @boardname@ ``||input:logo up||``.
 This is the gesture to get a new word.
@@ -36,7 +36,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 The items in the ``||arrays:text list||`` are numbered ``0`` to ``length - 1``.
 Add code to pick a ``||math:random||`` ``||variables:index||``.
@@ -50,7 +50,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Add code to ``||basic:show||`` the value of the item stored at ``||variables:index||`` in
 ``||arrays:text list||``.
@@ -65,7 +65,7 @@ input.onGesture(Gesture.LogoUp, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Use an event to run code when a gesture has the  @boardname@ ``||input:screen||`` is
 pointing ``||input:down||``. This is the gesture for a correct guess.
@@ -76,7 +76,7 @@ input.onGesture(Gesture.ScreenDown, function () {
 })
 ```
 
-## Step 7
+## {Step 7}
 
 Put in code to add points to the ``||game:score||``.
 
@@ -87,7 +87,7 @@ input.onGesture(Gesture.ScreenDown, function () {
 })
 ```
 
-## Step 8
+## {Step 8}
 
 Add anonther event to run code when a gesture has the @boardname@ ``||input:screen||`` is
 pointing ``||input:up||``. This is the gesture for a pass.
@@ -98,7 +98,7 @@ input.onGesture(Gesture.ScreenUp, function () {
 })
 ```
 
-## Step 9
+## {Step 9}
 
 For the pass gesture, add code to remove a ``||game:life||`` from the player.
 

--- a/docs/projects/spy/hot-potato.md
+++ b/docs/projects/spy/hot-potato.md
@@ -3,7 +3,7 @@
 ### @explicitHints true
 ### @diffs true
 
-## Introduction @unplugged
+## Pass off that potato! @unplugged
 
 In this game, you will start a timer with a random countdown of a number of seconds. When the timer is off, the game is over and whoever is holding the potato has lost!
 Watch the tutorial on the [MakeCode YouTube channel](https://youtu.be/xLEy1B_gWKY).

--- a/docs/projects/spy/level.md
+++ b/docs/projects/spy/level.md
@@ -2,14 +2,14 @@
 
 ### @explicitHints true
 
-## Introduction @unplugged
+## Is it level? @unplugged
 
 Is your table flat? Use the @boardname@ as a level!
 
 ![A level drawing](/static/mb/projects/level.png)
 
 
-## Step 1
+## {Step 1}
 
 Make a variable ``||variables:x||`` and store the ``||input:acceleration x||`` value
 in the ``||basic:forever||`` loop.
@@ -21,7 +21,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Make another variable ``||variables:y||`` and store the ``||input:acceleration y||`` value.
 
@@ -33,7 +33,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add a code to test ``||logic:if||`` the ``||Math:absolute value||`` of ``||variables:x||`` is ``||logic:greater than||`` ``32``. 
 If it is true, ``||basic:show an icon||`` to tell you that the @boardname@ is not flat, ``||logic:else||`` show nothing, for now.
@@ -51,7 +51,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Add an ``||logic:else if||`` to check that the ``||Math:absolute value||`` of ``||variables:y||`` is ``||logic:greater than||`` ``32``. 
 If it is true, ``||basic:show an icon||`` that tells you the @boardname@ is not flat.
@@ -71,7 +71,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 The code under the ``||logic:else||`` will run if both acceleration ``x`` and ``y`` are small, which happens when the @boardname@ is laying flat. Add code to ``||basic:show a happy image||``.
 
@@ -90,7 +90,7 @@ basic.forever(function() {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code!
 Try it out on a table, counter, or window sill in your house!

--- a/docs/projects/spy/stopwatch.md
+++ b/docs/projects/spy/stopwatch.md
@@ -8,7 +8,7 @@
 
 This project turns the @boardname@ into a simple stopwatch. Pressing **A** starts the timer. Pressing **B** displays the elapsed seconds.
 
-## Step 1
+## {Step 1}
 
 Add an event to run code when ``||input:button A is pressed||``.
 
@@ -17,7 +17,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Add code inside the ``||input:button A is pressed||`` event to store the current
 ``||input:running time||`` in a variable ``||variables:start||``. This is the start time.
@@ -29,7 +29,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add another event to run code when ``||input:button B is pressed||``.
 
@@ -38,7 +38,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Add code in that event to compute the difference between the ``||input:running time||`` 
 and ``||variables:value||`` time. This is the elapsed number of milliseconds since
@@ -51,7 +51,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 After setting the ``||variables:elapsed||`` time, add code to ``||basic:show||`` the
 number of milliseconds ``||variables:elapsed||``. Use ``||Math:integer division||`` to
@@ -65,11 +65,11 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Try your program in the simulator. Press **A** to start the stopwatch and press **B** to get the
 current elapsed time. You can press **B** multiple times.
 
-## Step 7
+## {Step 7}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code!

--- a/docs/projects/stopwatch.md
+++ b/docs/projects/stopwatch.md
@@ -1,12 +1,12 @@
 # Stopwatch
 
-## Introduction @unplugged
+## Time is ticking! @unplugged
 
 ![A @boardname@ stopwatch toon image](/static/mb/projects/stopwatch.png)
 
 This project turns the @boardname@ into a simple stopwatch. Pressing **A** starts the timer. Pressing **B** displays the elapsed seconds.
 
-## Step 1
+## {Step 1}
 
 Use an event to run code when ``||input:button A is pressed||``.
 
@@ -15,7 +15,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 2
+## {Step 2}
 
 Add code to store the current ``||input:running time||``
 in a variable ``||variables:start||``. This is the start time.
@@ -27,7 +27,7 @@ input.onButtonPressed(Button.A, function () {
 })
 ```
 
-## Step 3
+## {Step 3}
 
 Add an event to run code when ``||input:button B is pressed||``.
 
@@ -36,7 +36,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 4
+## {Step 4}
 
 Add code to compute the difference between the ``||input:running time||`` 
 and ``||variables:value||`` time. This is the elapsed millisecond since pressing button A.
@@ -48,7 +48,7 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 5
+## {Step 5}
 
 Add code to ``||basic:show||`` the number of milliseconds ``||variables:elapsed||``. 
 Use ``||Math:integer division||`` to divide ``||variables:elapsed||`` by ``1000`` and get seconds.
@@ -61,11 +61,11 @@ input.onButtonPressed(Button.B, function () {
 })
 ```
 
-## Step 6
+## {Step 6}
 
 Try your program in the simulator. Press **A** to start the stopwatch and press **B** to get the current elapsed time. You can press **B** multiple times.
 
-## Step 7
+## {Step 7}
 
 If you have a @boardname@ connected, click ``|Download|`` to transfer your code!
 

--- a/docs/projects/v2-play-sound.md
+++ b/docs/projects/v2-play-sound.md
@@ -1,6 +1,6 @@
 # Dance to the Beat
 
-## 1. Introduction @unplugged
+## Introduction @unplugged
 
 The new micro:bit has speakers so you can hear sounds without being tied down!
 
@@ -9,7 +9,7 @@ Let's use movement to create an electronic beat of our own.
 ![Dance beat banner message](/static/mb/projects/dance-beat.png)
 
 
-## 2. Add Play Sound Block
+## Add Play Sound Block
 
 To start your electronic beat, you'll want to repeat a sound forever.
 
@@ -28,7 +28,7 @@ basic.forever(function(){
 
 
 
-## 3. Listen Close
+## Listen Close
 
 When your code runs again, you should hear a short laser/alarm
 sound that repeats over and over forever.
@@ -41,7 +41,7 @@ sound that repeats over and over forever.
 
 
 
-## 4. Make a Change
+## Make a Change
 
 For the sound to change with your speed of movement, we need to put the
 micro:bit **acceleration** value in the sound block.
@@ -63,7 +63,7 @@ basic.forever(function(){
 
 
 
-## 5. Listen Again
+## Listen Again
 
 Run your code again.
 
@@ -74,7 +74,7 @@ You should hear the sound change as the micro:bit moves.
 
 
 
-## 6. Rotation Values
+## Rotation Values
 
 You can make the beat even more fun by changing the end frequency as the micro:bit rotates.
 
@@ -92,7 +92,7 @@ basic.forever(function(){
 
 
 
-## 7. Listen Again
+## Listen Again
 
 Run your code again.
 
@@ -108,7 +108,7 @@ Try moving the micro:bit in different ways. Can you make a fun beat?
 
 
 
-## 8. Customize Your Beat
+## Customize Your Beat
 
 Try changing the **duration** of the beat to something other than **500**. <br/>
 Then, change the dropdown selection inside both the **acceleration** and **rotation**


### PR DESCRIPTION
Hide the numbered step headings (e.g.: "Step 1") in the balance of the tutorials that remain to have this done.

Note: The "Smiley Buttons" tutorial has this done in #5738.

Closes #5545