### PR TITLE
Actually pass the flags for message bus listeners

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -98,7 +98,7 @@ static void initCodal() {
 
 void registerWithDal(int id, int event, Action a, int flags) {
     uBit.messageBus.ignore(id, event, dispatchForeground);
-    uBit.messageBus.listen(id, event, dispatchForeground, a);
+    uBit.messageBus.listen(id, event, dispatchForeground, a, (uint16_t) flags);
     incr(a);
     registerGCPtr(a);
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "12.0.1",
-        "pxt-core": "10.0.23"
+        "pxt-common-packages": "12.0.3",
+        "pxt-core": "10.2.3"
     }
 }

--- a/sim/state/misc.ts
+++ b/sim/state/misc.ts
@@ -35,7 +35,7 @@ namespace pxsim.basic {
 namespace pxsim.control {
     export var inBackground = thread.runInBackground;
 
-    export function onEvent(id: number, evid: number, handler: RefAction) {
+    export function onEvent(id: number, evid: number, handler: RefAction, flags: number) {
         if (id == DAL.MICROBIT_ID_BUTTON_AB) {
             const b = board().buttonPairState;
             if (!b.usesButtonAB) {
@@ -43,7 +43,7 @@ namespace pxsim.control {
                 runtime.queueDisplayUpdate();
             }
         }
-        pxtcore.registerWithDal(id, evid, handler)
+        pxtcore.registerWithDal(id, evid, handler, flags)
     }
 
     export function eventTimestamp() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5709

This PR requires https://github.com/microsoft/pxt/pull/10054 and https://github.com/microsoft/pxt-common-packages/pull/1483 to be merged+bumped.

This PR simply passes the message bus flags passed to control.onEvent() to the corresponding codal function and enables simulator support for the same flags.