### PR TITLE
Match music play hints with toolbox blocks in 'V2 Hamster'

### DIFF
--- a/docs/projects/v2-countdown.md
+++ b/docs/projects/v2-countdown.md
@@ -99,7 +99,7 @@ for (let index = 0; index <= 2; index++) {
     basic.showNumber(3 - index)
 }
 // @highlight
-music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
+music.play(music.tonePlayable(392, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
 basic.showString("GO!")
 ```
 
@@ -114,7 +114,7 @@ for (let index = 0; index <= 2; index++) {
     music.play(music.tonePlayable(262, music.beat(BeatFraction.Quarter)), music.PlaybackMode.UntilDone)
     basic.showNumber(3 - index)
 }
-music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
+music.play(music.tonePlayable(392, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
 basic.showString("GO!")
 ```
 

--- a/docs/projects/v2-pet-hamster.md
+++ b/docs/projects/v2-pet-hamster.md
@@ -39,7 +39,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
     basic.showIcon(IconNames.Happy)
     //@highlight
-    music.play(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
 })
 ```
 
@@ -67,7 +67,7 @@ input.onGesture(Gesture.Shake, function () {
 input.onGesture(Gesture.Shake, function () {
     basic.showIcon(IconNames.Sad)
     //@highlight
-    music.play(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
 })
 ```
 
@@ -81,13 +81,13 @@ Let's ensure that Cyrus will always go back to sleep after being shaken or tickl
 ```blocks
 input.onGesture(Gesture.Shake, function () {
     basic.showIcon(IconNames.Sad)
-    music.play(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
     //@highlight
     basic.showIcon(IconNames.Asleep)
 })
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
     basic.showIcon(IconNames.Happy)
-    music.play(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
 })
 basic.showIcon(IconNames.Asleep)
 ```
@@ -99,12 +99,12 @@ basic.showIcon(IconNames.Asleep)
 ```blocks
 input.onGesture(Gesture.Shake, function () {
     basic.showIcon(IconNames.Sad)
-    music.play(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
     basic.showIcon(IconNames.Asleep)
 })
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
     basic.showIcon(IconNames.Happy)
-    music.play(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
     //@highlight
     basic.showIcon(IconNames.Asleep)
 })
@@ -124,12 +124,12 @@ If you have a new @boardname@ (the one with the **shiny gold** logo at the top),
 ```blocks
 input.onGesture(Gesture.Shake, function () {
     basic.showIcon(IconNames.Sad)
-    music.play(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.Wawawawaa), music.PlaybackMode.UntilDone)
     basic.showIcon(IconNames.Asleep)
 })
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
     basic.showIcon(IconNames.Happy)
-    music.play(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
+    music._playDefaultBackground(music.builtInPlayableMelody(Melodies.JumpUp), music.PlaybackMode.UntilDone)
     basic.showIcon(IconNames.Asleep)
 })
 basic.showIcon(IconNames.Asleep)

--- a/docs/projects/v2-pet-hamster.md
+++ b/docs/projects/v2-pet-hamster.md
@@ -33,7 +33,7 @@ input.onLogoEvent(TouchButtonEvent.Pressed, function () {
 
 ## {Tickle sound}
 
-► From the ``||music:Music||`` category, get a ``||music:play melody [jump up] [in background]||`` and add it to the **bottom** of your ``||input:on logo [pressed]||`` container. Change the playback mode to ``||music:[until done]||``.
+► From the ``||music:Music||`` category, get a ``||music:play [melody jump up] [in background]||`` and add it to the **bottom** of your ``||input:on logo [pressed]||`` container. Change the playback mode to ``||music:[until done]||``.
 
 ```blocks
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {
@@ -60,7 +60,7 @@ input.onGesture(Gesture.Shake, function () {
 
 ## {Dizzy sound}
 
-► From the ``||music:Music||`` category, find the ``||music:play melody [dadadum] [in background]||`` block and add it to the **bottom** of your ``||input:on [shake]||`` container. Change the playback mode to ``||music:[until done]||``.
+► From the ``||music:Music||`` category, find the ``||music:play [melody dadadum] [in background]||`` block and add it to the **bottom** of your ``||input:on [shake]||`` container. Change the playback mode to ``||music:[until done]||``.
 ► Click on the **dropdown** and set it so Cyrus plays a sad sound until done.
 
 ```blocks


### PR DESCRIPTION
The `play()` function in the hints mismatched with `_playDefaultBackground()` from the toolbox blocks causing code validation to fail for valid blocks. The `play()` functions in the hints are changed to match.

Closes #5940 