### PR TITLE
Update radio-broadcast examples in reference pages

### DIFF
--- a/docs/reference/radio/on-received-message.md
+++ b/docs/reference/radio/on-received-message.md
@@ -1,17 +1,6 @@
-# on Received Message
+# @extends
 
-Run part of a program when the @boardname@ receives a
-message over ``radio``.
-
-```sig
-radio.onReceivedMessage(0, function() {})
-```
-
-## Parameters
-
-* **msg**: The message to listen for. See [send message](/reference/radio/send-message)
-
-## Example
+## Example #example
 
 Send a ``Hello`` message when button ``A`` is pressed, ``Goodbye`` when button ``B`` is pressed. If the messages are received, display either a ``heart`` or a ``scissor`` for the messages.
 
@@ -33,12 +22,4 @@ input.onButtonPressed(Button.B, function () {
 radio.onReceivedMessage(RadioMessage.Goodbye, function () {
     basic.showIcon(IconNames.Scissors)
 })
-```
-
-## See also
-
-[send message](/reference/radio/send-message),
-
-```package
-radio-broadcast
 ```

--- a/docs/reference/radio/send-message.md
+++ b/docs/reference/radio/send-message.md
@@ -1,17 +1,6 @@
-# on Received Message
+# @extends
 
-Run part of a program when the @boardname@ receives a
-message over ``radio``.
-
-```sig
-radio.onReceivedMessage(0, function() {})
-```
-
-## Parameters
-
-* **msg**: The message to listen for. See [send message](/reference/radio/send-message)
-
-## Example
+## Example #example
 
 Send a ``Hello`` message when button ``A`` is pressed, ``Goodbye`` when button ``B`` is pressed. If the messages are received, display either a ``heart`` or a ``scissor`` for the messages.
 
@@ -33,12 +22,4 @@ input.onButtonPressed(Button.B, function () {
 radio.onReceivedMessage(RadioMessage.Goodbye, function () {
     basic.showIcon(IconNames.Scissors)
 })
-```
-
-## See also
-
-[send message](/reference/radio/send-message),
-
-```package
-radio-broadcast
 ```

--- a/libs/radio-broadcast/docs/reference/radio/send-message.md
+++ b/libs/radio-broadcast/docs/reference/radio/send-message.md
@@ -10,27 +10,27 @@ radio.sendMessage(0);
 
 * **msg**: a coded message.
 
+## Example
 
-## Example: Broadcasting heart or skull
-
-Sends a ``heart`` message when ``A`` is pressed, ``skull`` when ``B`` is pressed. On the side, display heart or skull for the message.
+Send a ``Hello`` message when button ``A`` is pressed, ``Goodbye`` when button ``B`` is pressed. If the messages are received, display either a ``heart`` or a ``scissor`` for the messages.
 
 ```blocks
 enum RadioMessage {
-    heart,
-    skull
+    message1 = 49434,
+    Hello = 49337,
+    Goodbye = 16885
 }
 input.onButtonPressed(Button.A, function () {
-    radio.sendMessage(RadioMessage.heart)
+    radio.sendMessage(RadioMessage.Hello)
 })
-input.onButtonPressed(Button.B, function () {
-    radio.sendMessage(RadioMessage.skull)
-})
-radio.onReceivedMessage(RadioMessage.heart, function () {
+radio.onReceivedMessage(RadioMessage.Hello, function () {
     basic.showIcon(IconNames.Heart)
 })
-radio.onReceivedMessage(RadioMessage.skull, function () {
-    basic.showIcon(IconNames.Skull)
+input.onButtonPressed(Button.B, function () {
+    radio.sendMessage(RadioMessage.Goodbye)
+})
+radio.onReceivedMessage(RadioMessage.Goodbye, function () {
+    basic.showIcon(IconNames.Scissors)
 })
 ```
 


### PR DESCRIPTION
Update radio-broadcast examples in reference pages.

* Add inherited pages for `radio-broadcast` from `pxt-common-packages`.
* Update pages from `./libs/radio-broadcast` even though they're obsolete.

**Note**: Despite using unique enums for the message names, the decompile and render into blocks on the document seems to always set it back to `message1`. The examples work fine in the editor context though.

```typescript
enum RadioMessage {
    message1 = 49434,
    Hello = 49337,
    Goodbye = 16885
}
input.onButtonPressed(Button.A, function () {
    radio.sendMessage(RadioMessage.Hello)
})
radio.onReceivedMessage(RadioMessage.Hello, function () {
    basic.showIcon(IconNames.Heart)
})
input.onButtonPressed(Button.B, function () {
    radio.sendMessage(RadioMessage.Goodbye)
})
radio.onReceivedMessage(RadioMessage.Goodbye, function () {
    basic.showIcon(IconNames.Scissors)
})
```

Closes #6115