### PR TITLE
Extension: add Craft & Code

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -521,6 +521,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Kitronik Craft & Code",
+  "url":"/pkg/KitronikLtd/pxt-kitronik-Craft-and-Code",
+  "cardType": "package"
+}, {
   "name": "Lectrify Brick:Bit",
   "url":"/pkg/softsmyth/lectrify-b4k",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -478,7 +478,8 @@
                     "devUrl": "http://localhost:5173",
                     "aspectRatio": 3.45
                 }
-            }
+            },
+            "kitronikltd/pxt-kitronik-craft-and-code": { "tags": [ "Robotics" ] }
         },
         "approvedEditorExtensionUrls": [
             "https://microsoft.github.io/ml4f/",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/83994 (private)
@KitronikLTD
@abchatra 

Extension: https://github.com/KitronikLtd/pxt-kitronik-Craft-and-Code/
All blocks: https://makecode.microbit.org/_R8ib512Y2bkt

![image](https://github.com/user-attachments/assets/8be0d579-3a74-451a-99d7-dcc92ee0fca0)
