### PR TITLE
Add reference pages for the built-in melody accessors

### DIFF
--- a/docs/reference/music/built-in-melody.md
+++ b/docs/reference/music/built-in-melody.md
@@ -1,0 +1,51 @@
+# built In Melody
+
+Get a melody string for a built-in melody.
+
+```sig
+music.builtInMelody(Melodies.Dadadadum)
+```
+
+A collection of built-in melodies are available. You choose one by selecting the name of the melody.
+
+## Parameters
+
+* **melody**: A melody name. The available melodies are:
+
+>* `dadadum`
+>* `entertainer`
+>* `prelude`
+>* `ode`
+>* `nyan`
+>* `ringtone`
+>* `funk`
+>* `blues`
+>* `birthday`
+>* `wedding`
+>* `funeral`
+>* `punchline`
+>* `baddy`
+>* `chase`
+>* `ba ding`
+>* `wawawawaa`
+>* `jump up`
+>* `jump down`
+>* `power up`
+>* `power down`
+
+## Returns
+
+* a [string](/types/string) that contains the melody.
+
+## Example
+
+Play the built-in melody for **blues**.
+
+```blocks
+music.startMelody(music.builtInMelody(Melodies.Blues), MelodyOptions.Once)
+```
+
+## See also
+
+[start melody](/reference/music/start-melody),
+[built-in sound effect](/reference/music/builtin-sound-effect)

--- a/docs/reference/music/built-in-playable-melody.md
+++ b/docs/reference/music/built-in-playable-melody.md
@@ -1,0 +1,50 @@
+# built In Playable Melody
+
+Get a playable sound object for a built-in melody.
+
+```sig
+music.builtInPlayableMelody(Melodies.Dadadadum)
+```
+
+A collection of built-in melodies are available as [playable](/types/playable) sound objects. You choose one by selecting the name of the melody.
+
+## Parameters
+
+* **melody**: A melody name. The available melodies are:
+
+>* `dadadum`
+>* `entertainer`
+>* `prelude`
+>* `ode`
+>* `nyan`
+>* `ringtone`
+>* `funk`
+>* `blues`
+>* `birthday`
+>* `wedding`
+>* `funeral`
+>* `punchline`
+>* `baddy`
+>* `chase`
+>* `ba ding`
+>* `wawawawaa`
+>* `jump up`
+>* `jump down`
+>* `power up`
+>* `power down`
+
+## Returns
+
+* a [playable](/types/playable) object that contains the melody.
+
+## Example
+
+Play the built-in melody for **blues**.
+
+```blocks
+music.play(music.builtInPlayableMelody(Melodies.Blues), music.PlaybackMode.InBackground)
+```
+
+## See also
+
+[built-in sound effect](/reference/music/builtin-sound-effect)

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -323,7 +323,7 @@ namespace music {
      * Gets the melody array of a built-in melody.
      * @param name the note name, eg: Note.C
      */
-    //% weight=50 help=music/builtin-melody
+    //% weight=50 help=music/built-in-melody
     //% blockId=device_builtin_melody block="%melody"
     //% blockHidden=true
     //% group="Melody Advanced"
@@ -336,7 +336,7 @@ namespace music {
      * Gets the melody array of a built-in melody.
      * @param melody the melody name
      */
-    //% weight=60 help=music/builtin-melody
+    //% weight=60 help=music/built-in-playable-melody
     //% blockId=device_builtin_melody_playable block="melody $melody"
     //% toolboxParent=music_playable_play_default_bkg
     //% toolboxParentArgument=toPlay


### PR DESCRIPTION
Reference pages added for the `music.builtInPlayableMelody()` and `music.builtInMelody()` melody object return functions.

Closes #5866