### PR TITLE
Use base page from core docs for 'text.md'

### DIFF
--- a/docs/reference/text.md
+++ b/docs/reference/text.md
@@ -1,18 +1,1 @@
-# Text
-
-Functions to combine, split, search, and convert text strings.
-
-```cards
-"".charAt(0);
-"".compare("");
-"".substr(0, 0);
-parseFloat("");
-parseInt("");
-convertToText(0);
-```
-
-## See also
-
-[char at](/reference/text/char-at), [compare](/reference/text/compare),
-[substr](/reference/text/substr), [parse int](/reference/text/parse-int), 
-[parse float](/reference/text/parse-float), [convert to text](/reference/text/convert-text)
+# @extends


### PR DESCRIPTION
Use the base page for `text.md` from the core docs. The `parseInt()` block is now obsolete/removed.

Closes #6212