### PR TITLE
Remove 'hardwareVersion()` from 'Control' main page

### DIFF
--- a/docs/reference/control.md
+++ b/docs/reference/control.md
@@ -12,7 +12,6 @@ control.onEvent(0, 0, () => { });
 control.raiseEvent(0, 0);
 control.eventTimestamp();
 control.eventValue();
-control.hardwareVersion();
 ```
 
 ## See Also

--- a/docs/reference/control/hardware-version.md
+++ b/docs/reference/control/hardware-version.md
@@ -1,7 +1,15 @@
-# WaitMicros
+# hardware Version
 
-Returns the major version of the microbit.
+Returns a string containing the the major version and minor version of the @boardname@.
 
 ```sig
 control.hardwareVersion()
 ```
+
+## Returns
+
+* a [string](/types/string) that contains the major and minor versions of the @boardname@. The string has an `"x.y"` format like `"1.5"`, `"2.1"`, or `"2.2"`.
+
+## See also
+
+[device name](/reference/control/device-name), [device serial number](/reference/control/device-serial-number)


### PR DESCRIPTION
The `hardwareVersion()` API is not a block so remove it from the 'Control' main page. Also, fix its reference page a bit.

Closes #6193