### PR TITLE
Extension: add Tobbie-II (Translated)

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -577,6 +577,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Tobbie-II (Translated)",
+  "url":"/pkg/Jim-no-surname-provided/pxt-tobbieII",
+  "cardType": "package"
+}, {
   "name": "Siyeenove Pybit",
   "url":"/pkg/siyeenove/pxt_pybit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -439,6 +439,7 @@
             "forward-education/pxt-coding-for-good": { "tags": [ "Science" ] },
             "dfrobot/pxt-dfrobot_huskylensv2": { "tags": [ "Science" ] },
             "steveturbek/pxt-rotary-encoder-ky-040-plus": { "tags": [ "Science" ] },
+            "jim-no-surname-provided/pxt-tobbieii": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/98361 (private)
@Jim-no-surname-provided
@abchatra 

Extension: https://github.com/Jim-no-surname-provided/pxt-tobbieII
Version: 2.2.11
All blocks: https://makecode.microbit.org/_bisPbp7f2VPF

<img width="851" height="262" alt="image" src="https://github.com/user-attachments/assets/6191cb93-dce7-4a60-ba48-8e3f1d10201c" />
