### PR TITLE
Hide heading in 'Coin Flipper' tutorial

### DIFF
--- a/docs/projects/spy/coin-flipper.md
+++ b/docs/projects/spy/coin-flipper.md
@@ -52,7 +52,7 @@ input.onButtonPressed(Button.A, () => {
 
 Press button **A** in the simulator to try the coin toss code.
 
-## Step 5
+## {Step 5}
 
 You can animate the coin toss to add the feeling of suspense. ``||basic:show||`` different
 icons before the check of the ``||math:random boolean||`` value to show that the


### PR DESCRIPTION
As a small oversight, one heading was missed in the batch from #5739.

Closes #5545