### PR TITLE
Update microbit.org buy page links

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -17,7 +17,7 @@ The BBC micro:bit is packaged with sensors, radio, microphone, speaker and other
 
 ## ~ hint
 
-**Looking to buy a micro:bit?** See the [list of resellers](https://microbit.org/resellers).
+**Looking to buy a micro:bit?** See the [list of official products](https://microbit.org/buy/).
 
 ## ~
 

--- a/docs/courses/csintro/introduction.md
+++ b/docs/courses/csintro/introduction.md
@@ -18,9 +18,9 @@ In this course, youâ€™ll be working on projects where you actually build thingsâ
 
 ![micro:bit man](/static/courses/csintro/microbitman.jpg)
 
-* micro:bits may be purchased from these resellers:
+* micro:bits may be purchased from resellers:
 
->   http://microbit.org/resellers (you will need at least 1 micro:bit for this course).  The "micro:bit Go Kit" includes a battery pack and USB cable as well.
+>   https://microbit.org/buy/ (you will need at least 1 micro:bit for this course).  The "BBC micro:bit Go" includes a battery pack and USB cable as well.
 
 * Other optional suggested micro:bit accessories include:
 

--- a/docs/device.md
+++ b/docs/device.md
@@ -4,7 +4,7 @@
 
 #### Looking to buy a micro:bit?
 
-See the [list of resellers](https://microbit.org/resellers).
+See the [list of official products](https://microbit.org/buy/).
 
 ### ~
 

--- a/docs/test/courses/csintro/introduction.md
+++ b/docs/test/courses/csintro/introduction.md
@@ -18,9 +18,9 @@ In this course, youâ€™ll be working on projects where you actually build thingsâ
 
 ![micro:bit man](/static/courses/csintro/microbitman.jpg)
 
-* micro:bits may be purchased from these resellers:
+* micro:bits may be purchased from resellers:
 
->   http://microbit.org/resellers (you will need at least 1 micro:bit for this course).  The "micro:bit Go Kit" includes a battery pack and USB cable as well.
+>   https://microbit.org/buy/ (you will need at least 1 micro:bit for this course).  The "BBC micro:bit Go" includes a battery pack and USB cable as well.
 
 * Other optional suggested micro:bit accessories include:
 

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -468,7 +468,7 @@
             },
             {
                 "name": "Buy",
-                "path": "https://microbit.org/resellers"
+                "path": "https://microbit.org/buy/"
             }
         ],
         "hasReferenceDocs": true,


### PR DESCRIPTION
Update links to the microbit.org buy page (use the product listing page we added a while back).
Fix the product name of “BBC micro:bit Go” so it’s easy for folks to find on that page.

cc: @microbit-matt-hillsdon 

Preview url: https://update-buy.pxt-microbit.pages.dev/