### PR TITLE
Disable AI Error Help in all geos (for now)

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -432,10 +432,7 @@
         "allowPackageExtensions": true,
         "addNewTypeScriptFile": true,
         "enabledFeatures": {
-            "blocksErrorList": {},
-            "aiErrorHelp": {
-                "includeRegions": ["US"]
-            }
+            "blocksErrorList": {}
         },
         "experiments": [
             "accessibleBlocks",


### PR DESCRIPTION
Feature is still available as an experiment.