### PR TITLE
[stable8.0] Update @types/node version to ^16.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "devDependencies": {
         "@types/dom-mediacapture-record": "1.0.20",
         "@types/marked": "0.3.0",
-        "@types/node": "8.10.66",
+        "@types/node": "^16.18.0",
         "@types/react": "16.4.7",
         "@types/react-dom": "16.0.3",
         "@types/web-bluetooth": "0.0.4",


### PR DESCRIPTION
for electron build, i was able to reproduce the typing failure by fulling clearing install; transitive dependency on @types/ws conflicts with this version, and build went through locally with this version. Making this on stable branch first so i can get a version out today / build electron app but will check if this needs to be ported elsewhere after