### PR TITLE
Improve simulator focus rings and keyboard accessibility

### DIFF
--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -171,13 +171,12 @@ namespace pxsim {
             }), opts);
 
             document.body.innerHTML = ""; // clear children
-            document.body.appendChild(this.view = this.viewHost.getView());
-
             if (shouldShowMute()) {
                 document.body.appendChild(createMuteButton());
                 AudioContextManager.mute(true);
                 setParentMuteState("disabled");
             }
+            document.body.appendChild(this.view = this.viewHost.getView());
 
             if (msg.theme === "mbcodal") {
                 this.ensureHardwareVersion(2);

--- a/sim/public/simulator.html
+++ b/sim/public/simulator.html
@@ -31,7 +31,7 @@ body {
   display: inline-block;
   min-height: 1rem;
   outline: none;
-  border: none;
+  border: 1px solid transparent;
   vertical-align: middle;
   margin: 0;
   padding: 0.75rem;
@@ -53,7 +53,8 @@ body {
   filter: grayscale(.15) brightness(.85) contrast(1.3);
 }
 .safari-mute-button:focus {
-  outline: 3px solid white;
+  border: 1px solid white;
+  outline: 3px solid #4D90FE;
 }
 .safari-mute-button svg {
   width: 24px;

--- a/sim/public/simulator.html
+++ b/sim/public/simulator.html
@@ -25,6 +25,7 @@ body {
   right: 10px;
 }
 .safari-mute-button {
+  z-index: 1;
   cursor: pointer;
   position: relative;
   display: inline-block;
@@ -50,6 +51,9 @@ body {
 }
 .safari-mute-button:hover {
   filter: grayscale(.15) brightness(.85) contrast(1.3);
+}
+.safari-mute-button:focus {
+  outline: 3px solid white;
 }
 .safari-mute-button svg {
   width: 24px;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -143,17 +143,19 @@ namespace pxsim.visuals {
             outline: none;
         }
         *:focus .sim-button-outer,
-        .sim-antenna-outer:focus,
-        .sim-pin:focus,
-        .sim-thermometer:focus,
         .sim-shake:focus,
-        .sim-light-level-button:focus {
-            stroke: #4D90FE;
-            stroke-width: 5px !important;
-        }
+        .sim-thermometer:focus,
+        .sim-light-level-button:focus,
         .sim-button-outer.sim-button-group:focus > .sim-button {
-            stroke: #4D90FE;
-            stroke-width: 10px !important;
+            outline: 6px solid white;
+            outline-offset: 6px;
+        }
+        .sim-antenna-outer:focus {
+            outline: 6px solid white;
+        }
+        .sim-pin:focus { 
+            stroke: white;
+            stroke-width: 5px !important;
         }
         .no-drag, .sim-text, .sim-text-small,
         .sim-text-pin {

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -739,12 +739,35 @@ path.sim-board {
                 let pt = this.element.createSVGPoint();
                 svg.buttonEvents(
                     this.head,
+                    // move
                     (ev: MouseEvent) => {
                         let cur = svg.cursorPoint(pt, this.element, ev);
                         state.compassState.heading = Math.floor(Math.atan2(cur.y - yc, cur.x - xc) * 180 / Math.PI) + 90;
                         if (state.compassState.heading < 0) state.compassState.heading += 360;
                         this.updateHeading();
-                    });
+                    },
+                    // start
+                    ev => { },
+                    // stop
+                    ev => { },
+                    // keydown
+                    (ev) => {
+                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
+                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
+                            ev.preventDefault();
+                            state.compassState.heading--;
+                            if (state.compassState.heading < 0) state.compassState.heading += 360;
+                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
+                            this.updateHeading();
+                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
+                            ev.preventDefault();
+                            state.compassState.heading++;
+                            if (state.compassState.heading < 0) state.compassState.heading += 360;
+                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
+                            this.updateHeading();
+                        }
+                    }
+                );
                 this.headInitialized = true;
             }
 
@@ -755,6 +778,10 @@ path.sim-board {
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("heading")] = state.compassState.heading;
             }
+
+            // make sim head focusable when there is a compass
+            this.headParts.setAttribute("class", "sim-button-outer sim-button-group")
+            accessibility.makeFocusable(this.headParts);
         }
 
         private lastFlashTime: number = 0;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -146,7 +146,7 @@ namespace pxsim.visuals {
         .sim-shake:focus,
         .sim-thermometer:focus,
         .sim-light-level-button:focus,
-        .sim-button-outer.sim-button-group:focus > .sim-button {
+        .sim-button-outer.sim-button-group:focus {
             outline: 6px solid white;
             outline-offset: 6px;
         }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -144,14 +144,21 @@ namespace pxsim.visuals {
         }
         *:focus .sim-button-outer,
         .sim-shake:focus,
-        .sim-thermometer:focus,
-        .sim-light-level-button:focus,
-        .sim-button-outer.sim-button-group:focus {
-            outline: 6px solid white;
-            outline-offset: 6px;
+        .sim-thermometer:focus {
+            outline: 5px solid white;
+            stroke: black;
+            stroke-width: 10px;
+            paint-order: stroke;
         }
-        .sim-antenna-outer:focus {
-            outline: 6px solid white;
+        .sim-button-outer.sim-button-group:focus > .sim-button {
+            outline: 5px solid white;
+            stroke: black;
+            stroke-width: 5px;
+            paint-order: stroke;
+        }
+        .sim-light-level-button:focus,
+        .sim-antenna-outer:focus > .sim-antenna {
+            outline: 5px solid white;
         }
         .sim-pin:focus { 
             stroke: white;

--- a/sim/visuals/mute.ts
+++ b/sim/visuals/mute.ts
@@ -8,7 +8,7 @@ namespace pxsim {
         const el = document.createElement("div");
         el.setAttribute("id", "safari-mute-button-outer");
         el.innerHTML = `
-            <button class="safari-mute-button">
+            <button class="safari-mute-button" tabindex="1">
                 ${icon}
             </button>
         `;


### PR DESCRIPTION
- Improve simulator focus ring clarity by using white outline around components
- Improve keyboard accessibility
  - Compass heading control - Add tab stop and controllable via arrow keys
(Down/left to reduce value, up/right to increase value)
  - Fixes https://github.com/microsoft/pxt-microbit/issues/6207

You can try it here: https://sim-focus-clarity.pxt-microbit.pages.dev/#editor

Demo project with sensors used: https://makecode.microbit.org/_FRM3wbLy8L7X