### PR TITLE
try with beta

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -453,7 +453,7 @@
             "jacdac/pxt-jacdac-test": {
                 "hidden": true,
                 "simx": {
-                    "sha": "8bab6a87265dc3e1e008a716a478306964b6d889",
+                    "sha": "3c60854f6e658971521ead73ceb6c0a9676ffb36",
                     "devUrl": "https://jacdac.github.io/pxt-jacdac-test/index.html"
                 }
             }


### PR DESCRIPTION
this test will confirm that that gatsby pathPrefix needs to include "beta" to work with beta versions of MakeCode editors.