### PR TITLE
Simulator keyboard navigation

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -310,7 +310,7 @@ path.sim-board {
         private rssi: SVGTextElement;
         private lightLevelButton: SVGCircleElement;
         private lightLevelGradient: SVGLinearGradientElement;
-        private lightLevelInittialized = false;
+        private lightLevelInitialized = false;
         private lightLevelText: SVGTextElement;
         private thermometerGradient: SVGLinearGradientElement;
         private thermometer: SVGRectElement;
@@ -827,8 +827,8 @@ path.sim-board {
             let state = this.board;
             if (!state || !state.lightSensorState.usesLightLevel) return;
 
-            if (!this.lightLevelInittialized) {
-                this.lightLevelInittialized = true;
+            if (!this.lightLevelInitialized) {
+                this.lightLevelInitialized = true;
                 this.lightLevelButton.style.visibility = "visible";
                 let pt = this.element.createSVGPoint();
                 svg.buttonEvents(this.lightLevelButton,

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1014,7 +1014,6 @@ path.sim-board {
             }
 
             // Order of construction affects tab ordering
-            // light level here
             this.buildLightLevelElement();
             this.buildHeadElement();
             this.buildThermometerElement();

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -196,6 +196,11 @@ path.sim-board {
         "P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10",
         "P11", "P12", "P13", "P14", "P15", "P16", "P17", "P18", "P19", "P20",
         "GND0", "GND", "+3v3", "GND1"];
+    const pinDrawOrder = [
+        "P3", "P0", "P4", "P5", "P6", "P7", "P1", "P8", "P9", "P10", "P11",
+        "P12", "P2", "P13", "P14", "P15", "P16", "P17", "P18", "P19", "P20",
+        "GND0", "GND", "+3v3", "GND1"
+    ];
     const pinTitles = [
         "P0, ANALOG IN",
         "P1, ANALOG IN",
@@ -1081,24 +1086,35 @@ path.sim-board {
 
         private buildPinElements() {
             // https://www.microbit.co.uk/device/pins
+            // The order of this.pins must match the edgeConnectorState.pins order.
+            // The draw order must match the desired tab order. To this end we
+            // create the drawlist in sim order and evaluate it in tab order.
+
             // P0, P1, P2
-            this.pins = [
+            let drawList: (() => SVGElement)[] = [
                 "M16.5,341.2c0,0.4-0.1,0.9-0.1,1.3v60.7c4.1,1.7,8.6,2.7,12.9,2.7h34.4v-64.7c0,0,0-0.1,0-0.1c0-13-10.6-23.6-23.7-23.6C27.2,317.6,16.5,328.1,16.5,341.2z M21.2,341.6c0-10.7,8.7-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3c0,10.7-8.6,19.3-19.3,19.3C29.9,360.9,21.2,352.2,21.2,341.6z",
                 "M139.1,317.3c-12.8,0-22.1,10.3-23.1,23.1V406h46.2v-65.6C162.2,327.7,151.9,317.3,139.1,317.3zM139.3,360.1c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C158.6,351.5,150,360.1,139.3,360.1z",
                 "M249,317.3c-12.8,0-22.1,10.3-23.1,23.1V406h46.2v-65.6C272.1,327.7,261.8,317.3,249,317.3z M249.4,360.1c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C268.7,351.5,260.1,360.1,249.4,360.1z"
-            ].map((p, pi) => svg.path(this.g, "sim-pin sim-pin-touch", p));
+            ].map((p) => () => svg.path(this.g, "sim-pin sim-pin-touch", p));
 
             // P3
-            this.pins.push(svg.path(this.g, "sim-pin", "M0,357.7v19.2c0,10.8,6.2,20.2,14.4,25.2v-44.4H0z"));
+            drawList.push(() => svg.path(this.g, "sim-pin", "M0,357.7v19.2c0,10.8,6.2,20.2,14.4,25.2v-44.4H0z"));
 
             pins4onXs.forEach(x => {
-                this.pins.push(svg.child(this.g, "rect", { x: x, y: 356.7, width: 10, height: 50, class: "sim-pin" }));
+                drawList.push(() => svg.child(this.g, "rect", { x: x, y: 356.7, width: 10, height: 50, class: "sim-pin" }));
             });
-            this.pins.push(svg.path(this.g, "sim-pin", "M483.6,402c8.2-5,14.4-14.4,14.4-25.1v-19.2h-14.4V402z"));
-            this.pins.push(svg.path(this.g, "sim-pin", "M359.9,317.3c-12.8,0-22.1,10.3-23.1,23.1V406H383v-65.6C383,327.7,372.7,317.3,359.9,317.3z M360,360.1c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C379.3,351.5,370.7,360.1,360,360.1z"));
-            this.pins.push(svg.path(this.g, "sim-pin", "M458,317.6c-13,0-23.6,10.6-23.6,23.6c0,0,0,0.1,0,0.1h0V406H469c4.3,0,8.4-1,12.6-2.7v-60.7c0-0.4,0-0.9,0-1.3C481.6,328.1,471,317.6,458,317.6z M457.8,360.9c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C477.1,352.2,468.4,360.9,457.8,360.9z"));
 
-            this.pins.forEach((p, i) => svg.hydrate(p, { title: pinTitles[i] }));
+            drawList.push(() => svg.path(this.g, "sim-pin", "M483.6,402c8.2-5,14.4-14.4,14.4-25.1v-19.2h-14.4V402z"));
+            drawList.push(() => svg.path(this.g, "sim-pin", "M359.9,317.3c-12.8,0-22.1,10.3-23.1,23.1V406H383v-65.6C383,327.7,372.7,317.3,359.9,317.3z M360,360.1c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C379.3,351.5,370.7,360.1,360,360.1z"));
+            drawList.push(() => svg.path(this.g, "sim-pin", "M458,317.6c-13,0-23.6,10.6-23.6,23.6c0,0,0,0.1,0,0.1h0V406H469c4.3,0,8.4-1,12.6-2.7v-60.7c0-0.4,0-0.9,0-1.3C481.6,328.1,471,317.6,458,317.6z M457.8,360.9c-10.7,0-19.3-8.6-19.3-19.3c0-10.7,8.6-19.3,19.3-19.3c10.7,0,19.3,8.7,19.3,19.3C477.1,352.2,468.4,360.9,457.8,360.9z"));
+
+            this.pins = pinDrawOrder.reduce((pins, pinName) => {
+                const simPinIndex = pinNames.indexOf(pinName);
+                const newPin = drawList[simPinIndex]();
+                svg.hydrate(newPin, { title: pinTitles[simPinIndex] });
+                pins[simPinIndex] = newPin;
+                return pins;
+            }, new Array(pinDrawOrder.length));
 
             this.pinGradients = this.pins.map((pin, i) => {
                 let gid = "gradient-pin-" + i;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -628,12 +628,14 @@ path.sim-board {
                     (ev) => {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
+                            ev.preventDefault();
                             state.thermometerState.temperature--;
                             if (state.thermometerState.temperature < -5) {
                                 state.thermometerState.temperature = 50;
                             }
                             this.updateTemperature();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
+                            ev.preventDefault();
                             state.thermometerState.temperature++;
                             if (state.thermometerState.temperature > 50) {
                                 state.thermometerState.temperature = -5;
@@ -692,9 +694,11 @@ path.sim-board {
                     (ev) => {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
+                            ev.preventDefault();
                             state.microphoneState.setLevel(state.microphoneState.getLevel() - 1);
                             this.updateMicrophone();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
+                            ev.preventDefault();
                             state.microphoneState.setLevel(state.microphoneState.getLevel() + 1)
                             this.updateMicrophone();
                         }
@@ -879,12 +883,14 @@ path.sim-board {
                     (ev) => {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
+                            ev.preventDefault();
                             this.board.lightSensorState.lightLevel--;
                             if (this.board.lightSensorState.lightLevel < 0) {
                                 this.board.lightSensorState.lightLevel = 255;
                             }
                             this.applyLightLevel();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
+                            ev.preventDefault();
                             this.board.lightSensorState.lightLevel++;
                             if (this.board.lightSensorState.lightLevel > 255) {
                                 this.board.lightSensorState.lightLevel = 0;
@@ -1428,12 +1434,14 @@ path.sim-board {
                         let pin = state.edgeConnectorState.pins[index];
 
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
+                            ev.preventDefault();
                             pin.value -= 10;
                             if (pin.value < 0) {
                                 pin.value = 1023;
                             }
                             this.updatePin(pin, index);
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
+                            ev.preventDefault();
                             pin.value += 10;
                             if (pin.value > 1023) {
                                 pin.value = 0;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -500,8 +500,9 @@ path.sim-board {
 
         private updateGestures() {
             let state = this.board;
-            if (state.accelerometerState.useShake && !this.shakeButton) {
-                this.shakeButton = svg.child(this.g, "circle", { cx: 404, cy: 115, r: 12, class: "sim-shake" }) as SVGCircleElement;
+            if (state.accelerometerState.useShake && !this.shakeInitialized) {
+                this.shakeInitialized = true;
+                this.shakeButton.style.visibility = "visible";
                 accessibility.makeFocusable(this.shakeButton);
                 svg.fill(this.shakeButton, this.props.theme.virtualButtonUp);
                 pointerEvents.down.forEach(evid => this.shakeButton.addEventListener(evid, ev => {


### PR DESCRIPTION
Provides the following accessibility improvements in the Microbit simulator:
* re-structures the DOM so that tab ordering of simulator elements is left-right top-bottom (see video 1)
* makes the antenna element interactive using keyboard navigation, simplest approach
* add some preventDefaults to prevent the screen scrolling while you're adjusting values when the simulator has a scrollbar

https://github.com/user-attachments/assets/5238ff6b-76bb-4ff0-87cd-fccb321d7157

