### PR TITLE
Extension: add Coderdojo Controller

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -142,6 +142,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Coderdojo Controller",
+  "url":"/pkg/jimd80/pxt-coderdojo-controller",
+  "cardType": "package"
+}, {
   "name": "Kittenbot JoyFrog",
   "url":"/pkg/KittenBot/pxt-joyfrog",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -476,6 +476,7 @@
             "dfrobot/pxt-dfrobot_creative-robotics-kit": { "tags": [ "Robotics" ] },
             "ines-hpmm/pxt-luma-matrix": { "tags": [ "Lights and Display" ] },
             "team-bp/pxt-bplab": { "tags": [ "Science" ] },
+            "jimd80/pxt-coderdojo-controller": { "tags": [ "Gaming" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/88244 (private)
@jimd80
@abchatra 

Extension: https://github.com/jimd80/pxt-coderdojo-controller
Version: 1.0.5
All blocks: https://makecode.microbit.org/_czgYAT5hc0EM
![image](https://github.com/user-attachments/assets/4c8cf3c6-19b2-42c9-af7b-487bcbaeabae)
