### PR TITLE
clear readers before clearing rest of buffer

### DIFF
--- a/editor/flash.ts
+++ b/editor/flash.ts
@@ -406,8 +406,8 @@ class DAPWrapper implements pxt.packetio.PacketIOWrapper {
             await this.io.reconnectAsync();
         }
 
-        await this.clearCommandsAsync()
         await this.stopReadersAsync();
+        await this.clearCommandsAsync()
         await this.cortexM.init();
         await this.cortexM.reset(true);
         await this.checkStateAsync();


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/5870, clear readers clearing buffer. Surprised it only showed up on v1 and that v2 microbit doesn't run into this same issue.