### PR TITLE
Hide eval from share page

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -620,7 +620,7 @@
         }
     },
     "teachertool": {
-        "showSharePageEvalButton": true,
+        "showSharePageEvalButton": false,
         "defaultChecklistUrl": "teachertool/checklists/general-code-quality.json",
         "carousels": [
             {


### PR DESCRIPTION
Hiding until we can resolve issues with timeouts on AI Eval