### PR TITLE
Remove white background from high contrast sim LEDs

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -182,6 +182,9 @@ path.sim-board {
 .sim-led {
     stroke: red;
 }
+.sim-led-back {
+    stroke: white;
+}
 *:focus .sim-button-outer,
 .sim-pin:focus,
 .sim-thermometer:focus,
@@ -286,9 +289,8 @@ path.sim-board {
         if (highContrast) {
             theme = JSON.parse(JSON.stringify(theme)) as IBoardTheme;
             theme.highContrast = true;
-            theme.ledOff = "#888";
-            theme.ledOn = "#0000bb";
-            theme.display = "#ffffff";
+            theme.ledOff = "#000000";
+            theme.ledOn = "#FF0000";
             theme.pin = "#D4AF37";
             theme.accent = "#FFD43A";
         }


### PR DESCRIPTION
Previously, we used a white background for the sim LEDs in high contrast mode, I suspect so that it contrasted with the _unlit_ LEDs as well as the lit ones. But it looks a little like a bug...instead of doing it that way, we can use the normal red-on-black appearance (with slightly brighter red) and outline the unlit LEDs with white.

Fixes https://github.com/microsoft/pxt-microbit/issues/6366

Before:
![image](https://github.com/user-attachments/assets/537a787e-e240-47b5-978f-3b3b3fed366f)

After:
![image](https://github.com/user-attachments/assets/bc716604-16c7-4dfc-b98b-0254f35a5b5c)

