### PR TITLE
Extension: add FWD Edu Climate Action Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -468,6 +468,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
   "url":"/pkg/joy-it/pxt-RB-JoyPi-Advanced",
   "cardType": "package"
 }, {
+   "name": "FWD Edu Climate Action Kit",
+   "url": "/pkg/Forward-Education/pxt-climate-action",
+   "cardType": "package"
+}, {
   "name": "FWD Edu Climate Action Kit Gen. 2 Kit",
   "url":"/pkg/climate-action-kits/pxt-fwd-edu",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -487,6 +487,7 @@
             "forward-education/pxt-smart-soldering": { "tags": [ "Science" ] },
             "forward-education/pxt-smart-solar": { "tags": [ "Science" ] },
             "forward-education/pxt-smart-hydroponics": { "tags": [ "Science" ] },
+            "forward-education/pxt-climate-action": { "tags": [ "Science" ] },
             "elecfreaks/pxt-petal": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/90233 (private)
@ssande-fwd
@abchatra

Extension: https://github.com/Forward-Education/pxt-climate-action
Version: 1.0.3
All blocks: https://makecode.microbit.org/_hz9eeThka9Ex

<img width="852" height="522" alt="image" src="https://github.com/user-attachments/assets/24df0bf9-7c37-425f-af52-619af785219c" />

<img width="788" height="660" alt="image" src="https://github.com/user-attachments/assets/02e2eeb7-ecce-4c56-972f-258c09005580" />
