### PR TITLE
Remove 'flipgrid' linking from pages

### DIFF
--- a/docs/courses/csintro.md
+++ b/docs/courses/csintro.md
@@ -38,10 +38,6 @@ Each of the 12 lessons is structured in this format:
 * Assessment - A project rubric and guidance for grading the project.
 * Standards - A list of CSTA K-12 Computer Science Standards and/or concepts covered by this lesson.
 
-### Course on Flipgrid
-
-Flipcode for the **Intro to CS** course grid: **[csintromicrobit](https://flipgrid.com/csintromicrobit)**
-
 ## Course contents
 
 * [About](/courses/csintro/about)

--- a/docs/courses/csintro/algorithms.md
+++ b/docs/courses/csintro/algorithms.md
@@ -17,10 +17,6 @@ Students will...
 3. [**Activity**: Happy face, sad face](/courses/csintro/algorithms/activity)
 4. [**Project**: Fidget cube](/courses/csintro/algorithms/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Algorithms** lesson: https://flipgrid.com/31ed5382
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/algorithms/standards)

--- a/docs/courses/csintro/arrays.md
+++ b/docs/courses/csintro/arrays.md
@@ -28,10 +28,6 @@ Students will...
 3. [**Activity**: Headband charades](/courses/csintro/arrays/activity)
 4. [**Project**: Musical instrument ](/courses/csintro/arrays/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Arrays** lesson: https://flipgrid.com/f0f1bbc5
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/arrays/standards)

--- a/docs/courses/csintro/binary.md
+++ b/docs/courses/csintro/binary.md
@@ -27,10 +27,6 @@ Students will...
 3. [**Activity**: Binary transmogrifier](/courses/csintro/binary/activity)
 4. [**Project**: Make binary a cash register](/courses/csintro/binary/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Binary** lesson: https://flipgrid.com/d44cd204
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/binary/standards)

--- a/docs/courses/csintro/booleans.md
+++ b/docs/courses/csintro/booleans.md
@@ -26,10 +26,6 @@ Students will...
 3. [**Activity**: Double coin flipper](/courses/csintro/booleans/activity)
 4. [**Project**: Boolean](/courses/csintro/booleans/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Booleans** lesson: https://flipgrid.com/36e0c7e0
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/booleans/standards)

--- a/docs/courses/csintro/conditionals.md
+++ b/docs/courses/csintro/conditionals.md
@@ -20,10 +20,6 @@ Students will...
 3. [**Activity**: Rock, paper, scissors](/courses/csintro/conditionals/activity)
 4. [**Project**: Board game](/courses/csintro/conditionals/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Conditionals** lesson: https://flipgrid.com/f260eda7
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/conditionals/standards)

--- a/docs/courses/csintro/coordinates.md
+++ b/docs/courses/csintro/coordinates.md
@@ -31,10 +31,6 @@ Students will...
 3. [**Activity**: Animation and patterns](/courses/csintro/coordinates/activity)
 4. [**Project**: Screensaver or game](/courses/csintro/coordinates/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Coordinates** lesson: https://flipgrid.com/699ca0b7
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/coordinates/standards)

--- a/docs/courses/csintro/iteration.md
+++ b/docs/courses/csintro/iteration.md
@@ -29,10 +29,6 @@ Students will...
 3. [**Activity**: Loops demos](/courses/csintro/iteration/activity)
 4. [**Project**: Get loopy](/courses/csintro/iteration/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Iteration** lesson: https://flipgrid.com/ee559ab7
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/iteration/standards)

--- a/docs/courses/csintro/making.md
+++ b/docs/courses/csintro/making.md
@@ -22,10 +22,6 @@ Students will...
 * [**Activity**: MakeCode download](/courses/csintro/making/activity)
 * [**Project**: micro:pet (including mods and rubric)](/courses/csintro/making/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Making** lesson: https://flipgrid.com/5773f935
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/making/standards)

--- a/docs/courses/csintro/radio.md
+++ b/docs/courses/csintro/radio.md
@@ -26,10 +26,6 @@ Students will...
 3. [**Activity**: Marco Polo and Morse code](/courses/csintro/radio/activity)
 4. [**Project**: Radio project](/courses/csintro/radio/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Radio** lesson: https://flipgrid.com/eb9af729
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/radio/standards)

--- a/docs/courses/csintro/variables.md
+++ b/docs/courses/csintro/variables.md
@@ -23,10 +23,6 @@ Students will...
 3. [**Activity**: Make a Game Scorekeeper](/courses/csintro/variables/activity)
 4. [**Project**: Everything Counts](/courses/csintro/variables/project)
 
-## Flipgrid
-
-The [Flipgrid](https://info.flipgrid.com/) topic for the **Variables** lesson: https://flipgrid.com/dc42bdcc
-
 ## Related standards
 
 [Targeted CSTA standards](/courses/csintro/variables/standards)


### PR DESCRIPTION
Flipgrid is retired so remove the linking to it in 'csintro' and 'project' pages.