### PR TITLE
change repo paths for forward extensions

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -389,15 +389,15 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 ```codecard
 [{
    "name": "FWD Edu Smart Solder Kit",
-   "url": "/pkg/Forward-Education/pxt-solder-3b3l",
+   "url": "/pkg/Forward-Education/pxt-smart-soldering-3b3l",
    "cardType": "package"
 }, {   
    "name": "FWD Edu Smart Solar Kit",
-   "url": "/pkg/Forward-Education/pxt-solar",
+   "url": "/pkg/Forward-Education/pxt-smart-solar",
    "cardType": "package"
 }, {
    "name": "FWD Edu Smart Hydroponics Kit",
-   "url": "/pkg/Forward-Education/pxt-hydroponics",
+   "url": "/pkg/Forward-Education/pxt-smart-hydroponics",
    "cardType": "package"
 }, {
    "name": "BP Lab micro:bit Kit",


### PR DESCRIPTION
This is to get properly branded text to show up in the search card title. It seems to be derived from the repo name. Was advised to create copies of the repos and make this pull request in support ticket #89407.

We are expecting that with these changes the card titles will now be:
smart-solar
smart-hydroponics
smart-soldering-3b3l

instead of:
solar
hydroponics
solder-3b3l