### PR TITLE
Extension: add Robotics Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -521,6 +521,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "DFRobot Creative Robotics Kit",
+  "url":"/pkg/DFRobot/pxt-DFRobot_creative-robotics-kit",
+  "cardType": "package"
+}, {
   "name": "Elecfreaks XGO Rider",
   "url":"/pkg/elecfreaks/XGO-Rider",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -472,6 +472,7 @@
             "parallaxinc/cyberbot_makecode": { "tags": [ "Robotics" ] },
             "siyeenove/pxt_mcar": { "tags": [ "Robotics" ] },
             "elecfreaks/xgo-rider": { "tags": [ "Robotics" ] },
+            "dfrobot/pxt-dfrobot_creative-robotics-kit": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/85912 (private)
@zhang-tang
@abchatra

Extension: https://github.com/DFRobot/pxt-DFRobot_creative-robotics-kit
Version: 1.0.6
All blocks: https://makecode.microbit.org/_8RsJ1h3F55k8

![image](https://github.com/user-attachments/assets/4e15372b-dd9a-4469-897c-cc9a768bb279)




