### PR TITLE
Bad 'see also' link for every-interval

### DIFF
--- a/docs/blocks/loops.md
+++ b/docs/blocks/loops.md
@@ -12,4 +12,4 @@ loops.everyInterval(500, function () {})
 [while](/blocks/loops/while), 
 [repeat](/blocks/loops/repeat), 
 [for of](/blocks/loops/for-of),
-[every](/reference/loops/every)
+[every](/reference/loops/every-interval)


### PR DESCRIPTION
Fix the 'See also' link for the `every-interval` page.

Closes #6211