### PR TITLE
Extension: add Lectrify Brick:Bit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -521,6 +521,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Lectrify Brick:Bit",
+  "url":"/pkg/softsmyth/lectrify-b4k",
+  "cardType": "package"
+}, {
   "name": "KittenBot TabbyBot",
   "url":"/pkg/KittenBot/pxt-tabbyrobot",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -462,7 +462,8 @@
             "eb8ga/pxt-roversa-2": { "tags": [ "Robotics" ] },
             "roborisen/gcube": { "tags": [ "Robotics" ] },
             "kittenbot/pxt-tabbyrobot": { "tags": [ "Robotics" ] },
-            "pythom1234/pxt-oled": { "tags": [ "Lights and Display" ] }
+            "pythom1234/pxt-oled": { "tags": [ "Lights and Display" ] },
+            "softsmyth/lectrify-b4k": { "tags": [ "Robotics" ] }
         },
         "upgrades": {
             "tinkertanker/pxt-iot-environment-kit": "min:v4.2.1",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/74782 (private)
@softsmyth
@abchatra

Extension: https://github.com/softsmyth/lectrify-b4k
All blocks: https://makecode.microbit.org/_2AmUK9J0LUx6

![image](https://github.com/user-attachments/assets/05f797c4-3e7d-4caa-b45a-13986e54e762)
