### PR TITLE
bumped codal to v0.2.68

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -200,7 +200,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.2.67",
+                    "branch": "v0.2.68",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
Workaround to fix:
- https://github.com/microsoft/pxt-microbit/issues/5913

Cannot test locally due to:
- https://github.com/microsoft/pxt-microbit/issues/5915

Minimal diff, nothing for codal-core, codal-nrf52, nor codal-microbit-nrf5sdk/. The diff for codal-microbit-v2 only includes an extra bug fix for datalogging:
- https://github.com/lancaster-university/codal-microbit-v2/compare/v0.2.67...v0.2.68