### PR TITLE
Update pxt-core to 11.1.7 (on stable7.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "docs/static/icons/favicon.ico"
     ],
     "devDependencies": {
-        "@types/dom-mediacapture-record": "^1.0.16",
+        "@types/dom-mediacapture-record": "1.0.20",
         "@types/marked": "0.3.0",
         "@types/node": "8.10.66",
         "@types/react": "16.4.7",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.0.4",
-        "pxt-core": "11.1.6"
+        "pxt-core": "11.1.7"
     }
 }


### PR DESCRIPTION
Contains:
![image](https://github.com/user-attachments/assets/44df9e67-1a21-44b7-98f3-74f5af4382b9)
