### PR TITLE
support exponents properly in v2

### DIFF
--- a/libs/core/_locales/core-jsdoc-strings.json
+++ b/libs/core/_locales/core-jsdoc-strings.json
@@ -37,7 +37,7 @@
   "Array.reduce": "Call the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.",
   "Array.reduce|param|callbackfn": "A function that accepts up to three arguments. The reduce method calls the callbackfn function one time for each element in the array.",
   "Array.reduce|param|initialValue": "Initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.",
-  "Array.removeAt": "Remove the element at a certain index.",
+  "Array.removeAt": "Remove and return the element at a certain index.",
   "Array.removeElement": "Remove the first occurence of an object. Returns true if removed.",
   "Array.reverse": "Reverse the elements in an array. The first array element becomes the last, and the last array element becomes the first.",
   "Array.set": "Store a value at a particular index",

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -254,6 +254,7 @@
   "SoundExpressionPlayMode.InBackground|block": "in background",
   "SoundExpressionPlayMode.UntilDone|block": "until done",
   "String.charAt|block": "char from %this=text|at %pos",
+  "String.charCodeAt|block": "char code from $this=text|at $index",
   "String.compare|block": "compare %this=text| to %that",
   "String.fromCharCode|block": "text from char code %code",
   "String.includes|block": "%this=text|includes %searchValue",

--- a/libs/core/platform.h
+++ b/libs/core/platform.h
@@ -2,4 +2,3 @@
 
 // helpful define to handle C++ differences in package
 #define PXT_MICROBIT_TAGGED_INT 1
-#define PXT_POWI 1

--- a/libs/core/pxtcore.h
+++ b/libs/core/pxtcore.h
@@ -23,6 +23,7 @@ void debuglog(const char *format, ...);
 #define MICROBIT_CODAL 0
 #define GC_MAX_ALLOC_SIZE 9000
 #define GC_BLOCK_SIZE 256
+#define PXT_POWI 1
 #endif
 
 #if !MICROBIT_CODAL


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5584

The `PXT_POWI` define is used to prevent us from pulling in the stdlib's pow implementation, which increases code size by enough to be a problem on v1. This PR moves that define so that it's only used on the v1, since v2 doesn't have this problem.

I also went ahead and checked in the updated strings file since i saw there were a couple changes