### PR TITLE
Update music reference pages to sync with current Playable API

### DIFF
--- a/docs/projects/SUMMARY.md
+++ b/docs/projects/SUMMARY.md
@@ -138,7 +138,7 @@
   * [First Steps](https://microbit.org/get-started/first-steps/introduction/)
   * [Make it: code it](https://microbit.org/projects/make-it-code-it/)
   * [Networking with the micro:bit](https://www.digitaltechnologieshub.edu.au/search/networking-with-the-micro-bit/)
-  * [SparkFun Videos](https://youtu.be/kaNtg1HGXbY?list=PLBcrWxTa5CS0mWJrytvii8aG5KUqMXvSk)
+  * [SparkFun Videos](https://youtu.be/kaNtg1HGXbY)
   * [Logic Lab](/courses/logic-lab)
   * [CodeJoy Remote Robotics](https://www.codejoy.org)
   * [Blocks to JavaScript](/courses/blocks-to-javascript)

--- a/docs/reference/music/built-in-playable-melody.md
+++ b/docs/reference/music/built-in-playable-melody.md
@@ -47,4 +47,4 @@ music.play(music.builtInPlayableMelody(Melodies.Blues), music.PlaybackMode.InBac
 
 ## See also
 
-[built-in sound effect](/reference/music/builtin-sound-effect)
+[string playable](/reference/music/string-playable)

--- a/docs/reference/music/create-sound-expression.md
+++ b/docs/reference/music/create-sound-expression.md
@@ -1,0 +1,68 @@
+# create Sound Expression
+
+Create a sound expression object for a sound effect.
+
+```sig
+music.createSoundExpression(WaveShape.Sine, 2000, 0, 1023, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
+```
+
+A sound expression is set of parameters that describe a **[Sound](/types/sound)** that will last for some amount of time. These parameters specify a base waveform, frequency range, sound volume, and effects. Sound data is created as a [Sound](/types/sound) object and can then be [played](/reference/music/play) to the speaker, headphones, or at an output pin.
+
+## Parameters
+
+* **waveShape**: the primary shape of the waveform:
+>* `sine`: sine wave shape
+>* `sawtooth`: sawtooth wave shape
+>* `triangle`: triangle wave shape
+>* `square`: square wave shape
+>* `noise`: random noise generated wave shape
+* **startFrequency**: a [number](/types/number) that is the frequency of the waveform when the sound expression starts.
+* **endFrequency**: a [number](/types/number) that is the frequency of the waveform when the sound expression stops.
+* **startVolume**: a [number](/types/number) the initial volume of the sound expression.
+* **endVolume**: a [number](/types/number) the ending volume of the sound expression.
+* **duration**: a [number](/types/number) the duration in milliseconds of the sound expression.
+* **effect**: an effect to add to the waveform. These are:
+>* `tremolo`: add slight changes in volume of the sound expression.
+>* `vibrato`: add slight changes in frequency to the sound expression.
+>* `warble`: similar to `vibrato` but with faster variations in the frequency changes.
+* **interpolation**: controls the rate of frequency change in the sound expression.
+>* `linear`: the change in frequency is constant for the duration of the sound.
+>* `curve`: the change in frequency is faster at the beginning of the sound and slows toward the end.
+>* `logarithmic`: the change in frequency is rapid during the very first part of the sound.
+
+## Returns
+
+* a [sound](/types/sound) expression with the the desired sound effect parameters.
+
+## Examples
+
+### Sine wave sound
+
+Create a sound expression and assign it to a variable. Play the sound for the sound expression.
+
+```blocks
+let mySound = music.createSoundExpression(WaveShape.Sine, 2000, 0, 1023, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
+music.play(mySound, music.PlaybackMode.UntilDone)
+```
+
+### Complex waveform sound
+
+Create a `triangle` wave sound expression with `vibrato` and a `curve` interpolation. Play the sound until it finishes.
+
+```typescript
+let mySound = music.createSoundExpression(
+    WaveShape.Triangle,
+    1000,
+    2700,
+    255,
+    255,
+    500,
+    SoundExpressionEffect.Vibrato,
+    InterpolationCurve.Curve
+    )
+music.play(mySound, music.PlaybackMode.UntilDone)
+```
+
+## See also
+
+[play](/reference/music/play)

--- a/docs/reference/music/create-sound-expression.md
+++ b/docs/reference/music/create-sound-expression.md
@@ -24,7 +24,7 @@ A sound expression is set of parameters that describe a **[Sound](/types/sound)*
 * **effect**: an effect to add to the waveform. These are:
 >* `tremolo`: add slight changes in volume of the sound expression.
 >* `vibrato`: add slight changes in frequency to the sound expression.
->* `warble`: similar to `vibrato` but with faster variations in the frequency changes.
+>* `warble`: a combination of the `tremolo` and `vibrato` effects.
 * **interpolation**: controls the rate of frequency change in the sound expression.
 >* `linear`: the change in frequency is constant for the duration of the sound.
 >* `curve`: the change in frequency is faster at the beginning of the sound and slows toward the end.

--- a/docs/reference/music/play.md
+++ b/docs/reference/music/play.md
@@ -1,14 +1,16 @@
 # play
 
-Play a sound expression.
+Play a song, melody, tone, or a sound effect from a playable music source.
 
 ```sig
-soundExpression.giggle.play()
+music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
 ```
 
-A sound expression is a preformatted set of tones that create a certain sound. There are several sounds to choose from. The sound is started and your program then continues.
+Music is played for a simple tone, a melody, or a song. Each of these music sources is called a [playable](/types/playable) object. The ``||music:play||`` block can take any of these playable objects and play them as sound output for your game.
 
 ### ~ reminder
+
+#### For micro:bit v2 only
 
 ![works with micro:bit V2 only image](/static/v2/v2-only.png)
 
@@ -16,28 +18,93 @@ This block requires the [micro:bit V2](/device/v2) hardware. If you use this blo
 
 ### ~
 
-## Parameters
-
-In blocks, the sound is selected from the list in the ``||music:play sound||`` block.
+The simplest music source is a **tone**, on note play for a duration of time:
 
 ```block
-soundExpression.giggle.play()
+music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
 ```
 
-When coding in JavaScript or Python, the sound is a ``soundExpression`` object which from which you run the ``play()`` function from. For example, to play the ``soaring`` sound, select ``soaring`` from the ``soundExpression`` namespace and run ``play()``:
+Then, there is the **melody** which is a series of notes played at a certain speed, or `tempo`. You can create your own melody of choose a built-in one to play:
 
-```typescript
-soundExpression.soaring.play()
+```block
+music.play(music.stringPlayable("D F E A E A C B ", 120), music.PlaybackMode.UntilDone)
+music.play(music.builtInPlayableMelody(Melodies.BaDing), music.PlaybackMode.UntilDone)
 ```
 
-## Example
+The most complex playable object is a **sound expression**. [Sound expressions](/reference/music/create-sound-expression) are composed in the [Sound Editor](/types/sound#sound-editing) using different parameters for making sound waves and effects..
 
-Play the ``twinkle`` sound on the speaker.
+```block
+music.play(music.createSoundExpression(WaveShape.Sine, 5000, 0, 255, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear), music.PlaybackMode.UntilDone)
+```
+
+## Parameters
+
+* **toPlay**: the [playable](/types/playable) object, or music source, to play.
+* **playbackMode**: the playback mode for continuing the program:
+>* `play until done`: play the music source in **toPlay** but wait to run the next part of the program until music play is done.
+>* `in background`: play the music source in **toPlay** but continue with the rest of the program before music play is done.
+>* `looping in background`: play the music source in **toPlay** but continue with the rest of the program before music play is done. The music will remain playing, returning to the first note of the music after its duration.
+
+### ~ hint
+
+#### Stop the music!
+
+You can stop any music currently playing with the ``||music:stop all sounds||`` block. This is useful if **playbackMode** is set to `in background looping` and you wish to stop the music for a scene change or respond to an event with a different sound.
+
+### ~
+
+## Examples #example
+
+### Play a melody
+
+Play a short melody created in the Melody Editor.
 
 ```blocks
-soundExpression.twinkle.play()
+music.play(music.stringPlayable("D F E A E A C B ", 120), music.PlaybackMode.UntilDone)
+```
+
+### Different music sources, one block to play them all
+
+Put 4 different playable music sources in an array. Play one after the other.
+
+```blocks
+let playables = [
+music.tonePlayable(262, music.beat(BeatFraction.Whole)),
+music.stringPlayable("D F E A E A C B ", 120),
+music.builtInPlayableMelody(Melodies.BaDing),
+music.createSoundExpression(WaveShape.Sine, 5000, 0, 255, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
+]
+for (let someMusic of playables) {
+    music.play(someMusic, music.PlaybackMode.UntilDone)
+    basic.pause(500)
+}
+```
+
+### Looping music play
+
+Play a simple song in the background. When the @boardname@ is shaken, stop the song an play the `power down` melody.
+
+```blocks
+music.play(music.stringPlayable("C5 A B G A F A C5 ", 120), music.PlaybackMode.LoopingInBackground)
+input.onGesture(Gesture.Shake, function () {
+    music.stopAllSounds()
+    music.play(music.builtInPlayableMelody(Melodies.PowerDown), music.PlaybackMode.InBackground)
+})
+```
+### Play a sound effect
+
+Play a sine wave sound effect for `5` seconds.
+
+```blocks
+music.play(music.createSoundExpression(WaveShape.Sine, 5000, 0, 255, 0, 5000, SoundExpressionEffect.None, InterpolationCurve.Linear), music.PlaybackMode.UntilDone)
 ```
 
 ## See also
 
-[play until done](/reference/music/play-until-done)
+[tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable),
+[melody playable](/reference/music/built-in-melody-playable),
+[create song](/reference/music/create-song),
+[stop all sounds](/reference/music/stop-all-sounds),
+[sound editor](/reference/types/sound#sound-editing),
+[create sound expression](/reference/music/create-sound-expression)

--- a/docs/types/playable.md
+++ b/docs/types/playable.md
@@ -22,6 +22,14 @@ Melodies are a series of notes and a tempo to play them at.
 music.stringPlayable("D F E A E A C B ", 120)
 ```
 
+### Sound Expression
+
+A sound expression is set of parameters that describe a **[sound](/types/sound)** that will last for some amount of time. These parameters specify a base waveform, frequency range, sound volume, and effects.
+
+```block
+music.play(music.createSoundExpression(WaveShape.Sine, 5000, 0, 255, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear), music.PlaybackMode.UntilDone)
+```
+
 ## Play the music
 
 In your programs, you can simply use the ``||music:play||`` blocks for each playable object. Like this one for tone:
@@ -47,5 +55,5 @@ for (let someMusic of playables) {
 
 ## See also
 
-[play](/reference/music/play), [tone playable](/reference/music/tone-playable),
-[string playable](/reference/music/string-playable)
+[play](/reference/music/play), [tone playable](/reference/music/tone-playable)
+[string playable](/reference/music/string-playable), [create sound expression](/reference/music/create-sound-expression)

--- a/docs/types/sound.md
+++ b/docs/types/sound.md
@@ -15,8 +15,8 @@ In code, a **Sound** type is a complex data object that includes data for all th
 Code for creating and playing a sound from a sound expression could look like this:
 
 ```typescript-ignore
-let mySound = music.createSoundEffect(WaveShape.Sine, 2000, 0, 1023, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
-music.playSoundEffect(mySound, SoundExpressionPlayMode.UntilDone)
+let mySound = music.createSoundExpression(WaveShape.Sine, 2000, 0, 1023, 0, 500, SoundExpressionEffect.None, InterpolationCurve.Linear)
+music.play(mySound, music.PlaybackMode.UntilDone)
 ```
 
 ### ~
@@ -59,7 +59,7 @@ A square wave has both verical rising and falling edges with a flat section on t
 
 ### Noise wave
 
-The noise wave is created using random frequenices and volume. Setting the frequency parameters for the sound expression creates a "tuning" range for the noise sound effect.
+The noise wave is created using random frequencies and volume. Setting the frequency parameters for the sound expression creates a "tuning" range for the noise sound effect.
 
 ![Noise wave](/static/types/sound/noise-wave.png)
 
@@ -85,9 +85,9 @@ The volume controls the loudness (amplitude) of the sound. The sound can start w
 
 ## Frequency
 
-Frequency is how fast a wave repeats itself from the zero line to its peak down to its trough and back to the zero line. If it does this 1000 times in one second then the frequency has 1000 cycles per second and is measured in units of Hertz (1000 Hz). The frequency of the sound at any point in time is its current _pitch_. Musical notes and parts of speech are different frequecies that last for short periods of time in a sound.
+Frequency is how fast a wave repeats itself from the zero line to its peak down to its trough and back to the zero line. If it does this 1000 times in one second then the frequency has 1000 cycles per second and is measured in units of Hertz (1000 Hz). The frequency of the sound at any point in time is its current _pitch_. Musical notes and parts of speech are different frequencies that last for short periods of time in a sound.
 
-A sound expression has both a starting frequency and an ending frequecy. The frequency can start low and end high, start high and end low, or remain the same for the duration of the sound.
+A sound expression has both a starting frequency and an ending frequency. The frequency can start low and end high, start high and end low, or remain the same for the duration of the sound.
 
 ### High to low
 
@@ -132,5 +132,5 @@ Interpolation is how the sound expression will make the changes in frequency or 
 
 ## See also
 
-[play sound effect](/reference/music/play-sound-effect),
-[create sound effect](/reference/music/create-sound-effect)
+[play](/reference/music/play),
+[create sound expression](/reference/music/create-sound-expression)

--- a/libs/core/_locales/core-strings.json
+++ b/libs/core/_locales/core-strings.json
@@ -249,7 +249,7 @@
   "String.isEmpty|block": "%this=text| is empty",
   "String.length|block": "length of %VALUE",
   "String.split|block": "split %this=text|at %separator",
-  "String.substr|block": "substring of %this=text|from %start|of length %length",
+  "String.substr|block": "substring of $this|from $start||of length $length",
   "String|block": "String",
   "TouchButtonEvent.LongPressed|block": "long pressed",
   "TouchButtonEvent.Pressed|block": "pressed",

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -436,7 +436,7 @@ namespace music {
      * @param interpolation interpolation method for frequency scaling
      */
     //% blockId=soundExpression_createSoundExpression
-    //% help=music/create-sound-effect
+    //% help=music/create-sound-expression
     //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
     //% waveShape.defl=WaveShape.Sine
     //% waveShape.fieldEditor=soundeffect


### PR DESCRIPTION
The `play()` and `SoundExpression` reference pages were a bit behind in documenting the current playable methods.

Closes #6301