### PR TITLE
Extension: add Siyeenove Pybit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -561,6 +561,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Siyeenove Pybit",
+  "url":"/pkg/siyeenove/pxt_pybit",
+  "cardType": "package"
+}, {
   "name": "Siyeenove mShield",
   "url":"/pkg/siyeenove/pxt_mshield",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -433,6 +433,7 @@
             "roborisen/braillebot": { "tags": [ "Robotics" ] },
             "backyardbrains/pxt-spikerbit": { "tags": [ "Science" ] },
             "siyeenove/pxt_mshield": { "tags": [ "Robotics" ] },
+            "siyeenove/pxt_pybit": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/93368 (private)
@siyeenove
@abchatra

Extension: https://github.com/siyeenove/pxt_pybit
Version:1.0.1
All blocks: https://makecode.microbit.org/_4pD9Wt5DucrM

<img width="1028" height="732" alt="image" src="https://github.com/user-attachments/assets/7feacb57-c8ec-4587-bd76-234be38e1160" />
