### PR TITLE
Add Dark Theme (and fix a few theming bugs)

### DIFF
--- a/theme/blockly-toolbox.less
+++ b/theme/blockly-toolbox.less
@@ -20,7 +20,7 @@ span.blocklyTreeLabel {
     font-weight: 200;
 }
 
-.blocklyToolboxDiv, .monacoToolboxDiv {
+.blocklyToolbox, .monacoToolboxDiv {
     background-color: var(--pxt-target-background3) !important;
     color: var(--pxt-target-foreground3);
     box-shadow: 4px 0px 2px -4px var(--pxt-neutral-alpha10), 4px 0px 2px -4px var(--pxt-neutral-alpha20);
@@ -28,7 +28,7 @@ span.blocklyTreeLabel {
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-    .blocklyToolboxDiv, .monacoToolboxDiv {
+    .blocklyToolbox, .monacoToolboxDiv {
         border-left: 0 !important;
     }
     div.blocklyTreeRoot {
@@ -38,7 +38,7 @@ span.blocklyTreeLabel {
 
 /* Tablet */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-    .blocklyToolboxDiv, .monacoToolboxDiv {
+    .blocklyToolbox, .monacoToolboxDiv {
         border-left: 0 !important;
     }
     div.blocklyTreeRoot {

--- a/theme/blockly-toolbox.less
+++ b/theme/blockly-toolbox.less
@@ -4,7 +4,7 @@
 *******************************/
 
 div.blocklyTreeRow {
-    box-shadow: inset 0 -1px 0 0 #ecf0f1;
+    box-shadow: inset 0 -1px 0 0 var(--pxt-target-stencil3);
 
     margin-bottom: 0px !important;
 
@@ -21,8 +21,9 @@ span.blocklyTreeLabel {
 }
 
 .blocklyToolboxDiv, .monacoToolboxDiv {
-    background-color: white !important;
-    box-shadow: 4px 0px 2px -4px rgba(0,0,0,0.12), 4px 0px 2px -4px rgba(0,0,0,0.24);
+    background-color: var(--pxt-target-background3) !important;
+    color: var(--pxt-target-foreground3);
+    box-shadow: 4px 0px 2px -4px var(--pxt-neutral-alpha10), 4px 0px 2px -4px var(--pxt-neutral-alpha20);
 }
 
 /* Mobile */

--- a/theme/color-themes/microbit-dark.json
+++ b/theme/color-themes/microbit-dark.json
@@ -1,0 +1,122 @@
+{
+    "id": "microbit-dark",
+    "name": "Dark",
+    "weight": 60,
+    "monacoBaseTheme": "vs-dark",
+    "overrideFiles": [
+        "/overrides/microbit-dark-overrides.css"
+    ],
+    "colors": {
+        "pxt-header-background": "#181818",
+        "pxt-header-foreground": "#ffffff",
+        "pxt-header-background-hover": "#252525",
+        "pxt-header-foreground-hover": "#ffffff",
+        "pxt-header-stencil": "#323232",
+
+        "pxt-primary-background": "#0078D4",
+        "pxt-primary-foreground": "#ffffff",
+        "pxt-primary-background-hover": "#026EC1",
+        "pxt-primary-foreground-hover": "#ffffff",
+        "pxt-primary-accent": "#005ba1",
+
+        "pxt-secondary-background": "#63276d",
+        "pxt-secondary-foreground": "#f3f2f1",
+        "pxt-secondary-background-hover": "#742e80",
+        "pxt-secondary-foreground-hover": "#f3f2f1",
+        "pxt-secondary-accent": "#411a47",
+
+        "pxt-tertiary-background": "#0078d4",
+        "pxt-tertiary-foreground": "#ffffff",
+        "pxt-tertiary-background-hover": "#026EC1",
+        "pxt-tertiary-foreground-hover": "#ffffff",
+        "pxt-tertiary-accent": "#0894ff",
+
+        "pxt-target-background1": "#1F1F1F",
+        "pxt-target-foreground1": "#f3f2f1", 
+        "pxt-target-background1-hover": "#2c2c2c",
+        "pxt-target-foreground1-hover": "#ffffff",
+        "pxt-target-stencil1": "#3b3a39",
+
+        "pxt-target-background2": "#181818",
+        "pxt-target-foreground2": "#ffffff",
+        "pxt-target-background2-hover": "#252525",
+        "pxt-target-foreground2-hover": "#ffffff",
+        "pxt-target-stencil2": "#323232",
+
+        "pxt-target-background3": "#181818",
+        "pxt-target-foreground3": "#ffffff",
+        "pxt-target-background3-hover": "#252525",
+        "pxt-target-foreground3-hover": "#ffffff",
+        "pxt-target-stencil3": "#323232",
+
+        "pxt-neutral-background1": "#1F1F1F",
+        "pxt-neutral-foreground1": "#f3f2f1",
+        "pxt-neutral-background1-hover": "#2c2c2c",
+        "pxt-neutral-foreground1-hover": "#ffffff",
+        "pxt-neutral-stencil1": "#3b3a39",
+
+        "pxt-neutral-background2": "#181818",
+        "pxt-neutral-foreground2": "#ffffff",
+        "pxt-neutral-background2-hover": "#252525",
+        "pxt-neutral-foreground2-hover": "#ffffff",
+        "pxt-neutral-stencil2": "#3b3a39",
+
+        "pxt-neutral-background3": "#2d2d2d",
+        "pxt-neutral-foreground3": "#f3f2f1",
+        "pxt-neutral-background3-hover": "#202020",
+        "pxt-neutral-foreground3-hover": "#ffffff",
+        "pxt-neutral-stencil3": "#070707",
+        "pxt-neutral-background3-alpha90": "#2d2d2de6",
+
+        "pxt-neutral-base": "rgba(180, 180, 180, 1)",
+        "pxt-neutral-alpha0": "rgba(180, 180, 180, 0)",
+        "pxt-neutral-alpha10": "rgba(180, 180, 180, 0.1)",
+        "pxt-neutral-alpha20": "rgba(180, 180, 180, 0.2)",
+        "pxt-neutral-alpha50": "rgba(180, 180, 180, 0.5)",
+        "pxt-neutral-alpha80": "rgba(180, 180, 180, 0.8)",
+
+        "pxt-link": "#479ef5",
+        "pxt-link-hover": "#62abf5",
+        "pxt-focus-border": "#5caae5",
+
+        "pxt-colors-purple-background": "#63276d",
+        "pxt-colors-purple-foreground": "#f3f2f1",
+        "pxt-colors-purple-hover": "#742e80",
+        "pxt-colors-purple-alpha10": "#63276d19",
+
+        "pxt-colors-orange-background": "#7a2101",
+        "pxt-colors-orange-foreground": "#ffffff",
+        "pxt-colors-orange-hover": "#932801",
+        "pxt-colors-orange-alpha10": "#7a210119",
+
+        "pxt-colors-brown-background": "#50301a",
+        "pxt-colors-brown-foreground": "#ffffff",
+        "pxt-colors-brown-hover": "#633c20",
+        "pxt-colors-brown-alpha10": "#50301a19",
+
+        "pxt-colors-blue-background": "#0078D4",
+        "pxt-colors-blue-foreground": "#ffffff",
+        "pxt-colors-blue-hover": "#026EC1",
+        "pxt-colors-blue-alpha10": "#0078D419",
+
+        "pxt-colors-green-background": "#27ae60",
+        "pxt-colors-green-foreground": "#ffffff",
+        "pxt-colors-green-hover": "#1e8449",
+        "pxt-colors-green-alpha10": "#27ae6019",
+
+        "pxt-colors-red-background": "#e74c3c",
+        "pxt-colors-red-foreground": "#ffffff",
+        "pxt-colors-red-hover": "#c0392b",
+        "pxt-colors-red-alpha10": "#e74c3c19",
+
+        "pxt-colors-teal-background": "#1abc9c",
+        "pxt-colors-teal-foreground": "#ffffff",
+        "pxt-colors-teal-hover": "#16a085",
+        "pxt-colors-teal-alpha10": "#1abc9c19",
+
+        "pxt-colors-yellow-background": "#fde300",
+        "pxt-colors-yellow-foreground": "#000000",
+        "pxt-colors-yellow-hover": "#e4cc00",
+        "pxt-colors-yellow-alpha10": "#fde30019"
+    }
+}

--- a/theme/color-themes/microbit-dark.json
+++ b/theme/color-themes/microbit-dark.json
@@ -31,7 +31,7 @@
         "pxt-tertiary-foreground-hover": "#ffffff",
         "pxt-tertiary-accent": "#0894ff",
 
-        "pxt-target-background1": "#1F1F1F",
+        "pxt-target-background1": "#2D2D2D",
         "pxt-target-foreground1": "#f3f2f1", 
         "pxt-target-background1-hover": "#2c2c2c",
         "pxt-target-foreground1-hover": "#ffffff",
@@ -43,7 +43,7 @@
         "pxt-target-foreground2-hover": "#ffffff",
         "pxt-target-stencil2": "#323232",
 
-        "pxt-target-background3": "#181818",
+        "pxt-target-background3": "#1F1F1F",
         "pxt-target-foreground3": "#ffffff",
         "pxt-target-background3-hover": "#252525",
         "pxt-target-foreground3-hover": "#ffffff",

--- a/theme/color-themes/microbit-dark.json
+++ b/theme/color-themes/microbit-dark.json
@@ -31,9 +31,9 @@
         "pxt-tertiary-foreground-hover": "#ffffff",
         "pxt-tertiary-accent": "#0894ff",
 
-        "pxt-target-background1": "#2D2D2D",
+        "pxt-target-background1": "#2d2d2d",
         "pxt-target-foreground1": "#f3f2f1", 
-        "pxt-target-background1-hover": "#2c2c2c",
+        "pxt-target-background1-hover": "#202020",
         "pxt-target-foreground1-hover": "#ffffff",
         "pxt-target-stencil1": "#3b3a39",
 
@@ -61,12 +61,12 @@
         "pxt-neutral-foreground2-hover": "#ffffff",
         "pxt-neutral-stencil2": "#3b3a39",
 
-        "pxt-neutral-background3": "#2d2d2d",
+        "pxt-neutral-background3": "#202020",
         "pxt-neutral-foreground3": "#f3f2f1",
-        "pxt-neutral-background3-hover": "#202020",
+        "pxt-neutral-background3-hover": "#131313",
         "pxt-neutral-foreground3-hover": "#ffffff",
         "pxt-neutral-stencil3": "#070707",
-        "pxt-neutral-background3-alpha90": "#2d2d2de6",
+        "pxt-neutral-background3-alpha90": "#202020e6",
 
         "pxt-neutral-base": "rgba(180, 180, 180, 1)",
         "pxt-neutral-alpha0": "rgba(180, 180, 180, 0)",

--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -42,14 +42,12 @@
     border-color: var(--pxt-focus-border) !important;
 }
 
-#root:not(.miniSim, .fullscreensim) .simframe iframe {
-    /* Need a slight background around microbit simulator to make it stand out, since it's black on black otherwise */
-    border-radius: 2rem;
-    background: var(--pxt-neutral-alpha50);
-    padding: 0.5rem;
+#simulator #editorSidebar.editor-sidebar {
+    /* Need a lighter background for sidebar to make the simulator stand out, since it's black on black otherwise */
+    background-color: var(--pxt-target-background1);
 }
 
-#boardview {
+.fullscreensim #boardview {
     /* Gradient background is a little too intense in dark mode. Use a solid color instead */
     background: var(--pxt-target-background2);
 }

--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -11,8 +11,23 @@
     color: var(--pxt-target-foreground3);
 }
 
-.pxtToolbox .blocklyTreeIcon,
-.tutorial-container span.docs.inlineblock {
+.pxtToolbox #advanced > .blocklyTreeRow {
+    /* Better contrast for advanced section color */
+    border-color: var(--pxt-neutral-alpha80);
+}
+.pxtToolbox #advanced > .blocklyTreeRow .blocklyTreeIcon {
+    /* Better contrast for advanced section arrow icon */
+    color: var(--pxt-neutral-alpha80);
+}
+
+.pxtToolbox #serial .blocklyTreeIcon,
+.tutorial-container .serial span.docs.inlineblock {
+    /* Better contrast in toolbox & tutorial block colors, but try to preserve some of the icon color */
+    filter: brightness(1.2) saturate(2);
+}
+
+.pxtToolbox #control .blocklyTreeIcon,
+.tutorial-container .control span.docs.inlineblock {
     /* Better contrast in toolbox & tutorial block colors, but try to preserve some of the icon color */
     filter: brightness(1.2) saturate(2);
 }

--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -27,7 +27,7 @@
     border-color: var(--pxt-focus-border) !important;
 }
 
-.simframe iframe {
+#root:not(.miniSim, .fullscreensim) .simframe iframe {
     /* Need a slight border around microbit simulator to make it stand out, since it's black on black otherwise */
     border: 2px solid var(--pxt-neutral-alpha50);
     border-radius: 2rem;

--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -28,9 +28,15 @@
 }
 
 #root:not(.miniSim, .fullscreensim) .simframe iframe {
-    /* Need a slight border around microbit simulator to make it stand out, since it's black on black otherwise */
-    border: 2px solid var(--pxt-neutral-alpha50);
+    /* Need a slight background around microbit simulator to make it stand out, since it's black on black otherwise */
     border-radius: 2rem;
+    background: var(--pxt-neutral-alpha50);
+    padding: 0.5rem;
+}
+
+#boardview {
+    /* Gradient background is a little too intense in dark mode. Use a solid color instead */
+    background: var(--pxt-target-background2);
 }
 
 /* 

--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -1,0 +1,66 @@
+
+#langmodal #availablelocales .langoption .header {
+    /* Better contrast than default, which is purple */
+    color: var(--pxt-neutral-foreground1);
+}
+
+.pxtToolbox span.blocklyTreeLabel,
+.pxtToolbox .blocklyTreeSelected span.blocklyTreeLabel,
+.pxtToolbox .blocklyTreeSelected .blocklyTreeIcon {
+    /* Better contrast in toolbox */
+    color: var(--pxt-target-foreground3);
+}
+
+.pxtToolbox .blocklyTreeIcon,
+.tutorial-container span.docs.inlineblock {
+    /* Better contrast in toolbox & tutorial block colors, but try to preserve some of the icon color */
+    filter: brightness(1.2) saturate(2);
+}
+
+#mainmenu {
+    /* Some parts of the app use the same color as a background. This keeps the menu from blending in */
+    border-bottom: 1px solid var(--pxt-header-stencil);
+}
+
+.projectsdialog .ui.card:hover {
+    /* Neutral and target colors are the same in dark theme, so it helps to have a clearer border when hovering over cards. */
+    border-color: var(--pxt-focus-border) !important;
+}
+
+.simframe iframe {
+    /* Need a slight border around microbit simulator to make it stand out, since it's black on black otherwise */
+    border: 2px solid var(--pxt-neutral-alpha50);
+    border-radius: 2rem;
+}
+
+/* 
+ * Inverted image colors
+ */
+.barcharticon,
+.blockly-ws-search-next-btn,
+.blockly-ws-search-previous-btn,
+.blockly-ws-search-close-btn {
+    filter: invert(1);
+}
+
+.modals .ui.button.immersive-reader-button,
+#mainmenu .immersive-reader-button.ui.item,
+#simulator .editor-sidebar .immersive-reader-button.ui.item {
+    background-image: url("/static/icons/immersive-reader-light.svg") !important;
+}
+
+.carouselarrow {
+    /* Better contrast, especially against images in carousels */
+    opacity: 0.9;
+}
+
+/* For inverted buttons, it almost always looks better to have the background be dark instead of light (even though non-inverted has a light foreground) */
+button.ui.button.inverted:not(.teaching-bubble-button),
+button.common-button.inverted:not(.teaching-bubble-button) {
+    background-color: var(--pxt-neutral-background2) !important;
+}
+
+button.ui.button.inverted:hover:not(.teaching-bubble-button),
+button.common-button.inverted:hover:not(.teaching-bubble-button) {
+    background-color: var(--pxt-neutral-background2-hover) !important;
+}

