### PR TITLE
Region-based feature flags for AI Error Help

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -430,14 +430,18 @@
         "workspaceSearch": true,
         "allowPackageExtensions": true,
         "addNewTypeScriptFile": true,
-        "aiErrorHelp": true,
+        "enabledFeatures": {
+            "blocksErrorList": {},
+            "aiErrorHelp": {
+                "includeRegions": ["US"]
+            }
+        },
         "experiments": [
             "accessibleBlocks",
             "debugExtensionCode",
             "bluetoothUartConsole",
             "bluetoothPartialFlashing",
-            "identity",
-            "blocksErrorList"
+            "identity"
         ],
         "supportedExperiences": [
             "code-eval"


### PR DESCRIPTION
This sets feature flags for the blocks error list (globally enabled) and the AI Error Help (currently set to US only, though we'll likely want to change that to a different region before shipping).

Support for region-based feature flags is added in https://github.com/microsoft/pxt/pull/10621