### PR TITLE
webusb: when connecting, send a few commands to flush commands

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -315,7 +315,9 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         // before calling into dapjs, we use our dapCmdNums() a few times, which which will make sure the responses
         // to commends from previous sessions (if any) are flushed
         for (let i = 0; i < 3; i++) {
-            await this.getDaplinkVersionAsync()
+            try {
+                await this.getDaplinkVersionAsync();
+            } catch (e) {}
         }
 
         // halt before reading from dap

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -312,8 +312,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         await this.io.reconnectAsync()
 
-        // before calling into dapjs, we use our dapCmdNums() a few times, which which will make sure the responses
-        // to commends from previous sessions (if any) are flushed
+        // before calling into dapjs, push through a commands to make sure the responses
+        // to commands from previous sessions (if any) are flushed
         for (let i = 0; i < 3; i++) {
             try {
                 await this.getDaplinkVersionAsync();

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -314,7 +314,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         // before calling into dapjs, push through a commands to make sure the responses
         // to commands from previous sessions (if any) are flushed
-        for (let i = 0; i < 3; i++) {
+        for (let i = 0; i < 5; i++) {
             try {
                 await this.getDaplinkVersionAsync();
             } catch (e) {}

--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -312,8 +312,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         await this.io.reconnectAsync()
 
-        // before calling into dapjs, push through a commands to make sure the responses
-        // to commands from previous sessions (if any) are flushed
+        // before calling into dapjs, push through a few commands to make sure the responses
+        // to commands from previous sessions (if any) are flushed. Count of 5 is arbitrary.
         for (let i = 0; i < 5; i++) {
             try {
                 await this.getDaplinkVersionAsync();


### PR DESCRIPTION
On my machine with a teams call & full server (watched pxt build / pxt serve) I was able to repro the 5 -> 131 almost 100% of the time when refreshing the same page (turns out having an old device helped a bit!). After poking at it for a bit, this fix of moving "command flushing" up / repeating it a few times to ensure it's cleared seems to have fixed that 100% on my machine in that scenario. I don't have as good of repro cases for the other issues but trying to get repros on the other scenarios now.

(test program i was using, modified from a previous one to be more spammy https://makecode.microbit.org/_5j14oYbeTcCC)

I believe this should actually cover the cases that the more comprehensive suggestion in https://github.com/microsoft/pxt-microbit/issues/5530 handles; our typical tactic for errors in operations is 'throw up hands and reconnect when things misbehave', so clearing through this does largely the same without spreading the logic throughout the app (and if not, first step would be to add reconnect attempts in those scenarios.)

