### PR TITLE
Extension: add Backyard Brains Spiker:Bit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -899,6 +899,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+    "name": "Backyard Brains Spiker:Bit",
+    "url": "/pkg/BackyardBrains/pxt-spikerbit",
+    "cardType": "package"
+}, {
     "name": "Elecfreaks Petal:bit",
     "url": "/pkg/elecfreaks/pxt-petal",
     "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -430,6 +430,7 @@
             "elecfreaks/pxt-petal": { "tags": [ "Science" ] },
             "kitronikltd/pxt-kitronik-mai-z": { "tags": [ "Robotics" ] },
             "roborisen/braillebot": { "tags": [ "Robotics" ] },
+            "backyardbrains/pxt-spikerbit": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/92246 (private)
@stanislavmircic
@abchatra

Extension: https://github.com/BackyardBrains/pxt-spikerbit
Version: 1.0.6
All blocks: https://makecode.microbit.org/_Ws5LFw47pPai

<img width="838" height="535" alt="image" src="https://github.com/user-attachments/assets/d457598d-5a34-4003-9ce0-982590a60489" />
