### PR TITLE
Reenable uploadDocs flag

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -629,5 +629,5 @@
             }
         }
     },
-    "uploadDocs": false
+    "uploadDocs": true
 }


### PR DESCRIPTION
should cover fixing https://github.com/microsoft/pxt-microbit/issues/5716 but will validate after it's merged / ci uploads

@riknoll was there anything remaining on crowdin v2 upgrades? looks like flag is off in arcade as well