### PR TITLE
pxtarget.json: codal-microbit-v2 dependency updated from v0.3.2 to v0.3.3

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -200,7 +200,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/lancaster-university/codal-microbit-v2",
-                    "branch": "v0.3.3",
+                    "branch": "v0.3.4",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",


### PR DESCRIPTION
codal-microbit-v2 v0.3.3 is a [codal-core bump](https://github.com/lancaster-university/codal-core/commit/1bc6d4d10c47f4fe34e2a54004530d5071e892d4) to fix a bug with the ST7735 driver therein.
