### PR TITLE
Update CreateAI links to use a more specific page

### DIFF
--- a/docs/microbit-org/createai.md
+++ b/docs/microbit-org/createai.md
@@ -32,7 +32,7 @@ Projects to get learners started quickly with AI and machine learning on the mic
 }, {
   "name": "More about CreateAI",
   "description": "Explore AI on and offscreen with tools, resources and more.",
-  "url": "https://microbit.org/ai/",
+  "url": "https://microbit.org/createai/",
   "imageUrl":"/static/microbit-org/createai/more-about.png",
   "label": " ",
   "labelClass": "black microbit-ribbon large",

--- a/docs/projects/SUMMARY.md
+++ b/docs/projects/SUMMARY.md
@@ -149,7 +149,7 @@
   * [AI storytelling friend](https://microbit.org/projects/make-it-code-it/ai-storytelling-friend/)
   * [Simple AI exercise timer](https://microbit.org/projects/make-it-code-it/simple-ai-exercise-timer/)
   * [AI activity timer](https://microbit.org/projects/make-it-code-it/ai-activity-timer/)
-  * [More about CreateAI](https://microbit.org/ai/)
+  * [More about CreateAI](https://microbit.org/createai/)
 * [Courses](/courses)
   * [Intro to CS Online](/courses/csintro)
   * [Intro to CS Classroom](/courses/csintro-educator)


### PR DESCRIPTION
Replace links to https://microbit.org/ai/ with https://microbit.org/createai/

The original still works, but the new page is our preferred landing page for CreateAI rather than micro:bit & AI in general.