### PR TITLE
Extension: add Siyeenove mShield

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -561,6 +561,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Siyeenove mShield",
+  "url":"/pkg/siyeenove/pxt_mshield",
+  "cardType": "package"
+}, {
   "name": "BrailleBot",
   "url":"/pkg/roborisen/braillebot",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -432,6 +432,7 @@
             "smarthon/pxt-smarthome": { "tags": [ "Networking" ] },
             "roborisen/braillebot": { "tags": [ "Robotics" ] },
             "backyardbrains/pxt-spikerbit": { "tags": [ "Science" ] },
+            "siyeenove/pxt_mshield": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/93144 (private)
@Siyeenove
@abchatra 

Extension: https://github.com/siyeenove/pxt_mshield
Version: 1.1.1
All blocks: https://makecode.microbit.org/_CyyPRWRYdhrp

<img width="842" height="429" alt="image" src="https://github.com/user-attachments/assets/afeac495-71fc-4711-839b-c17e08a6953b" />
