### PR TITLE
Extension: Add Sound Level in decibels (dB).

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -1076,6 +1076,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
   "url":"/pkg/microbit-foundation/pxt-microbit-v2-power",
   "cardType": "package"
 }, {
+  "name": "Sound Level in decibels (dB)",
+  "url":"/pkg/microbit-foundation/pxt-sound-level-db",
+  "cardType": "package"
+}, {
   "name": "DS3231 Real Time Clock",
   "url":"/pkg/AlexandreFrolov/DS3231",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -404,6 +404,7 @@
             "stemhub/pxt-stemhubcity": { "tags": [ "Science" ] },
             "kittenbot/pxt-powerbrick": { "tags": [ "Science" ] },
             "microbit-foundation/pxt-microbit-v2-power": { "tags": [ "Software" ] },
+            "microbit-foundation/pxt-sound-level-db": { "tags": [ "Software" ] },
             "kittenbot/pxt-joyfrog": { "tags": [ "Gaming" ] },
             "kittenbot/pxt-sugar": { "tags": [ "Science" ] },
             "kittenbot/pxt-koi": { "tags": [ "Science" ] },


### PR DESCRIPTION
A simple software-only extension to add "sound level (dB)" block, currently in beta:

<img width="346" alt="image" src="https://github.com/user-attachments/assets/c4402845-53b6-4f06-a962-59e8a78cb2b5" />

One thing to note is that this extension adds a block to the "Input ... more" category, instead of creating a new one. This is not something that we should normally approve for third party extensions, but we'd like to make an exception for this extension from the Foundation.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/8c700c86-0709-4d41-832c-70a12c83849a" />