--- a/theme/color-themes/overrides/microbit-light-overrides.css
+++ b/theme/color-themes/overrides/microbit-light-overrides.css
@@ -15,6 +15,14 @@
 /*
  * Adjustments to match the original micro:bit theme
  */
+path.blocklyFlyoutBackground {
+    fill: #4b4949 !important;
+}
+
+.monacoFlyout {
+    background: #4b4949 !important;
+}
+
 #simulator .editor-sidebar .filemenu {
     background: var(--pxt-secondary-background);
     color: var(--pxt-secondary-foreground);

--- a/theme/color-themes/overrides/microbit-light-overrides.css
+++ b/theme/color-themes/overrides/microbit-light-overrides.css
@@ -6,3 +6,39 @@
 .theme-preview-microbit-light .theme-preview-sim-button {
     background-color: var(--pxt-neutral-background2) !important;
 }
+
+#filelist, #editortools {
+    /* Special textured backgrounds, but we only have assets for light theme */
+    background: #fff url("/static/logo_texture.png") 0 0 repeat !important;
+}
+
+/*
+ * Adjustments to match the original micro:bit theme
+ */
+#simulator .editor-sidebar .filemenu {
+    background: var(--pxt-secondary-background);
+    color: var(--pxt-secondary-foreground);
+}
+
+#simulator .editor-sidebar .filemenu .item:hover, #simulator .editor-sidebar .filemenu .link.item:hover {
+    background: var(--pxt-secondary-background-hover) !important;
+    color: var(--pxt-secondary-foreground-hover) !important;
+}
+
+#simulator .ui.button.play-button .icon.play {
+    color: var(--pxt-colors-green-background) !important;
+}
+
+.simtoolbar .ui.button.icon {
+    background-color: #e0e1e2;
+    color: rgba(0,0,0,.6);
+}
+
+.simtoolbar .ui.button.icon:hover {
+    filter: none;
+    background-color: rgb(224, 225, 226);
+}
+
+#serialPreview .label {
+    border-color: var(--pxt-primary-background);
+}

