### PR TITLE
Update simx hash for pxt-microbit-ml

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -489,7 +489,7 @@
             },
             "microbit-foundation/pxt-microbit-ml": {
                 "simx": {
-                    "sha": "ba99fd9588e87eb994345d04b596adc51d2d8116",
+                    "sha": "de376b74f38c8f7d805a0d5704205fffd7453da1",
                     "devUrl": "http://localhost:5173",
                     "aspectRatio": 3.45
                 },


### PR DESCRIPTION
This updates to a version that lower cases the language parameter which fixes translations for language codes like es-ES. It also adds support for Catalan.

Source diff: https://github.com/microbit-foundation/pxt-microbit-ml/compare/1e3147dc861695ad81398ed6d72ae6ea03a11351...e10cf6edb57e31e5bf9ae80ba85d93a2c834abf0 (only changes in simx are relevant)

deployment/demo:
https://microbit-foundation.github.io/pxt-microbit-ml/?language=es-ES

CC @microbit-matt-hillsdon @microbit-grace 