### PR TITLE
Extension: add Smarthon Smart Home IoT Maker Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -388,6 +388,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+   "name": "Smarthon Smart Home IoT Maker Kit",
+   "url": "/pkg/SMARTHON/pxt-smarthome",
+   "cardType": "package"
+}, {
    "name": "FWD Edu Smart Solder Kit",
    "url": "/pkg/Forward-Education/pxt-smart-soldering",
    "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -429,6 +429,7 @@
             "forward-education/pxt-climate-action": { "tags": [ "Science" ] },
             "elecfreaks/pxt-petal": { "tags": [ "Science" ] },
             "kitronikltd/pxt-kitronik-mai-z": { "tags": [ "Robotics" ] },
+            "smarthon/pxt-smarthome": { "tags": [ "Networking" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/71939 (private)
@SMARTHON
@abchatra 

Extension: https://github.com/SMARTHON/pxt-smarthome
Version: 1.8.2
Product: https://en.smarthon.cc/micro-bit-smart-home-kit
All blocks: https://makecode.microbit.org/_hAHMAvf8Y1j3

<img width="972" height="386" alt="image" src="https://github.com/user-attachments/assets/496f7153-cafe-4414-a286-6346acf22b12" />
