### PR TITLE
flashlog needs new sim functions

### DIFF
--- a/sim/state/flashlog.ts
+++ b/sim/state/flashlog.ts
@@ -162,4 +162,12 @@ namespace pxsim.flashlog {
         init();
         mirrorToSerial = !!enabled;
     }
+
+    export function getNumberOfRows(fromRowIndex = 0): number {
+        return 0 // TODO
+    }
+
+    export function getRows(fromRowIndex: number, nRows: number): string {
+        return "" // TODO
+    }
 }


### PR DESCRIPTION
- this requires quite a bit of work to get CSV file back from persistent storage.   
- for now, just leave stubs with TODO to avoid runtime error