### PR TITLE
Reference pages for pin number shadow functions

### DIFF
--- a/docs/reference/pins/analog-pin.md
+++ b/docs/reference/pins/analog-pin.md
@@ -1,0 +1,32 @@
+# analog Pin
+
+Get an analog pin number for a pin identifier.
+
+```sig
+pins._analogPin(AnalogPin.P0)
+```
+
+## Parameters
+
+* **pin**: a pin identifier for an analog pin (`P0` through `P20`).
+
+## Returns
+
+* a pin [number](/types/number) for the pin identifier.
+
+## Example
+
+Set an analog pin variable for `P1`, read pin `P1`, and show the input value on the LED screen.
+
+```blocks
+let myPin = AnalogPin.P1
+basic.forever(function() {
+    let value = pins.analogReadPin(myPin)
+    basic.showNumber(value)
+})
+```
+
+## See also
+
+[analog read pin](/reference/pins/analog-read-pin),
+[analog write pin](/reference/pins/analog-write-pin)

--- a/docs/reference/pins/digital-pin.md
+++ b/docs/reference/pins/digital-pin.md
@@ -1,0 +1,43 @@
+# digital Pin
+
+Get an digital pin number for a pin identifier.
+
+```sig
+pins._digitalPin(DigitalPin.P3)
+```
+
+## Parameters
+
+* **pin**: a pin identifier for an digital pin (`P0` through `P20`).
+
+## Returns
+
+* a pin [number](/types/number) for the pin identifier.
+
+## Example: football score keeper
+
+This program reads pin `P0` to find when a goal is scored. When `P0`
+is `1`, the program makes the score bigger and plays a buzzer sound
+through `P2` with ``||pins:digital write pin||``. Use pin variables
+to set the read and write pin numbers.
+
+```blocks
+let score = 0
+let readPin = DigitalPin.P0
+let writePin = DigitalPin.P2
+basic.showNumber(score)
+basic.forever(() => {
+    if (pins.digitalReadPin(readPin) == 1) {
+        score++;
+        pins.digitalWritePin(writePin, 1)
+        basic.showNumber(score)
+        basic.pause(1000)
+        pins.digitalWritePin(writePin, 0)
+    }
+})
+```
+
+## See also
+
+[digital read pin](/reference/pins/digital-read-pin),
+[digital write pin](/reference/pins/digital-write-pin)


### PR DESCRIPTION
Add reference pages for the pin accessor functions `_analogPin()` and `_digitalPin()`. Help paths were already set/correct, no need to update.

Closes #5859