### PR TITLE
Extension: fix gallery path to pxt-MatrixMicro

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -598,7 +598,7 @@ Many extensions are available to work with interface kits, add-on hardware, or o
   "cardType": "package"
 }, {
   "name": "MATRIX Micro",
-  "url":"/pkg/pxt-MatrixMicro",
+  "url":"/pkg/matrix-robotics/pxt-MatrixMicro",
   "cardType": "package"
 }, {
   "name": "PTKidsBIT",


### PR DESCRIPTION
@abchatra This adds the user/organisation part to the path in the extension gallery.
https://github.com/microsoft/pxt-microbit/blob/174754547ef71cb3131aac43d30d6d5f9ac6cbe6/docs/extensions/extension-gallery.md?plain=1#L601

to match

https://github.com/microsoft/pxt-microbit/blob/174754547ef71cb3131aac43d30d6d5f9ac6cbe6/targetconfig.json#L394