### PR TITLE
Remove RNG seed call in platform_init().

### DIFF
--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -50,7 +50,6 @@ MicroBitEvent lastEvent;
 bool serialLoggingDisabled;
 
 void platform_init() {
-    microbit_seed_random();
     int seed = microbit_random(0x7fffffff);
     DMESG("random seed: %d", seed);
     seedRandom(seed);


### PR DESCRIPTION
This call is not needed, as the random number generator is already seeded in uBit.init().

This also resolves/works-around this issue (more info in https://github.com/microsoft/pxt-microbit/issues/5409#issuecomment-2349284769), which might take a while before we fix it in DAL:
- https://github.com/microsoft/pxt-microbit/issues/5409

Apart from that, this is a costly call, specially in V1 where it takes 50 microsec or more, and in theory could take up to 480 us.