### PR TITLE
Set embedded YouTube link and update hint formatting

### DIFF
--- a/docs/reference/basic/show-leds.md
+++ b/docs/reference/basic/show-leds.md
@@ -19,11 +19,15 @@ basic.showLeds(`
 * `interval` is an optional [number](/types/number) that means how many milliseconds to wait after showing a picture.
 If you are programming with blocks, `interval` is set at 400 milliseconds.
 
-## ~ hint
+### ~ hint
 
-See how the @boardname@ shows numbers, text, and displays images by watching this video about [LEDs](https://www.youtube.com/watch?v=qqBmvHD5bCw).
+#### LED display
 
-## ~
+Watch this video to see how the @boardname@ shows numbers, text, and displays images with [LEDs](/reference/led).
+
+https://www.youtube.com/watch?v=qqBmvHD5bCw
+
+### ~
 
 ## Example
 

--- a/docs/reference/radio/on-data-received.md
+++ b/docs/reference/radio/on-data-received.md
@@ -7,13 +7,13 @@ Run part of a program when the @boardname@ receives a
 radio.onDataReceived(() => { });
 ```
 
-## ~ hint
+### ~ alert
 
-**Deprecated**
+#### Deprecated API
 
 This API has been deprecated! Use [on received number](/reference/radio/on-received-number) instead.
 
-## ~
+### ~
 
 ```sig
 radio.onDataReceived(() => { });

--- a/docs/reference/radio/on-received-buffer.md
+++ b/docs/reference/radio/on-received-buffer.md
@@ -46,11 +46,11 @@ radio.onReceivedBuffer(function (receivedBuffer) {
 ```
 
 
-## ~hint
+### ~hint
 
 A radio that can both transmit and receive is called a _transceiver_.
 
-## ~
+### ~
 
 ## See also
 

--- a/docs/reference/radio/on-received-number.md
+++ b/docs/reference/radio/on-received-number.md
@@ -11,13 +11,15 @@ radio.onReceivedNumber(function (receivedNumber) {})
 
 * **receivedNumber**: The [number](/types/number) that was sent in this packet or `0` if this packet did not contain a number. See [send number](/reference/radio/send-number) and [send value](/reference/radio/send-value)
 
-## ~ hint
+### ~ hint
+
+#### @boardname@ radio
 
 Watch this video to see how the radio hardware works on the @boardname@:
 
 https://www.youtube.com/watch?v=Re3H2ISfQE8
 
-## ~
+### ~
 
 ## Examples
 

--- a/docs/reference/radio/on-received-string.md
+++ b/docs/reference/radio/on-received-string.md
@@ -10,13 +10,15 @@ radio.onReceivedString(function (receivedString) {})
 
 * **receivedString**: The [string](/types/string) that was sent in this packet or the empty string if this packet did not contain a string. See [send string](/reference/radio/send-string) and [send value](/reference/radio/send-value)
 
-## ~ hint
+### ~ hint
+
+#### @boardname@ radio
 
 Watch this video to see how the radio hardware works on the @boardname@:
 
 https://www.youtube.com/watch?v=Re3H2ISfQE8
 
-## ~
+### ~
 
 ## Example
 

--- a/docs/reference/radio/on-received-value.md
+++ b/docs/reference/radio/on-received-value.md
@@ -11,13 +11,15 @@ radio.onReceivedValue(function (name, value) {})
 * **name**: a [string](/types/string) that is a name for the value received.
 * **value**: a [number](/types/number) that is the value received.
 
-## ~ hint
+### ~ hint
+
+#### @boardname@ radio
 
 Watch this video to see how the radio hardware works on the @boardname@:
 
 https://www.youtube.com/watch?v=Re3H2ISfQE8
 
-## ~
+### ~
 
 ## Example
 

--- a/docs/reference/radio/receive-number.md
+++ b/docs/reference/radio/receive-number.md
@@ -6,13 +6,13 @@ Receive the next number sent by a @boardname@ in the same ``radio`` group.
 radio.receiveNumber();
 ```
 
-## ~ hint
+### ~ alert
 
-**Deprecated**
+#### Deprecated API
 
 This API has been deprecated! Use [on received number](/reference/radio/on-received-number) instead.
 
-## ~
+### ~
 
 ## Returns
 

--- a/docs/reference/radio/receive-string.md
+++ b/docs/reference/radio/receive-string.md
@@ -5,13 +5,13 @@ Find the next string sent by radio from another @boardname@.
 ```sig
 radio.receiveString()
 ```
-## ~ hint
+### ~ alert
 
-**Deprecated**
+#### Deprecated
 
 This API has been deprecated! Use [on received string](/reference/radio/on-received-string) instead.
 
-## ~
+### ~
 
 ## Returns
 


### PR DESCRIPTION
Use an embedded YouTube link in `basic.showLeds()` reference page hint. Also, update some hint formatting in a few other pages.

Closes #6097