### PR TITLE
Add in new overrides for blockly

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,13 @@
     "dependencies": {
         "pxt-common-packages": "12.3.30",
         "pxt-core": "11.4.24"
+    },
+    "overrides": {
+        "@blockly/field-colour": {
+            "blockly": "^12.1.0-beta.0"
+        },
+        "@blockly/plugin-workspace-search": {
+            "blockly": "^12.1.0-beta.0"
+        }
     }
 }


### PR DESCRIPTION
weird that it built locally without these overrides in place, but i guess they are required for building from a fresh clone