### PR TITLE
Error Helper AI FAQ

### DIFF
--- a/docs/ai-faq.md
+++ b/docs/ai-faq.md
@@ -1,0 +1,30 @@
+# MakeCode AI Features
+
+## Responsible AI FAQ
+
+MakeCode is introducing AI-powered features to enhance the learning and teaching experiences on the platform. These tools are designed to provide educational support while maintaining responsible AI practices.
+
+### AI Features Overview
+
+MakeCode now includes several AI-powered tools to support both students and educators:
+
+- **Error Helper**: Helps students understand and resolve coding errors with AI-generated explanations
+- **Code Evaluation Tool**: Assists teachers in evaluating and providing feedback on student projects
+
+### Feature-Specific FAQs
+
+For detailed information about each AI feature, including their capabilities, limitations, and responsible use guidelines, please visit the specific FAQ pages:
+
+#### [Error Helper AI FAQ](/errorhelper/ai-faq)
+Learn about the AI-powered Error Helper that walks students through exceptions in their projects.
+
+#### [Code Evaluation Tool AI FAQ](/teachertool/ai-faq)
+Learn about the AI tool designed to help teachers evaluate and provide feedback on student programs.
+
+### General AI Principles
+
+All MakeCode AI features are designed with the following principles:
+
+- **Educational Focus**: Tools are specifically designed for learning and teaching scenarios
+- **Transparency**: Clear information about what each tool does and its limitations
+- **Safety**: Built-in safeguards and content filtering appropriate for educational environments

--- a/docs/errorhelper/ai-faq.md
+++ b/docs/errorhelper/ai-faq.md
@@ -8,7 +8,7 @@ The MakeCode Error Helper is an AI-powered tool to help students understand codi
 
 ### 2. What can the MakeCode Error Helper do?
 
-The MakeCode Error Helper sends the student's current code along with the exception details to DeepPrompt (a Microsoft Azure LLM service) along with some contextual prompt information. It returns a detailed analysis that explains the error in student-friendly language.
+The MakeCode Error Helper sends the student's current code along with the exception details to DeepPrompt (a Microsoft Azure LLM service) along with some contextual prompt information. It returns a detailed walkthrough of the error in student-friendly language.
 
 ### 3. What is MakeCode Error Helper's intended use?
 

--- a/docs/errorhelper/ai-faq.md
+++ b/docs/errorhelper/ai-faq.md
@@ -1,0 +1,23 @@
+# Microsoft MakeCode Error Helper
+
+## Responsible AI FAQ
+
+### 1. What is the MakeCode Error Helper?
+
+The MakeCode Error Helper is an AI-powered tool to help students understand coding errors in their projects. When an exception occurs, students can click an "Explain with AI" button in the problems window to get an AI-generated walkthrough of the issue. The tool analyzes the student's code and the specific exception to provide detailed, educational feedback about what went wrong and how to fix it.
+
+### 2. What can the MakeCode Error Helper do?
+
+The MakeCode Error Helper sends the student's current code along with the exception details to DeepPrompt (a Microsoft Azure LLM service) along with some contextual prompt information. It returns a detailed analysis that explains the error in student-friendly language.
+
+### 3. What is MakeCode Error Helper's intended use?
+
+The MakeCode Error Helper is intended to help students learn from their coding mistakes by providing educational walkthroughs of exceptions. It aims to transform frustrating error messages into learning opportunities by explaining what went wrong and how to fix it in an understandable way.
+
+### 4. How was the MakeCode Error Helper evaluated? What metrics are used to measure performance?
+
+The system was evaluated with hundreds of coding errors and exceptions from student projects to ensure the responses are accurate, educational, and grounded. We evaluated accuracy with red teaming and expert review of responses.
+
+### 5. What are the limitations of the MakeCode Error Helper? How can users minimize the impact of the Error Helper's limitations when using the system?
+
+The Error Helper is designed specifically for compile-time and runtime exceptions in MakeCode programming environments. It may not perform well for complex or niche errors, and cannot be invoked for issues that don't generate exceptions. Students should still be encouraged to think through problems independently and to verify responses from the AI, using the Error Helper as a learning aid rather than a replacement for developing debugging skills.


### PR DESCRIPTION
This adds a dedicated AI FAQ page for the MakeCode Error Helper, as needed per RAI requirements. Content is based on the existing AI FAQ page for code evaluation: https://makecode.microbit.org/teachertool/ai-faq

It also adds a generic, overall AI FAQ page that links out to the more-specific subpages, as requested in https://github.com/microsoft/pxt-microbit/issues/6350#issuecomment-3009301373

For transparency: most of this text was AI generated, then revised by me. Worth some extra scrutiny, in case I missed anything.