### PR TITLE
Add note for extensions using v2 features in 'device/v2' page

### DIFF
--- a/docs/device/v2.md
+++ b/docs/device/v2.md
@@ -9,7 +9,7 @@ Let's learn how this works in MakeCode...
 ![works with micro:bit v2 only image](/static/v2/v2-only.png)
 <br/>
 
-The following blocks require the micro:bit v2 hardware to run.
+Here are the standard blocks that **require** micro:bit v2 hardware to run.
 
 ```block
 let pressed = input.logoIsPressed()
@@ -23,7 +23,7 @@ input.onSound(DetectedSound.Loud, function () {})
 input.onLogoEvent(TouchButtonEvent.Pressed, function () {})
 ```
 
-If your program tries to run any of these blocks on a micro:bit v1 board, you will see the ``927`` error code scroll across your screen.
+If your program tries to run any of these blocks on a micro:bit **v1** board, you will see the **927** error code scroll across your screen.
 
 ```sim
 basic.forever(function() {
@@ -31,6 +31,15 @@ basic.forever(function() {
     basic.pause(2000)
 })
 ```
+
+### ~ alert
+
+#### v2 features in extension blocks
+
+if you're using blocks from a loaded extension, such as [Datalogger](/reference/datalogger), that are using any newer **v2** features on a **v1** board, you will also see the **927** error when your program tries to run those blocks.
+
+### ~
+
 
 ### New blocks reference
 


### PR DESCRIPTION
Add a note to explain that blocks in loaded extensions with raise the 927 error if run on v1 hardware.

Closes #6347