### PR TITLE
add dialog for when program too big for v2

### DIFF
--- a/editor/dialogs.tsx
+++ b/editor/dialogs.tsx
@@ -16,7 +16,18 @@ export function cantImportAsync(project: pxt.editor.IProjectView) {
 
 
 export async function showProgramTooLargeErrorAsync(variants: string[], confirmAsync: (opts: any) => Promise<number>, saveOnly?: boolean) {
-    if (variants.length !== 2) return undefined;
+    if (variants.length !== 2) {
+        if (variants[0] !== "mbcodal") return undefined;
+        await confirmAsync({
+            header: lf("Oops, there was a problem downloading your code"),
+            body: lf("Great coding skills! Unfortunately, your program is too large to fit on a micro:bit V2😢. You can go back and try to make your program smaller, or continue to use the simulator to run your code."),
+            bigHelpButton: true,
+            agreeLbl: lf("Go Back"),
+            agreeClass: "positive",
+            agreeIcon: "cancel",
+        });
+        return undefined
+    }
 
     if (pxt.packetio.isConnected() && pxt.packetio.deviceVariant() === "mbcodal" && !saveOnly) {
         // connected micro:bit V2 will be flashed; don't give warning dialog


### PR DESCRIPTION
Give an error dialog when a program is too big for v2: 

![image](https://github.com/user-attachments/assets/0ec1bb8c-3cec-48d8-b287-189925772997)

wording intended to be similar to the 'too big for v1' one just below, but any wordsmithing appreciated.

re: https://github.com/microsoft/pxt-microbit/issues/5396, moving off milestone with this but not closing -- this addresses the intent of the original issue / why it was marked, but the specific problem there is basically https://github.com/microsoft/pxt-microbit/issues/5403; if we have time before release we should address that (e.g. add a 'parts override' field to hardware in pxtarget json, which lets you specify `flashEnd` per enabled part) but not guaranteed.

'way too big' version of program https://makecode.microbit.org/_6oaTMe08Yc7b

requires https://github.com/microsoft/pxt/pull/10090