### PR TITLE
Clear previous commands before starting flash as well

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -312,13 +312,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
 
         await this.io.reconnectAsync()
 
-        // before calling into dapjs, push through a few commands to make sure the responses
-        // to commands from previous sessions (if any) are flushed. Count of 5 is arbitrary.
-        for (let i = 0; i < 5; i++) {
-            try {
-                await this.getDaplinkVersionAsync();
-            } catch (e) {}
-        }
+        await this.clearCommandsAsync()
 
         // halt before reading from dap
         // to avoid interference from data logger
@@ -353,6 +347,16 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
         this.io.onConnectionChanged()
         // start jacdac, serial async
         this.startReadSerial(connectionId)
+    }
+
+    private async clearCommandsAsync() {
+        // before calling into dapjs, push through a few commands to make sure the responses
+        // to commands from previous sessions (if any) are flushed. Count of 5 is arbitrary.
+        for (let i = 0; i < 5; i++) {
+            try {
+                await this.getDaplinkVersionAsync();
+            } catch (e) {}
+        }
     }
 
     private async getDaplinkVersionAsync() {
@@ -402,6 +406,7 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             await this.io.reconnectAsync();
         }
 
+        await this.clearCommandsAsync()
         await this.stopReadersAsync();
         await this.cortexM.init();
         await this.cortexM.reset(true);


### PR DESCRIPTION
Was seeing some failures along this path with e.g. 5->0 output while reproducing the memory leak, clearing in the same way as https://github.com/microsoft/pxt-microbit/pull/5843 appears to mitigate this path as well on my device as a stopgap.