### PR TITLE
[pxt-cli] bump version to v8.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-microbit",
-    "version": "8.0.3",
+    "version": "8.0.4",
     "description": "micro:bit target for Microsoft MakeCode (PXT)",
     "keywords": [
         "JavaScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.