--- a/theme/style.less
+++ b/theme/style.less
@@ -110,6 +110,10 @@
     }
 }
 
+.sound-effect-header {
+    background-color: rgb(230, 48, 34); // Match block color
+}
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
     #filelist {

--- a/theme/style.less
+++ b/theme/style.less
@@ -41,10 +41,6 @@
     color: var(--pxt-primary-foreground);
 }
 
-.ui.button.exit-tutorial-btn {
-    &:extend(.ui.inverted.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
-}
-
 #editortools .ui.button.editortools-btn, .simtoolbar .ui.button.icon {
     background-color: var(--pxt-secondary-background);
     color: var(--pxt-secondary-foreground);

--- a/theme/style.less
+++ b/theme/style.less
@@ -27,35 +27,49 @@
 }
 
 .ui.button.download-button {
-    &:extend(.ui.purple.button all);
+    background-color: var(--pxt-primary-background);
+    color: var(--pxt-primary-foreground);
 }
 
 .ui.button.hw-button {
-    background-color: darken(@purple, 10%);
+    background-color: var(--pxt-primary-accent);
+    color: var(--pxt-primary-foreground);
 }
 
 .docs.inlinebutton.ui.button.download-button:hover {
-    &:extend(.ui.purple.button all);
+    background-color: var(--pxt-primary-background);
+    color: var(--pxt-primary-foreground);
 }
 
 .ui.button.play-button.play-button-full {
-    &:extend(.ui.inverted.button all);
+    &:extend(.ui.inverted.button all); /* TODO : thsparks - check this */
 }
 
 .ui.button.getting-started-btn {
-    &:extend(.ui.orange.button all);
+    &:extend(.ui.orange.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
 }
 
 .ui.button.editortools-btn {
-    &:extend(.ui.blue.button all);
+    &:extend(.ui.blue.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
 }
 
 .ui.button.exit-tutorial-btn {
-    &:extend(.ui.inverted.button all);
+    &:extend(.ui.inverted.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
 }
 
-#filelist, #editortools {
-    background: #fff data-uri("../docs/static/logo_texture.png") 0 0 repeat !important;
+.simtoolbar .ui.button.icon {
+    background-color: var(--pxt-secondary-background);
+    color: var(--pxt-secondary-foreground);
+
+    &:hover {
+        filter: none;
+        background-color: var(--pxt-secondary-background-hover);
+        color: var(--pxt-secondary-foreground-hover);
+    }
+}
+
+#simulator .ui.button.play-button .icon.play {
+    color: var(--pxt-secondary-foreground) !important;
 }
 
 #downloadArea {

--- a/theme/style.less
+++ b/theme/style.less
@@ -32,8 +32,8 @@
 }
 
 .ui.button.hw-button {
-    background-color: var(--pxt-primary-accent);
-    color: var(--pxt-primary-foreground);
+    background-color: var(--pxt-primary-accent) !important;
+    color: var(--pxt-primary-foreground) !important;
 }
 
 .docs.inlinebutton.ui.button.download-button:hover {
@@ -41,23 +41,11 @@
     color: var(--pxt-primary-foreground);
 }
 
-.ui.button.play-button.play-button-full {
-    &:extend(.ui.inverted.button all); /* TODO : thsparks - check this */
-}
-
-.ui.button.getting-started-btn {
-    &:extend(.ui.orange.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
-}
-
-.ui.button.editortools-btn {
-    &:extend(.ui.blue.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
-}
-
 .ui.button.exit-tutorial-btn {
     &:extend(.ui.inverted.button all); /* TODO : thsparks - primary, secondary, etc... or move to overrides */
 }
 
-.simtoolbar .ui.button.icon {
+#editortools .ui.button.editortools-btn, .simtoolbar .ui.button.icon {
     background-color: var(--pxt-secondary-background);
     color: var(--pxt-secondary-foreground);
 


### PR DESCRIPTION
This adds a dark theme for micro:bit and fixes a few theming bugs along the way. While doing this work, I found a few places in the micro:bit styles.less that were hard-coded to light-theme-specific values. I themed them when I could and moved the rest into overrides.

Fixes https://github.com/microsoft/pxt-microbit/issues/6220
Fixes https://github.com/microsoft/pxt-microbit/issues/6196
Fixes https://github.com/microsoft/pxt-microbit/issues/6197

![image](https://github.com/user-attachments/assets/fce59a28-383d-4ee2-86d3-34381ea9a360)
![image](https://github.com/user-attachments/assets/0c30de8e-1757-45ea-a84c-2406857e8d0b)
![image](https://github.com/user-attachments/assets/3cb31759-3f03-4626-a191-5fc90d5a0e4d)
![image](https://github.com/user-attachments/assets/4f3330b4-c2d3-4433-86da-804ab6d8bfee)
![image](https://github.com/user-attachments/assets/3021ca03-fb9a-4adf-a2a1-a2fed2240930)
![image](https://github.com/user-attachments/assets/93602efc-65e6-4731-96bd-58b7f6ed29d5)
![image](https://github.com/user-attachments/assets/b7f3f85c-a104-4fa0-84e2-85bafaa5944b)

Remaining Work:
This does not address the issue of the control and serial categories having poor contrast against the workspace & toolbox backgrounds. That will require per-theme block coloring, which is quite a bit of work, so I think it's best left to a separate change: https://github.com/microsoft/pxt-microbit/issues/6342
![image](https://github.com/user-attachments/assets/7a646142-1e90-498f-b4b9-322f4861fb96)
![image](https://github.com/user-attachments/assets/be414595-db51-49bb-a4fc-58be8b365dd9)

