### PR TITLE
Explicitly mention 'for' loop limit in step 5 of "Turtle Square"

### DIFF
--- a/docs/projects/turtle-square.md
+++ b/docs/projects/turtle-square.md
@@ -43,7 +43,7 @@ input.onButtonPressed(Button.A, function() {
 
 ## "for" is for repetition
 
-Did you notice the pattern of repeated blocks needed to draw a square? Try using a ``for`` loop to achieve the same effect.
+Did you notice the pattern of repeated blocks needed to draw a square? Try using a ``for`` loop with an `index` limit of **3** to achieve the same effect.
 
 ```blocks
 input.onButtonPressed(Button.A, function() {


### PR DESCRIPTION
Mention the loop limit for the `index` in the `for` loop of step 5. Seems that some users may miss this after dropping in the loop block.

This could get preset as a custom toolbox block if `blockconfig` worked in this target?

````
```blockconfig.global
for(let index = 0; index <= 3; index++) {}
```
````

Closes #5841