### PR TITLE
Extension: add Nezha V2

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -812,6 +812,18 @@ Many extensions are available to work with interface kits, add-on hardware, or o
   "name": "TinkerTanker Stepper Motor",
   "url":"/pkg/Tinkertanker/pxt-stepper-motor",
   "cardType": "package"
+}, {
+  "name": "ALS Robot Keyboard",
+  "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotKeyboard",
+  "cardType": "package"
+}, {
+    "name": "Elecfreaks NeZha",
+    "url": "/pkg/elecfreaks/pxt-nezha",
+    "cardType": "package"
+}, {
+    "name": "Elecfreaks NeZha V2",
+    "url": "/pkg/elecfreaks/pxt-nezha2",
+    "cardType": "package"
 }]
 ```
 
@@ -1079,13 +1091,5 @@ Many extensions are available to work with interface kits, add-on hardware, or o
   "name": "Proportional Font",
   "url":"/pkg/lwchkg/pxt-proportional-font",
   "cardType": "package"
-}, {
-  "name": "ALS Robot Keyboard",
-  "url":"/pkg/alsrobot-microbit-makecode-packages/ALSRobotKeyboard",
-  "cardType": "package"
-}, {
-    "name": "Elecfreaks NeZha",
-    "url": "/pkg/elecfreaks/pxt-nezha",
-    "cardType": "package"
 }]
 ```

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -280,6 +280,7 @@
                 "upgrades": [ "min:v0.13.1" ]
             },
             "elecfreaks/pxt-nezha": { "tags": [ "Robotics" ] },
+            "elecfreaks/pxt-nezha2": { "tags": [ "Robotics" ] },
             "philipphenkel/pxt-powerfunctions": {},
             "1010technologies/pxt-makerbit-ir-transmitter": {},
             "dfrobot/pxt-dfrobot_huskylens": { "tags": [ "Science" ] },


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/79816 (private)

@DeXin64
Please change "Angular value" to "angular value" 

@abchatra 
This PR also moves 2 misplaced extensions in the gallery, from Utilities to Robotics.
 
Extension: https://github.com/elecfreaks/pxt-nezha2
Product: https://shop.elecfreaks.com/products/nezha-breakout-board-v2
All blocks project: https://makecode.microbit.org/_1wp7hWKszDwA

![image](https://github.com/user-attachments/assets/10ca6a8c-5b5d-42d2-9072-2cf67752d5cc)
