### PR TITLE
Enable AI Error Helper in Canada

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -432,7 +432,10 @@
         "allowPackageExtensions": true,
         "addNewTypeScriptFile": true,
         "enabledFeatures": {
-            "blocksErrorList": {}
+            "blocksErrorList": {},
+            "aiErrorHelp": {
+                "includeRegions": ["CA"]
+            }
         },
         "experiments": [
             "debugExtensionCode",


### PR DESCRIPTION
This enables the AI Error Helper by default in Canada (no need to turn on the experiment).