### PR TITLE
Update running time api reference doc with overflow note

### DIFF
--- a/docs/reference/input/running-time-micros.md
+++ b/docs/reference/input/running-time-micros.md
@@ -1,17 +1,33 @@
-# Running Time Micros
+# running Time Micros
 
-Find how long it has been since the program started in micro-seconds.
+Find how long a program has run since it was started, in microseconds.
 
 ```sig
-input.runningTimeMicros();
+input.runningTimeMicros()
+```
+
+### ~ alert
+
+#### Running time maximum count
+
+The program running time counter can only count up to approximately 17 minutes of time (1,073,741,823 microseconds). After that, the running time will reset to zero and start counting up again. If a program is using the running time counter, it should rely on the counter for only this amount of time or less. Otherwise, the program will need to account for the reset and add the difference to any accumulated time it is counting.
+
+### ~
+
+## Example
+
+Pause for one second and then show the program running time on the screen.
+
+```blocks
+basic.pause(1000)
+basic.showNumber(input.runningTimeMicros())
 ```
 
 ## Returns
 
-* the [Number](/types/number) of microseconds since the program started.
-(One second is 1000000 microseconds.)
+* the [number](/types/number) of microseconds since the program started.
+(One second is 1,000,000 microseconds.)
 
 ## See also
 
-[show number](/reference/basic/show-number), [pause](/reference/basic/pause)
-
+[show number](/reference/basic/show-number), [pause](/reference/basic/pause), [running time](/reference/input/running-time)

--- a/docs/reference/input/running-time.md
+++ b/docs/reference/input/running-time.md
@@ -1,9 +1,9 @@
 # Running Time
 
-Find how long it has been since the program started in milli-seconds.
+Find how long a program has run since it was started, in milliseconds.
 
 ```sig
-input.runningTime();
+input.runningTime()
 ```
 
 ## Returns
@@ -13,12 +13,12 @@ input.runningTime();
 
 ## Example: elapsed time
 
-When you press button `B` on the microbit, this
+When you press button `B` on the @boardname@, this
 program finds the number of milliseconds since the program started
 and shows it on the [LED screen](/device/screen).
 
 ```blocks
-input.onButtonPressed(Button.B, () => {
+input.onButtonPressed(Button.B, function() {
     let now = input.runningTime()
     basic.showNumber(now)
 })
@@ -27,5 +27,5 @@ input.onButtonPressed(Button.B, () => {
 
 ## See also
 
-[show number](/reference/basic/show-number), [pause](/reference/basic/pause)
+[show number](/reference/basic/show-number), [pause](/reference/basic/pause), [running time micros](/reference/input/running-time-micros)
 


### PR DESCRIPTION
Add a mention for the possibility of overflow of the running time counter.

Closes #5372 