### PR TITLE
Extension: add BestModules BMduino

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -911,6 +911,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+    "name": "BestModules BMduino",
+    "url": "/pkg/BestModules-Libraries/pxt-bmduino",
+    "cardType": "package"
+}, {
     "name": "Backyard Brains Spiker:Bit",
     "url": "/pkg/BackyardBrains/pxt-spikerbit",
     "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -434,6 +434,7 @@
             "backyardbrains/pxt-spikerbit": { "tags": [ "Science" ] },
             "siyeenove/pxt_mshield": { "tags": [ "Robotics" ] },
             "siyeenove/pxt_pybit": { "tags": [ "Robotics" ] },
+            "bestmodules-libraries/pxt-bmduino": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/93572 (private)
@BestModules-Libraries
@abchatra

Extension: https://github.com/BestModules-Libraries/pxt-bmduino
Version: 1.0.3
Product: https://www.bestmodulescorp.com/en/bmb81tm01a.html
All blocks: https://makecode.microbit.org/_2LD3913iWYCY

<img width="1216" height="668" alt="image" src="https://github.com/user-attachments/assets/80cd8181-8714-46ad-9528-311d9ce455bd" />

<img width="1067" height="717" alt="image" src="https://github.com/user-attachments/assets/42736841-31fe-457d-810a-73592dd0575c" />
