### PR TITLE
add a simulator extension registration to targetconfig.json

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -464,7 +464,13 @@
             "kittenbot/pxt-tabbyrobot": { "tags": [ "Robotics" ] },
             "pythom1234/pxt-oled": { "tags": [ "Lights and Display" ] },
             "softsmyth/lectrify-b4k": { "tags": [ "Robotics" ] },
-            "davidnsousa/sonification": { "tags": [ "Software" ] }
+            "davidnsousa/sonification": { "tags": [ "Software" ] },
+            "eanders-ms/simx-sample": {
+                "simx": {
+                    "sha": "611e641a4b80d979235dd9ac267d0a707c129a85",
+                    "devUrl": "http://localhost:5173"
+                }
+            }
         },
         "approvedEditorExtensionUrls": [
             "https://microsoft.github.io/ml4f/",


### PR DESCRIPTION
This is needed for testing simulator extensions against live config.