### PR TITLE
pin mediacapture types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "docs/static/icons/favicon.ico"
     ],
     "devDependencies": {
-        "@types/dom-mediacapture-record": "^1.0.16",
+        "@types/dom-mediacapture-record": "1.0.20",
         "@types/marked": "0.3.0",
         "@types/node": "8.10.66",
         "@types/react": "16.4.7",


### PR DESCRIPTION
the cursed `^` versions strike again.

this pins the typings to the version tagged for ts 4.8 in npm