### PR TITLE
Extension: add Kitronik Mai-Z the Mouse Bot

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -553,6 +553,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Kitronik Mai-Z the Mouse Bot",
+  "url":"/pkg/KitronikLtd/pxt-kitronik-mai-z",
+  "cardType": "package"
+}, {
   "name": "DFRobot Creative Robotics Kit",
   "url":"/pkg/DFRobot/pxt-DFRobot_creative-robotics-kit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -489,6 +489,7 @@
             "forward-education/pxt-smart-hydroponics": { "tags": [ "Science" ] },
             "forward-education/pxt-climate-action": { "tags": [ "Science" ] },
             "elecfreaks/pxt-petal": { "tags": [ "Science" ] },
+            "kitronikltd/pxt-kitronik-mai-z": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/90078 (private)
@MaxAtKitronik
@abchatra

Extension: https://github.com/KitronikLtd/pxt-kitronik-mai-z
Version: 1.0.6
All blocks:  https://makecode.microbit.org/_ThR46RC1y7i8

<img width="993" height="562" alt="image" src="https://github.com/user-attachments/assets/27bd0fc9-2b80-44ee-b05e-d8239a3cf01a" />
