### PR TITLE
Revert "Update CODAL to v0.3.1. (#6452)", back to v0.3.0.

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -200,7 +200,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.3.1",
+                    "branch": "v0.3.0",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
This reverts commit 6bdcb3e645ebaf299a767ae29d462013ab9e7f3b from PR:
- https://github.com/microsoft/pxt-microbit/pull/6452.

Unfortunately we did find an issue in CODAL v0.3.1: 
- https://github.com/lancaster-university/codal-microbit-v2/issues/499

So we'll have to revert back to v0.3.0. This release has two sound level bugs:
- When the board is reset, first sound level value is always zero
- When the pipeline is shut down (microphone LED off), the first sound level reading is the last value from the previous run

Having the microphone LED on when a programme doesn't use the microphone likely affects a lot more users, so it's probably best to revert.

For the previous v0.3.0 tag we tested with relevant sound-related projects from the microbit.org Make-it-code-it projects:
- https://microbit.org/projects/make-it-code-it/?filters=8b3fcf5a-0ad4-4c12-9f4e-109cfba7c9db
- https://microbit.org/projects/make-it-code-it/?filters=55cf6247-cc32-4c39-97a9-1be69c3441a7
- https://microbit.org/projects/make-it-code-it/?filters=8c2e3990-4b3b-4925-8972-9cdc60e49f10

The only issues that we found where those listed before, so apart from that v0.3.0 should be ready for release.
We'll aim to make a bug-fix v0.3.2. release next week.