### PR TITLE
Sync 'onReceiveString()' hints in tutorial with toobox template

### DIFF
--- a/docs/projects/spy/micro-chat.md
+++ b/docs/projects/spy/micro-chat.md
@@ -47,7 +47,7 @@ radio.setGroup(1)
 input.onButtonPressed(Button.A, function() {
     radio.sendString("Micro Chat!")
 })
-radio.onReceivedString(function (receivedString) {
+radio.onReceivedString(function(receivedString: string) {
 })
 ```
 
@@ -60,7 +60,7 @@ radio.setGroup(1)
 input.onButtonPressed(Button.A, function() {
     radio.sendString("Micro Chat!")
 })
-radio.onReceivedString(function (receivedString) {
+radio.onReceivedString(function(receivedString: string) {
     // @highlight
     basic.showString(receivedString)
 })


### PR DESCRIPTION
The Toolbox provides - 

```typescript
radio.onReceivedString(function(receivedString: string) {
})
```
so, make the hints match it.

Closes #5577