### PR TITLE
add query variant to hide the language picker from the settings menu

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -618,6 +618,11 @@
                 "hideMenuBar": true
             }
         },
+        "hidelanguage": {
+            "appTheme": {
+                "selectLanguage": false
+            }
+        },
         "androidapp": {
             "compile": {
                 "webUSB": false


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/6068

adds a query variant for removing the language picker. sites that embed us can add `?hidelanguage=1` to the url to prevent the language picker from showing up in the settings menu (e.g. if the embedding site handles the language selection themselves)

@microbit-matt-hillsdon let me know if this works for you!