### PR TITLE
Revert the pin pulse event

### DIFF
--- a/editor/patch.ts
+++ b/editor/patch.ts
@@ -24,7 +24,6 @@ export function patchBlocks(pkgTargetVersion: string, dom: Element) {
             .concat(pxt.U.toArray(dom.querySelectorAll("shadow[type=device_get_analog_pin]")))
             .concat(pxt.U.toArray(dom.querySelectorAll("block[type=device_set_analog_pin]")))
             .concat(pxt.U.toArray(dom.querySelectorAll("block[type=device_set_analog_period]")))
-            .concat(pxt.U.toArray(dom.querySelectorAll("block[type=pins_on_pulsed]")))
             .concat(pxt.U.toArray(dom.querySelectorAll("block[type=pins_pulse_in]")))
             .concat(pxt.U.toArray(dom.querySelectorAll("shadow[type=pins_pulse_in]")))
             .concat(pxt.U.toArray(dom.querySelectorAll("block[type=device_set_servo_pin]")))
@@ -51,7 +50,6 @@ export function patchBlocks(pkgTargetVersion: string, dom: Element) {
                             case "pin_set_audio_pin":
                                 return oldPinNode.getAttribute("name") === "name";
                             case "device_set_analog_period":
-                            case "pins_on_pulsed":
                             case "device_set_pull":
                             case "device_set_pin_events":
                             case "pin_neopixel_matrix_width":

--- a/libs/core/blocks-test/pins.blocks
+++ b/libs/core/blocks-test/pins.blocks
@@ -1,10 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <block type="pins_on_pulsed" x="-157" y="130">
-    <value name="pin">
-      <shadow type="digital_pin">
-    <field name="pin">DigitalPin.P5</field>
-      </shadow>
-    </value>
+    <field name="pin">DigitalPin.P10</field>
     <field name="pulse">PulseValue.Low</field>
     <statement name="HANDLER">
       <block type="device_set_analog_pin">

--- a/libs/core/blocks-test/test.blocks
+++ b/libs/core/blocks-test/test.blocks
@@ -538,11 +538,7 @@
     </statement>
   </block>
   <block type="pins_on_pulsed" x="1538" y="929">
-    <value name="pin">
-      <shadow type="digital_pin">
-        <field name="pin">DigitalPin.P10</field>
-      </shadow>
-    </value>
+    <field name="pin">DigitalPin.P10</field>
     <field name="pulse">PulseValue.Low</field>
     <statement name="HANDLER">
       <block type="i2c_writenumber">

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -241,11 +241,12 @@ namespace pins {
     */
     //% help=pins/on-pulsed advanced=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
-    //% pin.shadow=digital_pin_shadow
+    //% pin.fieldEditor="gridpicker" pin.fieldOptions.columns=4
+    //% pin.fieldOptions.tooltips="false" pin.fieldOptions.width="250"
     //% group="Pulse"
     //% weight=25
     //% blockGap=8
-    void onPulsed(int name, PulseValue pulse, Action body) {
+    void onPulsed(DigitalPin name, PulseValue pulse, Action body) {
         MicroBitPin* pin = getPin((int)name);
         if (!pin) return;
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -682,7 +682,7 @@ declare namespace music {
      */
     //% blockId=music_sound_is_playing block="sound is playing"
     //% group="micro:bit (V2)"
-    //% help=music/volume
+    //% help=music/is-sound-playing
     //% weight=0 shim=music::isSoundPlaying
     function isSoundPlaying(): boolean;
 
@@ -757,11 +757,12 @@ declare namespace pins {
      */
     //% help=pins/on-pulsed advanced=true
     //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
-    //% pin.shadow=digital_pin_shadow
+    //% pin.fieldEditor="gridpicker" pin.fieldOptions.columns=4
+    //% pin.fieldOptions.tooltips="false" pin.fieldOptions.width="250"
     //% group="Pulse"
     //% weight=25
     //% blockGap=8 shim=pins::onPulsed
-    function onPulsed(name: int32, pulse: PulseValue, body: () => void): void;
+    function onPulsed(name: DigitalPin, pulse: PulseValue, body: () => void): void;
 
     /**
      * Get the duration of the last pulse in microseconds. This function should be called from a ``onPulsed`` handler.


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/5878

Reverting the on pulse event so that it no longer accepts a variable given that using a variable doesn't actually work.

Looks like someone didn't check in a change to the shims file, you can safely ignore the change to `is-sound-playing`