### PR TITLE
Bring event block after "on-start"

### DIFF
--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -299,7 +299,7 @@ namespace control {
      * Registers an event handler.
      */
     //% weight=20 blockGap=8 blockId="control_on_event" block="on event|from %src=control_event_source_id|with value %value=control_event_value_id"
-    //% help=control/on-event
+    //% help=control/on-event afterOnStart=true
     //% blockExternalInputs=1
     void onEvent(int src, int value, Action handler, int flags = 0) {
         if (!flags) flags = ::EventFlags::QueueIfBusy;

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -252,7 +252,7 @@ namespace pins {
     * @param name digital pin to register to, eg: DigitalPin.P0
     * @param pulse the value of the pulse, eg: PulseValue.High
     */
-    //% help=pins/on-pulsed advanced=true
+    //% help=pins/on-pulsed advanced=true afterOnStart=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
     //% pin.shadow=digital_pin
     //% group="Pulse"

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -416,7 +416,7 @@ declare namespace control {
      * Registers an event handler.
      */
     //% weight=20 blockGap=8 blockId="control_on_event" block="on event|from %src=control_event_source_id|with value %value=control_event_value_id"
-    //% help=control/on-event
+    //% help=control/on-event afterOnStart=true
     //% blockExternalInputs=1 flags.defl=0 shim=control::onEvent
     function onEvent(src: int32, value: int32, handler: () => void, flags?: int32): void;
 
@@ -755,7 +755,7 @@ declare namespace pins {
      * @param name digital pin to register to, eg: DigitalPin.P0
      * @param pulse the value of the pulse, eg: PulseValue.High
      */
-    //% help=pins/on-pulsed advanced=true
+    //% help=pins/on-pulsed advanced=true afterOnStart=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
     //% pin.shadow=digital_pin
     //% group="Pulse"


### PR DESCRIPTION
#5700 
> This is because unfortunately the code generation can end up placing the event handler code on top of the "on start" code, and so we might end up with an undefined variable:

block
![block](https://github.com/user-attachments/assets/78583481-df5a-4e3c-b092-876f9c564d76)

before
![before](https://github.com/user-attachments/assets/d9669c58-15a3-47b8-aa8b-f4f731f67308)

after
![after](https://github.com/user-attachments/assets/951e4417-63cb-4fc5-8d17-d1c81be85d1f)

@microbit-carlos @abchatra 