### PR TITLE
Microbit: Add AI Error Explainer Experiment to pxtarget

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -442,7 +442,8 @@
             "debugExtensionCode",
             "bluetoothUartConsole",
             "bluetoothPartialFlashing",
-            "identity"
+            "identity",
+            "forceEnableAiErrorHelp"
         ],
         "supportedExperiences": [
             "code-eval"


### PR DESCRIPTION
This includes the AI Error Explainer Experiment (added by https://github.com/microsoft/pxt/pull/10692) inside micro:bit's list of active experiments. The flag has no effect if the feature is already enabled for the user's geo.

![image](https://github.com/user-attachments/assets/81b96f23-233d-4d12-a9f8-7ab8264d6e5b)

