### PR TITLE
prevent pxt-core types from leaking into target extension builds

### DIFF
--- a/compiler/tsconfig.json
+++ b/compiler/tsconfig.json
@@ -12,6 +12,7 @@
         "newLine": "LF",
         "sourceMap": false,
         "typeRoots": ["../node_modules/@types"],
+        "types": [],
         "lib": [
             "dom",
             "dom.iterable",

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -19,6 +19,7 @@
             "scripthost",
             "es2017",
             "ES2018.Promise"
-        ]
+        ],
+        "types": []
     }
 }

--- a/fieldeditors/tsconfig.json
+++ b/fieldeditors/tsconfig.json
@@ -9,6 +9,7 @@
         "newLine": "LF",
         "sourceMap": false,
         "allowSyntheticDefaultImports": true,
-        "declaration": true
+        "declaration": true,
+        "types": []
     }
 }

--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -14,7 +14,8 @@
             "dom.iterable",
             "scripthost",
             "es2017"
-        ]
+        ],
+        "types": []
     },
     "include": [
         "*.ts",


### PR DESCRIPTION
fixes the build problems. the typings i added for the audio worklet in pxt were leaking into the compilation of the target extensions. could also fix this by updating the target es version, but figured i might as well just prevent this from happening in the future by explicitly putting in a types array