### PR TITLE
Update simx hash for pxt-microbit-ml

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -480,7 +480,7 @@
             },
             "microbit-foundation/pxt-microbit-ml": { 
                 "simx": {
-                    "sha": "e349a2feaae9f84a24ebd56716209ef74e1758d2",
+                    "sha": "ba99fd9588e87eb994345d04b596adc51d2d8116",
                     "devUrl": "http://localhost:5173",
                     "aspectRatio": 3.45
                 }


### PR DESCRIPTION
This updates to a version with an initial set of translations corresponding to those we just shipped in CreateAI.

Source diff: https://github.com/microbit-foundation/pxt-microbit-ml/compare/4564abedfeeff5bcc793b9af5c9c1e7b938ef5bf...1e3147dc861695ad81398ed6d72ae6ea03a11351 (only changes in simx are relevant)

deployment/demo:
https://microbit-foundation.github.io/pxt-microbit-ml/?language=ko

Please can this change also be ported to stable so it can be shipped in live MakeCode?

CC @microbit-robert @microbit-grace