### PR TITLE
Code QL analysis should be done on correct commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,15 +21,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@main
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
### Problem
At some point it was neccessary to checkout a commit two behind the current head for code analysis. This is no longer the case, and is in fact the reason all of the Code QL runs are being ignored in the `Security` tab.
<img width="1367" height="140" alt="image" src="https://github.com/user-attachments/assets/94368c94-023a-4fa6-9157-55faec3392fb" />

### Solution
- Update the CodeQL yml to run the analysis against the current commit
- Limit CodeQL runs to important branches, and on pushes against the master branch