### PR TITLE
copy over blockly 12 overrides and patch script from pxt-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,19 @@
     "dependencies": {
         "pxt-common-packages": "12.3.29",
         "pxt-core": "11.4.16"
+    },
+    "overrides": {
+        "@blockly/field-colour": {
+            "blockly": "^12.0.0-beta.4"
+        },
+        "@blockly/plugin-workspace-search": {
+            "blockly": "^12.0.0-beta.4"
+        },
+        "@blockly/keyboard-navigation": {
+            "blockly": "^12.0.0-beta.4"
+        }
+    },
+    "scripts": {
+        "postinstall": "node ./scripts/patchBlocklyFieldColour.js"
     }
 }

--- a/scripts/patchBlocklyFieldColour.js
+++ b/scripts/patchBlocklyFieldColour.js
@@ -1,0 +1,34 @@
+// This script patches Blockly's FieldColour plugin which has a typing
+// error with the Blockly 12 beta. Presumably this plugin will receive
+// an update when Blockly 12 is officially released and at that time
+// this script can be removed.
+
+const fs = require("fs");
+const path = require("path");
+
+if (!fs.existsSync(path.resolve("./node_modules/@blockly/field-colour/package.json"))) {
+    return;
+}
+
+const packageJson = JSON.parse(fs.readFileSync(path.resolve("./node_modules/@blockly/field-colour/package.json"), "utf8"));
+
+if (packageJson.version !== "5.0.12") {
+    throw new Error("patchBlocklyFieldColour was written for @blockly/field-colour version 5.0.12. If the version has been updated, update or remove this script!");
+}
+
+
+function patchFile(filepath) {
+    const contents = fs.readFileSync(filepath, "utf8");
+
+    const patched = contents.replace(
+        "protected isFullBlockField(): boolean",
+        "public    isFullBlockField(): boolean"
+    );
+
+    fs.writeFileSync(filepath, patched, "utf8");
+}
+
+patchFile(path.resolve(__dirname, "..", "./node_modules/@blockly/field-colour/dist/field_colour.d.ts"));
+patchFile(path.resolve(__dirname, "..", "./node_modules/@blockly/field-colour/src/field_colour.ts"));
+
+console.log("Patched @blockly/field-colour")


### PR DESCRIPTION
this brings in the overrides for our blockly plugin dependencies that i made in pxt-core. i mistakenly assumed that those would also apply to repos that added pxt-core as a dependency. similarly, copying over the script to patch the typing error in the field_colour plugin.

all of this can be removed once the child plugins have been updated to blockly 12, which will presumably happen prior to blockly's release