### PR TITLE
Use new decompiler shadow alias attribute

### DIFF
--- a/libs/core/pins.ts
+++ b/libs/core/pins.ts
@@ -19,6 +19,7 @@ namespace pins {
     //% weight=17
     //% blockGap=8
     //% advanced=true
+    //% decompilerShadowAlias=digital_pin_shadow
     export function _digitalPin(pin: DigitalPin): number {
         return pin;
     }
@@ -37,6 +38,7 @@ namespace pins {
     //% weight=16
     //% blockGap=8
     //% advanced=true
+    //% decompilerShadowAlias=analog_pin_shadow
     export function _analogPin(pin: AnalogPin): number {
         return pin;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5834

This requires https://github.com/microsoft/pxt/pull/10129 to work, but is safe to merge without.

basically tells the decompiler to map one block to another in the situation where doing so would create a shadow block. the only difference between the shadow and non-shadow versions of these blocks is that the non-shadow versions have extra text that looks bad when used in place of a shadow block.