### PR TITLE
add unit conversion block

### DIFF
--- a/libs/core/helpers.ts
+++ b/libs/core/helpers.ts
@@ -6,11 +6,7 @@ enum UnitConversion {
     //% block="celsius to fahrenheit"
     CelsiusToFahrenheit,
     //% block="fahrenheit to celsius"
-    FahrenheitToCelsius,
-    //% block="seconds to milliseconds"
-    SecondsToMilliseconds,
-    //% block="milliseconds to seconds"
-    MillisecondsToSeconds
+    FahrenheitToCelsius
 }
 
 namespace Math {
@@ -38,8 +34,6 @@ namespace Math {
             case UnitConversion.RadiansToDegrees: return value * 57.29577951308232;
             case UnitConversion.CelsiusToFahrenheit: return (value * 1.8) + 32;
             case UnitConversion.FahrenheitToCelsius: return (value - 32) * 0.5555555555555556;
-            case UnitConversion.SecondsToMilliseconds: return value * 1000;
-            case UnitConversion.MillisecondsToSeconds: return value / 1000;
         }
         return value;
     }

--- a/libs/core/helpers.ts
+++ b/libs/core/helpers.ts
@@ -1,10 +1,46 @@
+enum UnitConversion {
+    //% block="degrees to radians"
+    DegreesToRadians,
+    //% block="radians to degrees"
+    RadiansToDegrees,
+    //% block="celsius to fahrenheit"
+    CelsiusToFahrenheit,
+    //% block="fahrenheit to celsius"
+    FahrenheitToCelsius,
+    //% block="seconds to milliseconds"
+    SecondsToMilliseconds,
+    //% block="milliseconds to seconds"
+    MillisecondsToSeconds
+}
+
 namespace Math {
     /**
      * Generates a `true` or `false` value randomly, just like flipping a coin.
      */
     //% blockId=logic_random block="pick random true or false"
-    //% help=math/random-boolean weight=0
+    //% help=math/random-boolean weight=1
     export function randomBoolean(): boolean {
         return Math.randomRange(0, 1) === 1;
+    }
+
+    /**
+     * Converts a value from one unit to another. For example, degrees to radians, fahrenheit to celsius, etc.
+     * @param value The value to convert.
+     * @param type The type of conversion to perform.
+     */
+    //% blockId=math_convert_unit
+    //% block="convert $value|from $type"
+    //% help=math/convert-unit
+    //% weight=0
+    export function convert(value: number, type: UnitConversion): number {
+        switch (type) {
+            case UnitConversion.DegreesToRadians: return value * 0.017453292519943295;
+            case UnitConversion.RadiansToDegrees: return value * 57.29577951308232;
+            case UnitConversion.CelsiusToFahrenheit: return (value * 1.8) + 32;
+            case UnitConversion.FahrenheitToCelsius: return (value - 32) * 0.5555555555555556;
+            case UnitConversion.SecondsToMilliseconds: return value * 1000;
+            case UnitConversion.MillisecondsToSeconds: return value / 1000;
+        }
+        return value;
     }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4510
fixes https://github.com/microsoft/pxt-microbit/issues/6689
fixes https://github.com/microsoft/pxt-microbit/issues/6751

adds a conversion block with three type of conversions:
* degrees <-> radians
* fahrenheit <-> celsisus
* seconds <-> milliseconds

these were the only useful ones i could think of in micro:bit, but perhaps there are more.
@jaustin @Jaqster @abchatra let me know if you have any opinions here

<img width="410" height="243" alt="image" src="https://github.com/user-attachments/assets/834a1f5d-44d7-4ba5-85e2-b6f20902f0ff" />
<br/>

<img width="365" height="189" alt="image" src="https://github.com/user-attachments/assets/993b314d-9f96-4735-a391-a5890bded499" />
<br/>
<img width="500" height="65" alt="image" src="https://github.com/user-attachments/assets/cebd12d4-ff39-47e2-9bac-1ff046236fbe" />
