### PR TITLE
Change url type for 'SparkFun Videos' in 'Courses' gallery

### DIFF
--- a/docs/courses.md
+++ b/docs/courses.md
@@ -107,7 +107,8 @@ Tutorials, lessons, and mini-courses about programming and computing.
 }, {
   "name": "SparkFun Videos",
   "description": "YouTube video tutorials produced by the SparkFun team!",
-  "url": "https://youtu.be/kaNtg1HGXbY?list=PLBcrWxTa5CS0mWJrytvii8aG5KUqMXvSk",
+  "youTubeId": "kaNtg1HGXbY",
+  "youTubePlaylistId": "PLBcrWxTa5CS0mWJrytvii8aG5KUqMXvSk",
   "imageUrl": "https://i.ytimg.com/vi/kaNtg1HGXbY/hqdefault.jpg"
 }, {
   "name": "Logic Lab",


### PR DESCRIPTION
Seems like a knit pick but I'll change the "SparkFun Videos" URL in order for the link button to say "Watch Video" instead of "Show Instructions".

Closes #5580