### PR TITLE
Add 'clear screen' to step 3 description for Tug-of-LED

### DIFF
--- a/docs/projects/spy/tug-of-led.md
+++ b/docs/projects/spy/tug-of-led.md
@@ -20,7 +20,7 @@ let rope = 2
 
 ## {Step 2}
 
-Add a ``||basic:forever||`` loop that turns on the LED at the position set in ``||variables:rope||``.
+Add a ``||basic:forever||`` loop that will ``||basic:clear screen||`` and turn on the LED at the position set in ``||variables:rope||``.
 
 ```spy
 let rope = 2

--- a/docs/projects/tug-of-led.md
+++ b/docs/projects/tug-of-led.md
@@ -19,7 +19,7 @@ let rope = 2
 
 ## {Step 2}
 
-Add a ``||basic:forever||`` loop that turns on the LED at the ``||variables:rope||`` position.
+In the ``||basic:forever||`` loop, put in a ``||basic:clear screen||`` and plot an LED at the ``||variables:rope||`` position.
 
 ```blocks
 let rope = 2


### PR DESCRIPTION
The existing hint contains `basic.clearScreen()` but isn't mentioned in the step description. Add 'clear screen' to the description.

Closes #5804