### PR TITLE
Microbit - Teacher Tool Theme Fixes

### DIFF
--- a/theme/color-themes/microbit-light.json
+++ b/theme/color-themes/microbit-light.json
@@ -72,6 +72,7 @@
         "pxt-neutral-alpha10": "rgba(0, 0, 0, 0.1)",
         "pxt-neutral-alpha20": "rgba(0, 0, 0, 0.2)",
         "pxt-neutral-alpha50": "rgba(0, 0, 0, 0.5)",
+        "pxt-neutral-alpha80": "rgba(0, 0, 0, 0.8)",
 
         "pxt-link": "#3977B4",
         "pxt-link-hover": "#204467",

--- a/theme/color-themes/microbit-light.json
+++ b/theme/color-themes/microbit-light.json
@@ -78,6 +78,21 @@
         "pxt-link-hover": "#204467",
         "pxt-focus-border": "#0078D4",
 
+        "pxt-success": "#2ECC71",
+        "pxt-pxt-success-foreground": "#000000",
+        "pxt-pxt-success-hover": "#22BE64",
+        "pxt-pxt-success-alpha10": "#2ECC7119",
+
+        "pxt-warning": "#FFD43A",
+        "pxt-warning-foreground": "#000000",
+        "pxt-warning-hover": "#FFCE21",
+        "pxt-warning-alpha10": "#FFD43A19",
+
+        "pxt-error": "#FF3A54",
+        "pxt-error-foreground": "#000000",
+        "pxt-error-hover": "#FF213E",
+        "pxt-error-alpha10": "#FF3A5419",
+
         "pxt-colors-purple-background": "#9932cc",
         "pxt-colors-purple-foreground": "#FFFFFF",
         "pxt-colors-purple-hover": "#7a28a3",

--- a/theme/style.less
+++ b/theme/style.less
@@ -22,6 +22,10 @@
     src: @RobotoFont format("woff");
 }
 
+:root, .pxt-theme-root {
+    --pxt-page-font: @pageFont;
+}
+
 .ui.button.download-button {
     &:extend(.ui.purple.button all);
 }

--- a/theme/themepacks.less
+++ b/theme/themepacks.less
@@ -1,7 +1,0 @@
-/*****************************************
-        Theme overrides
-        source vars: pxt/theme/themepacks.less
-******************************************/
-:root, .pxt-theme-root {
-    --pxt-page-font: @pageFont;
-}

--- a/theme/themepacks.less
+++ b/theme/themepacks.less
@@ -3,40 +3,5 @@
         source vars: pxt/theme/themepacks.less
 ******************************************/
 :root, .pxt-theme-root {
-    /// Page
     --pxt-page-font: @pageFont;
-    --pxt-page-foreground-light: var(--pxt-neutral-background3);
-    /// Header bar
-    --pxt-headerbar-background: var(--pxt-header-background);
-    --pxt-headerbar-background-glass: var(--pxt-neutral-alpha10);
-    --pxt-headerbar-foreground: var(--pxt-header-foreground);
-    --pxt-headerbar-accent: var(--pxt-header-stencil);
-    --pxt-headerbar-accent-smoke: var(--pxt-neutral-alpha20);
-    /// Content area
-    --pxt-content-background: var(--pxt-target-background1);
-    --pxt-content-background-glass: var(--pxt-neutral-alpha10);
-    --pxt-content-foreground: var(--pxt-colors-blue-background);
-    --pxt-content-accent: var(--pxt-target-background1-hover);
-    --pxt-content-secondary-foreground: var(--pxt-neutral-background3);
-    /// Primary button
-    --pxt-button-primary-background: var(--pxt-primary-background);
-    --pxt-button-primary-foreground: var(--pxt-primary-foreground);
-    --pxt-button-primary-accent: var(--pxt-primary-accent);
-    /// Secondary button
-    --pxt-button-secondary-background: var(--pxt-secondary-background);
-    --pxt-button-secondary-foreground: var(--pxt-secondary-foreground);
-    --pxt-button-secondary-accent: var(--pxt-secondary-accent);
-    /// Status colors
-    --pxt-success: var(--pxt-colors-green-background);
-    --pxt-info: var(--pxt-colors-blue-background);
-    --pxt-warning: var(--pxt-colors-yellow-background);
-    --pxt-error: var(--pxt-colors-red-background);
-    --pxt-success-background: var(--pxt-colors-green-alpha10);
-    --pxt-info-background: var(--pxt-colors-blue-alpha10);
-    --pxt-warning-background: var(--pxt-colors-yellow-alpha10);
-    --pxt-error-background: var(--pxt-colors-red-alpha10);
-    --pxt-success-accent: var(--pxt-colors-green-hover);
-    --pxt-info-accent: var(--pxt-colors-blue-hover);
-    --pxt-warning-accent: var(--pxt-colors-yellow-hover);
-    --pxt-error-accent: var(--pxt-colors-red-hover);
 }


### PR DESCRIPTION
In https://github.com/microsoft/pxt/pull/10481, I have swapped out the themepack with our new theme variables, so we can remove the themepack file from microbit. The one thing we needed to keep was the font variable, so I've moved that into style.less instead.

I've also added a color that was missed in the original theme file. This already existed in arcade themes (and the base theme).

Upload Target: https://makecode.microbit.org/app/2c6d961517b971a19375a8090903860676c8e0f7-fa4ad57a6d--eval