### PR TITLE
Extension: add BrailleBot

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -557,6 +557,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "BrailleBot",
+  "url":"/pkg/roborisen/braillebot",
+  "cardType": "package"
+}, {
   "name": "Kitronik Mai-Z the Mouse Bot",
   "url":"/pkg/KitronikLtd/pxt-kitronik-mai-z",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -429,6 +429,7 @@
             "forward-education/pxt-climate-action": { "tags": [ "Science" ] },
             "elecfreaks/pxt-petal": { "tags": [ "Science" ] },
             "kitronikltd/pxt-kitronik-mai-z": { "tags": [ "Robotics" ] },
+            "roborisen/braillebot": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from ticket https://support.microbit.org/helpdesk/tickets/66578 (private)
@roborisen
@abchatra

Extension: https://github.com/roborisen/braillebot
Version: 1.0.75
All blocks: https://makecode.microbit.org/_f7aWK4KKuKVb

<img width="770" height="512" alt="image" src="https://github.com/user-attachments/assets/092d36f2-7b7c-4268-8049-5040ab9b4d23" />
