### PR TITLE
0x73000 is usable end for codal-microbit-v2

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -191,7 +191,7 @@
         "mbcodal": {
             "compile": {
                 "flashCodeAlign": 4096,
-                "flashUsableEnd": 487424,
+                "flashUsableEnd": 471040,
                 "flashEnd": 524288
             },
             "compileService": {


### PR DESCRIPTION
Per the codal-v2-microbit memory map:

https://github.com/lancaster-university/codal-microbit-v2/blob/master/docs/MemoryMap.md