### PR TITLE
Extensions: Set pxt-sound-level-db to upgrade to v0.1.13.

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -345,7 +345,10 @@
             "stemhub/pxt-stemhubcity": { "tags": [ "Science" ] },
             "kittenbot/pxt-powerbrick": { "tags": [ "Science" ] },
             "microbit-foundation/pxt-microbit-v2-power": { "tags": [ "Software" ] },
-            "microbit-foundation/pxt-sound-level-db": { "tags": [ "Software" ] },
+            "microbit-foundation/pxt-sound-level-db": {
+                "tags": [ "Software" ],
+                "upgrades": [ "min:v0.1.13" ]
+            },
             "kittenbot/pxt-joyfrog": { "tags": [ "Gaming" ] },
             "kittenbot/pxt-sugar": { "tags": [ "Science" ] },
             "kittenbot/pxt-koi": { "tags": [ "Science" ] },


### PR DESCRIPTION
Versions below v0.1.10 are incompatible with CODAL v0.3.x used in MakeCode v8, and versions below v0.1.13 had an issue at the point the projects are upgraded to the latest extension release. So upgrading any project to v0.1.13+ should be safe.

I've tested localy this upgrade with multiple projects using versions v0.1.13+ and it works correctly (thanks @riknoll for the help with the block ID issue!).