### PR TITLE
Allow-list Code Eval in Microbit

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,5 @@
+# robots.txt for PXT Micro:Bit
+
+# Disable crawling in /v2 path for micro:bit
+User-agent: *
+Disallow: /v2

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -438,6 +438,9 @@
             "identity",
             "blocksErrorList"
         ],
+        "supportedExperiences": [
+            "code-eval"
+        ],
         "bluetoothUartFilters": [
             {
                 "namePrefix": "BBC micro:bit"


### PR DESCRIPTION
This creates an override for the `robots.txt` file in the `docs` directory to allow for code evaluation in the Micro:Bit experience. My understanding is that this will overwrite the file in pxt's common-docs folder, so only micro:bit will serve this version without --eval blocked. It also adds code-eval as a supported experience in Micro:bit.

Closely tied to changes in https://github.com/microsoft/pxt/pull/10357