### PR TITLE
Set and explain the 'Show data' console button in the "Plot Acceleration" tutorial

### DIFF
--- a/docs/projects/plot-acceleration.md
+++ b/docs/projects/plot-acceleration.md
@@ -19,7 +19,17 @@ basic.forever(function() {
 
 ## Console
 
-Click on the **Show Console** button by the simulator to see a chart of the values plotted by the block over a period of time. Hover over the board in the simulator to make a force in the ``x`` dimension.
+Click on the **(+)** in the ``||led:plot bar graph||`` block to expand it. The ``||led:serial write||`` parameter will appear and is set to **ON**. Now, after a moment, the **Show data Simulator** button will show up near the simulator. Click on it to see a chart of the values plotted by the block over a period of time. Hover over the board in the simulator to make a force in the ``x`` dimension.
+
+```blocks
+basic.forever(function() {
+    led.plotBarGraph(
+        input.acceleration(Dimension.X),
+        0,
+        true
+    )
+})
+```
 
 ## Maximum value
 
@@ -30,7 +40,8 @@ For example, we can tell the block that we don't expect values beyond ``1000`` m
 basic.forever(function() {
     led.plotBarGraph(
         input.acceleration(Dimension.X),
-        1000
+        1000,
+        true
     )
 })
 ```
@@ -43,7 +54,8 @@ You can use this block for pretty much any kind of data. Try it out! Plot the ``
 basic.forever(function() {
     led.plotBarGraph(
         input.lightLevel(),
-        0
+        0,
+        true
     )
 })
 ```


### PR DESCRIPTION
Explain how to expand the parms for the ``led.plotBarGraph`` block, use the **Show data** button, and update the hints to show the serial write parm.

**Note**: Using ```` ```blockconfig.global```` to show the expanded block won't show it expanded in the toolbox. So, I chose to just explain it and have it expanded in the hints.

Closes #6734 

@martinwork 