### PR TITLE
Disable "Reload on Update" for teacher tool iframes

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -624,7 +624,8 @@
         "teachertool=1": {
             "appTheme": {
                 "hideMenuBar": true,
-                "workspaceSearch": true
+                "workspaceSearch": true,
+                "noReloadOnUpdate": true
             }
         }
     },


### PR DESCRIPTION
Per https://github.com/microsoft/pxt/pull/10120, this adds the noReloadOnUpdate flag to our teachertool query variant, which gets added to the url passed into the iframe on the teacher tool.

When this is set, the webapp won't automatically reload when the service worker updates, which was causing unloaded projects (https://github.com/microsoft/pxt-microbit/issues/5824) and a breakdown in communication between the teacher tool and the webapp (https://github.com/microsoft/pxt-microbit/issues/5822).

We'll have to manually handle the reload in the teacher tool, but that will be a separate change in pxt.