### PR TITLE
Move uBit.logo usage to uBit.io.logo

### DIFF
--- a/libs/core/logo.cpp
+++ b/libs/core/logo.cpp
@@ -26,7 +26,7 @@ namespace input {
     //% help="input/on-logo-event"
     void onLogoEvent(TouchButtonEvent action, Action body) {
 #if MICROBIT_CODAL
-        registerWithDal(uBit.logo.id, action, body);
+        registerWithDal(uBit.io.logo.id, action, body);
 #else
         target_panic(PANIC_VARIANT_NOT_SUPPORTED);
 #endif
@@ -43,7 +43,7 @@ namespace input {
     //% help="input/logo-is-pressed"
     bool logoIsPressed() {
 #if MICROBIT_CODAL
-        return uBit.logo.isPressed();
+        return uBit.io.logo.isTouched();
 #else
         target_panic(PANIC_VARIANT_NOT_SUPPORTED);
         return false;


### PR DESCRIPTION
As `uBit.logo` is a `TouchButton` instance that does not work well in resistive mode. Since CODAL v0.2.67 `uBit.io.logo `has the touch functionality needed for all existing MakeCode blocks.

This fixes the issue where changing the logo touch type to resistive didn't work correctly.

Fixes https://github.com/microsoft/pxt-microbit/issues/3724

Setting this as a draft PR since it needs the CODAL tag to be updated to v0.2.67 first, and I believe that might be tackled in a different PR by a member of the MakeCode team.