### PR TITLE
Improve simulator accessibility

### DIFF
--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -35,14 +35,14 @@ namespace pxsim.pins {
         let pin = getPin(pinId);
         if (!pin) return -1;
         pin.mode = PinFlags.Digital | PinFlags.Input;
-        return pin.value > 100 ? 1 : 0;
+        return pin.value > 0 ? 1 : 0;
     }
 
     export function digitalWritePin(pinId: number, value: number) {
         let pin = getPin(pinId);
         if (!pin) return;
         pin.mode = PinFlags.Digital | PinFlags.Output;
-        pin.value = value > 0 ? 1023 : 0;
+        pin.value = value > 0 ? 1: 0;
         runtime.queueDisplayUpdate();
     }
 

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -190,11 +190,11 @@ path.sim-board {
 .sim-led-back {
     stroke: white;
 }
-*:focus .sim-button-outer,
-.sim-pin:focus,
-.sim-thermometer:focus,
-.sim-shake:focus,
-.sim-light-level-button:focus {
+*:focus-visible .sim-button-outer,
+.sim-pin:focus-visible,
+.sim-thermometer:focus-visible,
+.sim-shake:focus-visible,
+.sim-light-level-button:focus-visible {
     stroke: #10C8CD !important;
 }
     `

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1493,6 +1493,7 @@ path.sim-board {
                         let pin = state.edgeConnectorState.pins[index];
 
                         if ([37, 38, 39, 40].includes(charCode) && !(pin.mode & PinFlags.Input)) {
+                            ev.preventDefault();
                             accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
                             return;
                         };

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -793,7 +793,7 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        const value = commonKeyHandler(ev, state.compassState.heading, 0, 360);
+                        const value = commonKeyHandler(ev, state.compassState.heading, 0, 359);
                         if (value !== undefined) {
                             state.compassState.heading = value;
                             this.updateHeading();

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -305,6 +305,7 @@ path.sim-board {
 
     export class MicrobitBoardSvg implements BoardView {
         public element: SVGSVGElement;
+        private liveRegionInitialized = false;
         private style: SVGStyleElement;
         private defs: SVGDefsElement;
         private g: SVGGElement;
@@ -381,7 +382,7 @@ path.sim-board {
             if (props && props.runtime) {
                 this.board = this.props.runtime.board as pxsim.DalBoard;
                 this.board.updateSubscribers.push(() => this.updateState());
-                this.updateState();
+                this.updateState(true);
                 this.attachEvents();
             }
         }
@@ -451,7 +452,7 @@ path.sim-board {
             this.positionV2Elements();
         }
 
-        public updateState() {
+        public updateState(initialCall: boolean = false) {
             const state = this.board;
             if (!state) return;
 
@@ -473,6 +474,11 @@ path.sim-board {
                 U.addClass(this.element, "grayscale");
             else
                 U.removeClass(this.element, "grayscale");
+
+            if (!initialCall && !this.liveRegionInitialized) {
+                accessibility.setLiveContent("");
+                this.liveRegionInitialized = true;
+            }
         }
 
         private updateButtonPairs() {
@@ -542,7 +548,7 @@ path.sim-board {
                     }
                 );
                 accessibility.setAria(this.shakeButton, "button", "Shake the board");
-                this.shakeText = svg.child(this.g, "text", { x: 420, y: 122, class: "sim-text-small" }) as SVGTextElement;
+                this.shakeText = svg.child(this.g, "text", { x: 420, y: 122, class: "sim-text-small", "aria-hidden": "true" }) as SVGTextElement;
                 this.shakeText.textContent = "SHAKE";
             }
         }
@@ -588,45 +594,59 @@ path.sim-board {
         private updatePin(pin: Pin, index: number) {
             if (!pin) return;
             let text = this.pinTexts[index];
-            let v = "";
+            let v: number;
+            let gradientValue = "";
             if (pin.mode & PinFlags.Analog) {
-                v = Math.floor(100 - (pin.value || 0) / 1023 * 100) + "%";
-                if (text) text.textContent = (pin.period ? "~" : "") + (pin.value || 0) + "";
+                gradientValue = Math.floor(100 - (pin.value || 0) / 1023 * 100) + "%";
+                v = pin.value || 0;
+                if (text) text.textContent = (pin.period ? "~" : "") + (v);
             }
             else if (pin.mode & PinFlags.Digital) {
-                v = pin.value > 0 ? "0%" : "100%";
-                if (text) text.textContent = pin.value > 0 ? "1" : "0";
+                gradientValue = pin.value > 0 ? "0%" : "100%";
+                v = pin.value;
+                if (text) text.textContent = v.toString();
             }
             else if (pin.mode & PinFlags.Touch) {
-                v = pin.touched ? "0%" : "100%";
+                gradientValue = pin.touched ? "0%": "100%";
+                v = Number(pin.touched);
                 if (text) text.textContent = "";
             } else {
-                v = "100%";
+                gradientValue = "100%"
+                v = 1;
                 if (text) text.textContent = "";
             }
-            if (v) svg.setGradientValue(this.pinGradients[index], v);
+            if (gradientValue) svg.setGradientValue(this.pinGradients[index], gradientValue);
 
             if (pin.mode !== PinFlags.Unused) {
                 accessibility.makeFocusable(this.pins[index]);
                 accessibility.setAria(this.pins[index], "slider", this.pins[index].firstChild.textContent);
                 this.pins[index].setAttribute("aria-valuemin", "0");
-                this.pins[index].setAttribute("aria-valuemax", pin.mode & PinFlags.Analog ? "1023" : "100");
+                this.pins[index].setAttribute("aria-valuemax", pin.mode & PinFlags.Analog ? "1023" : "1");
                 this.pins[index].setAttribute("aria-orientation", "vertical");
-                this.pins[index].setAttribute("aria-valuenow", text ? text.textContent : v);
-                accessibility.setLiveContent(text ? text.textContent : v);
+                this.pins[index].setAttribute("aria-valuenow", v.toString());
+                if (text?.textContent) {
+                    this.pins[index].setAttribute("aria-valuetext", text?.textContent ?? null);
+                } else {
+                    this.pins[index].removeAttribute("aria-valuetext");
+                }
+                if (pin.mode & PinFlags.Input) {
+                    this.pins[index].removeAttribute("aria-readonly");
+                } else {
+                    this.pins[index].setAttribute("aria-readonly", "true");
+                }
             }
         }
 
         private updateTemperature() {
-            let state = this.board;
+            const state = this.board;
             if (!state || !state.thermometerState.usesTemperature) return;
 
-            let tmin = -5;
-            let tmax = 50;
+            const tmin = -5;
+            const tmax = 50;
             if (!this.thermometerInitialized) {
                 this.thermometerInitialized = true;
                 this.thermometer.style.visibility = "visible";
-                this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130 }) as SVGTextElement;
+                this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130, "aria-hidden": "true" }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("temperature")] = state.thermometerState.temperature;
                 this.updateTheme();
@@ -649,41 +669,40 @@ path.sim-board {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
                             ev.preventDefault();
-                            state.thermometerState.temperature--;
-                            if (state.thermometerState.temperature < -5) {
-                                state.thermometerState.temperature = 50;
+                            if (state.thermometerState.temperature === tmin) {
+                                return
                             }
+                            state.thermometerState.temperature--;
                             this.updateTemperature();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
                             ev.preventDefault();
-                            state.thermometerState.temperature++;
-                            if (state.thermometerState.temperature > 50) {
-                                state.thermometerState.temperature = -5;
+                            if (state.thermometerState.temperature === tmax) {
+                                return
                             }
+                            state.thermometerState.temperature++;
                             this.updateTemperature();
                         }
                     })
 
                 accessibility.makeFocusable(this.thermometer);
-                accessibility.setAria(this.thermometer, "slider", pxsim.localization.lf("Thermometer"));
-                this.thermometer.setAttribute("aria-valuemin", "-5");
-                this.thermometer.setAttribute("aria-valuemax", "50");
+                accessibility.setAria(this.thermometer, "slider", pxsim.localization.lf("Temperature"));
+                this.thermometer.setAttribute("aria-valuemin", tmin.toString());
+                this.thermometer.setAttribute("aria-valuemax", tmax.toString());
                 this.thermometer.setAttribute("aria-orientation", "vertical");
                 this.thermometer.setAttribute("aria-valuenow", "21");
                 this.thermometer.setAttribute("aria-valuetext", "21°C");
             }
 
-            let t = Math.max(tmin, Math.min(tmax, state.thermometerState.temperature))
-            let per = Math.floor((state.thermometerState.temperature - tmin) / (tmax - tmin) * 100)
+            const t = Math.max(tmin, Math.min(tmax, state.thermometerState.temperature))
+            const per = Math.floor((state.thermometerState.temperature - tmin) / (tmax - tmin) * 100)
             svg.setGradientValue(this.thermometerGradient, 100 - per + "%");
             this.thermometerText.textContent = t + "°C";
             this.thermometer.setAttribute("aria-valuenow", t.toString());
             this.thermometer.setAttribute("aria-valuetext", t + "°C");
-            accessibility.setLiveContent(t + "°C");
         }
 
         private updateSoundLevel() {
-            let state = this.board;
+            const state = this.board;
             if (!state || !state.microphoneState.sensorUsed) return;
 
             const tmin = 0 // state.microphoneState.min;
@@ -692,7 +711,7 @@ path.sim-board {
                 this.soundLevelInitialized = true;
                 this.soundLevel.style.visibility = "visible";
                 const level = state.microphoneState.getLevel();
-                this.soundLevelText = svg.child(this.g, "text", { class: 'sim-text', x: 370, y: 90 }) as SVGTextElement;
+                this.soundLevelText = svg.child(this.g, "text", { class: 'sim-text', x: 370, y: 90, "aria-hidden": "true" }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("sound level")] = state.microphoneState.getLevel();
                 this.updateTheme();
@@ -715,31 +734,36 @@ path.sim-board {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
                             ev.preventDefault();
-                            state.microphoneState.setLevel(state.microphoneState.getLevel() - 1);
+                            const level = state.microphoneState.getLevel()
+                            if (level === tmin) {
+                                return
+                            }
+                            state.microphoneState.setLevel(level - 1);
                             this.updateMicrophone();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
                             ev.preventDefault();
-                            state.microphoneState.setLevel(state.microphoneState.getLevel() + 1)
+                            const level = state.microphoneState.getLevel()
+                            if (level === tmax) {
+                                return
+                            }
+                            state.microphoneState.setLevel(level + 1)
                             this.updateMicrophone();
                         }
                     })
 
                 accessibility.makeFocusable(this.soundLevel);
                 accessibility.setAria(this.soundLevel, "slider", pxsim.localization.lf("Sound Level"));
-                this.soundLevel.setAttribute("aria-valuemin", tmin + "");
-                this.soundLevel.setAttribute("aria-valuemax", tmax + "");
+                this.soundLevel.setAttribute("aria-valuemin", tmin.toString());
+                this.soundLevel.setAttribute("aria-valuemax", tmax.toString());
                 this.soundLevel.setAttribute("aria-orientation", "vertical");
-                this.soundLevel.setAttribute("aria-valuenow", level + "");
-                this.soundLevel.setAttribute("aria-valuetext", level + "");
+                this.soundLevel.setAttribute("aria-valuenow", level.toString());
             }
 
-            let t = Math.max(tmin, Math.min(tmax, state.microphoneState.getLevel()))
-            let per = Math.floor((state.microphoneState.getLevel() - tmin) / (tmax - tmin) * 100)
+            const t = Math.max(tmin, Math.min(tmax, state.microphoneState.getLevel()))
+            const per = Math.floor((state.microphoneState.getLevel() - tmin) / (tmax - tmin) * 100)
             svg.setGradientValue(this.soundLevelGradient, (100 - per) + "%");
-            this.soundLevelText.textContent = t + "";
+            this.soundLevelText.textContent = t.toString();
             this.soundLevel.setAttribute("aria-valuenow", t.toString());
-            this.soundLevel.setAttribute("aria-valuetext", t + "");
-            accessibility.setLiveContent(t + "");
         }
 
         private updateHeading() {
@@ -847,12 +871,11 @@ path.sim-board {
                 this.antenna.addEventListener('keydown', keyboardEventHandler);
 
                 accessibility.makeFocusable(this.antenna);
-                accessibility.setAria(this.antenna, "slider", "RSSI");
+                accessibility.setAria(this.antenna, "slider", "Received Signal Strength Indicator");
                 this.antenna.setAttribute("aria-valuemin", `${valueMin}`);
                 this.antenna.setAttribute("aria-valuemax", `${valueMax}`);
                 this.antenna.setAttribute("aria-orientation", "horizontal");
-                this.antenna.setAttribute("aria-valuenow", "");
-                accessibility.setLiveContent("");
+                this.antenna.setAttribute("aria-valuenow", (this.board.radioState.datagram.rssi ?? -75).toString());
             }
             let now = Date.now();
             if (now - this.lastAntennaFlash > 200) {
@@ -873,7 +896,7 @@ path.sim-board {
                 let ayb = 40;
                 for (let i = 0; i < 4; ++i)
                     svg.child(this.g, "rect", { x: ANTENNA_X - 90 + i * 6, y: ayt + 28 - i * 4, width: 4, height: 2 + i * 4, fill: "#fff" })
-                this.rssi = svg.child(this.g, "text", { x: ANTENNA_X - 64, y: ayb, class: "sim-text" }) as SVGTextElement;
+                this.rssi = svg.child(this.g, "text", { x: ANTENNA_X - 64, y: ayb, class: "sim-text", "aria-hidden": "true" }) as SVGTextElement;
                 this.rssi.textContent = "";
             }
 
@@ -881,7 +904,6 @@ path.sim-board {
             if (vt !== this.rssi.textContent) {
                 this.rssi.textContent = v.toString();
                 this.antenna.setAttribute("aria-valuenow", this.rssi.textContent);
-                accessibility.setLiveContent(this.rssi.textContent);
             }
         }
 
@@ -893,8 +915,11 @@ path.sim-board {
         }
 
         private updateLightLevel() {
-            let state = this.board;
+            const state = this.board;
             if (!state || !state.lightSensorState.usesLightLevel) return;
+
+            const min = 0;
+            const max = 255;
 
             if (!this.lightLevelInitialized) {
                 this.lightLevelInitialized = true;
@@ -905,10 +930,10 @@ path.sim-board {
                     (ev) => {
                         let pos = svg.cursorPoint(pt, this.element, ev);
                         let rs = LIGHT_LEVEL_BUTTON_RADIUS / 2;
-                        let level = Math.max(0, Math.min(255, Math.floor((pos.y - (LIGHT_LEVEL_BUTTON_POSITION_Y - rs)) / (2 * rs) * 255)));
-                        if (level != this.board.lightSensorState.lightLevel) {
-                            this.board.lightSensorState.lightLevel = level;
-                            this.applyLightLevel();
+                        let level = Math.max(min, Math.min(max, Math.floor((pos.y - (LIGHT_LEVEL_BUTTON_POSITION_Y - rs)) / (2 * rs) * max)));
+                        if (level != state.lightSensorState.lightLevel) {
+                            state.lightSensorState.lightLevel = level;
+                            this.updateLightLevel();
                         }
                     },
                     // start
@@ -920,43 +945,37 @@ path.sim-board {
                         let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
                             ev.preventDefault();
-                            this.board.lightSensorState.lightLevel--;
-                            if (this.board.lightSensorState.lightLevel < 0) {
-                                this.board.lightSensorState.lightLevel = 255;
+                            if (state.lightSensorState.lightLevel === min) {
+                                return
                             }
-                            this.applyLightLevel();
+                            state.lightSensorState.lightLevel--;
+                            this.updateLightLevel();
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
                             ev.preventDefault();
-                            this.board.lightSensorState.lightLevel++;
-                            if (this.board.lightSensorState.lightLevel > 255) {
-                                this.board.lightSensorState.lightLevel = 0;
+                            if (state.lightSensorState.lightLevel === max) {
+                                return;
                             }
-                            this.applyLightLevel();
+                            state.lightSensorState.lightLevel++;
+                            this.updateLightLevel();
                         }
                     });
-                this.lightLevelText = svg.child(this.g, "text", { x: 85, y: LIGHT_LEVEL_BUTTON_POSITION_Y + LIGHT_LEVEL_BUTTON_RADIUS - 5, text: '', class: 'sim-text' }) as SVGTextElement;
+                this.lightLevelText = svg.child(this.g, "text", { x: 85, y: LIGHT_LEVEL_BUTTON_POSITION_Y + LIGHT_LEVEL_BUTTON_RADIUS - 5, text: '', class: 'sim-text', "aria-hidden": "true" }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("lightLevel")] = state.lightSensorState.lightLevel;
                 this.updateTheme();
 
                 accessibility.makeFocusable(this.lightLevelButton);
                 accessibility.setAria(this.lightLevelButton, "slider", "Light level");
-                this.lightLevelButton.setAttribute("aria-valuemin", "0");
-                this.lightLevelButton.setAttribute("aria-valuemax", "255");
+                this.lightLevelButton.setAttribute("aria-valuemin", min.toString());
+                this.lightLevelButton.setAttribute("aria-valuemax", max.toString());
                 this.lightLevelButton.setAttribute("aria-orientation", "vertical");
-                this.lightLevelButton.setAttribute("aria-valuenow", "128");
+                this.lightLevelButton.setAttribute("aria-valuenow", state.lightSensorState.lightLevel.toString());
             }
 
-            svg.setGradientValue(this.lightLevelGradient, Math.min(100, Math.max(0, Math.floor(state.lightSensorState.lightLevel * 100 / 255))) + '%')
-            this.lightLevelText.textContent = state.lightSensorState.lightLevel.toString();
-        }
-
-        private applyLightLevel() {
-            let lv = this.board.lightSensorState.lightLevel;
-            svg.setGradientValue(this.lightLevelGradient, Math.min(100, Math.max(0, Math.floor(lv * 100 / 255))) + '%')
+            let lv = state.lightSensorState.lightLevel;
+            svg.setGradientValue(this.lightLevelGradient, Math.min(100, Math.max(min, Math.floor(lv * 100 / 255))) + '%')
             this.lightLevelText.textContent = lv.toString();
             this.lightLevelButton.setAttribute("aria-valuenow", lv.toString());
-            accessibility.setLiveContent(lv.toString());
         }
 
         findParentElement() {
@@ -996,21 +1015,21 @@ path.sim-board {
                 // update text
                 if (acc.flags & AccelerometerFlag.X) {
                     if (!this.accTextX) {
-                        this.accTextX = svg.child(this.g, "text", { x: 365, y: 260, class: "sim-text" }) as SVGTextElement;
+                        this.accTextX = svg.child(this.g, "text", { x: 365, y: 260, class: "sim-text", "aria-hidden": "true" }) as SVGTextElement;
                         this.accTextX.textContent = "";
                     }
                     this.accTextX.textContent = `ax:${x}`;
                 }
                 if (acc.flags & AccelerometerFlag.Y) {
                     if (!this.accTextY) {
-                        this.accTextY = svg.child(this.g, "text", { x: 365, y: 285, class: "sim-text" }) as SVGTextElement;
+                        this.accTextY = svg.child(this.g, "text", { x: 365, y: 285, class: "sim-text", "aria-hidden": "true" }) as SVGTextElement;
                         this.accTextY.textContent = "";
                     }
                     this.accTextY.textContent = `ay:${-y}`;
                 }
                 if (acc.flags & AccelerometerFlag.Z) {
                     if (!this.accTextZ) {
-                        this.accTextZ = svg.child(this.g, "text", { x: 365, y: 310, class: "sim-text" }) as SVGTextElement;
+                        this.accTextZ = svg.child(this.g, "text", { x: 365, y: 310, class: "sim-text", "aria-hidden": "true" }) as SVGTextElement;
                         this.accTextZ.textContent = "";
                     }
                     this.accTextZ.textContent = `az:${z}`;
@@ -1171,7 +1190,7 @@ path.sim-board {
             this.heads.push(svg.path(this.headParts, "sim-theme", "M269.9,50.2L269.9,50.2l-39.5,0v0c-14.1,0.1-24.6,10.7-24.6,24.8c0,13.9,10.4,24.4,24.3,24.7v0h39.6c14.2,0,24.8-10.6,24.8-24.7C294.5,61,284,50.3,269.9,50.2 M269.7,89.2L269.7,89.2l-39.3,0c-7.7-0.1-14-6.4-14-14.2c0-7.8,6.4-14.2,14.2-14.2h39.1c7.8,0,14.2,6.4,14.2,14.2C283.9,82.9,277.5,89.2,269.7,89.2"));
             this.heads.push(svg.path(this.headParts, "sim-theme", "M230.6,69.7c-2.9,0-5.3,2.4-5.3,5.3c0,2.9,2.4,5.3,5.3,5.3c2.9,0,5.3-2.4,5.3-5.3C235.9,72.1,233.5,69.7,230.6,69.7"));
             this.heads.push(svg.path(this.headParts, "sim-theme", "M269.7,80.3c2.9,0,5.3-2.4,5.3-5.3c0-2.9-2.4-5.3-5.3-5.3c-2.9,0-5.3,2.4-5.3,5.3C264.4,77.9,266.8,80.3,269.7,80.3"));
-            this.headText = <SVGTextElement>svg.child(this.g, "text", { x: 160, y: 60, class: "sim-text" })
+            this.headText = <SVGTextElement>svg.child(this.g, "text", { x: 160, y: 60, class: "sim-text", "aria-hidden": "true" })
         }
 
         private buildPinElements() {
@@ -1213,7 +1232,7 @@ path.sim-board {
                 return lg;
             });
 
-            this.pinTexts = [67, 165, 275].map(x => <SVGTextElement>svg.child(this.g, "text", { class: "sim-text-pin", x: x, y: 345 }));
+            this.pinTexts = [67, 165, 275].map(x => <SVGTextElement>svg.child(this.g, "text", { class: "sim-text-pin", x: x, y: 345, "aria-hidden": "true" }));
 
             svg.path(this.g, "sim-label", "M35.7,376.4c0-2.8,2.1-5.1,5.5-5.1c3.3,0,5.5,2.4,5.5,5.1v4.7c0,2.8-2.2,5.1-5.5,5.1c-3.3,0-5.5-2.4-5.5-5.1V376.4zM43.3,376.4c0-1.3-0.8-2.3-2.2-2.3c-1.3,0-2.1,1.1-2.1,2.3v4.7c0,1.2,0.8,2.3,2.1,2.3c1.3,0,2.2-1.1,2.2-2.3V376.4z");
             svg.path(this.g, "sim-label", "M136.2,374.1c2.8,0,3.4-0.8,3.4-2.5h2.9v14.3h-3.4v-9.5h-3V374.1z");
@@ -1246,6 +1265,7 @@ path.sim-board {
                 let btng = svg.child(this.g, "g", { class: "sim-button-group" });
                 accessibility.makeFocusable(btng);
                 accessibility.setAria(btng, "button", label);
+                btng.setAttribute("aria-pressed", "false");
                 this.buttonsOuter.push(btng);
                 svg.child(btng, "rect", { class: "sim-button-outer", x: left, y: top, rx: btnr, ry: btnr, width: btnw, height: btnw });
                 svg.child(btng, "circle", { class: "sim-button-nut", cx: left + btnnm, cy: top + btnnm, r: btnn });
@@ -1312,6 +1332,7 @@ path.sim-board {
             accessibility.makeFocusable(this.headParts);
             accessibility.setAria(this.headParts, "button", headTitle);
             this.headParts.setAttribute("class", "sim-button-outer sim-button-group")
+            this.headParts.setAttribute("aria-pressed", "false");
             this.attachButtonEvents(this.board.logoTouch, this.headParts, this.headParts);
             document.body.addEventListener(pointerEvents.down[0], this.moveHeadingOnClick);
 
@@ -1469,18 +1490,31 @@ path.sim-board {
                         let state = this.board;
                         let pin = state.edgeConnectorState.pins[index];
 
+                        if ([37, 38, 39, 40].includes(charCode) && !(pin.mode & PinFlags.Input)) {
+                            accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
+                            return;
+                        };
+
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow
                             ev.preventDefault();
-                            pin.value -= 10;
-                            if (pin.value < 0) {
-                                pin.value = 1023;
+                            if (pin.mode & PinFlags.Analog) {
+                                pin.value -= 10;
+                                if (pin.value < 0) {
+                                    pin.value = 0;
+                                }
+                            } else {
+                                pin.value = 0;
                             }
                             this.updatePin(pin, index);
                         } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
                             ev.preventDefault();
-                            pin.value += 10;
-                            if (pin.value > 1023) {
-                                pin.value = 0;
+                            if (pin.mode & PinFlags.Analog) {
+                                pin.value += 10;
+                                if (pin.value > 1023) {
+                                    pin.value = 1023;
+                                }
+                            } else {
+                                pin.value = 1;
                             }
                             this.updatePin(pin, index);
                         }
@@ -1553,17 +1587,20 @@ path.sim-board {
             pointerEvents.down.forEach(evid => buttonOuter.addEventListener(evid, ev => {
                 stateButton.pressed = true;
                 this.updateButtonPairs();
+                buttonOuter.setAttribute("aria-pressed", "true");
                 this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
-                pressedTime = runtime.runningTime()
+                pressedTime = runtime.runningTime();
             }));
             buttonOuter.addEventListener(pointerEvents.leave, ev => {
                 stateButton.pressed = false;
                 this.updateButtonPairs();
+                buttonOuter.setAttribute("aria-pressed", "false");
                 svg.fill(elButton, this.props.theme.buttonUp);
             })
             buttonOuter.addEventListener(pointerEvents.up, ev => {
                 stateButton.pressed = false;
                 this.updateButtonPairs();
+                buttonOuter.setAttribute("aria-pressed", "false");
                 this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_UP);
                 const currentTime = runtime.runningTime()
                 if (currentTime - pressedTime > DAL.DEVICE_BUTTON_LONG_CLICK_TIME)
@@ -1575,11 +1612,13 @@ path.sim-board {
             accessibility.enableKeyboardInteraction(buttonOuter,
                 () => { // keydown
                     stateButton.pressed = true;
+                    buttonOuter.setAttribute("aria-pressed", "true");
                     this.updateButtonPairs();
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 }, () => { // keyup
                     stateButton.pressed = false;
                     this.updateButtonPairs();
+                    buttonOuter.setAttribute("aria-pressed", "false");
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_UP);
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_CLICK);
             });
@@ -1595,6 +1634,7 @@ path.sim-board {
                 bpState.bBtn.pressed = true;
                 bpState.abBtn.pressed = true;
                 this.updateButtonPairs();
+                this.buttonsOuter[2].setAttribute("aria-pressed", "true");
                 this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 pressedTime = runtime.runningTime()
             }));
@@ -1603,12 +1643,14 @@ path.sim-board {
                 bpState.bBtn.pressed = false;
                 bpState.abBtn.pressed = false;
                 this.updateButtonPairs();
+                this.buttonsOuter[2].setAttribute("aria-pressed", "false");
             })
             this.buttonsOuter[2].addEventListener(pointerEvents.up, ev => {
                 bpState.aBtn.pressed = false;
                 bpState.bBtn.pressed = false;
                 bpState.abBtn.pressed = false;
                 this.updateButtonPairs();
+                this.buttonsOuter[2].setAttribute("aria-pressed", "false");
 
                 this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_UP);
                 const currentTime = runtime.runningTime()
@@ -1625,12 +1667,14 @@ path.sim-board {
                     bpState.bBtn.pressed = true;
                     bpState.abBtn.pressed = true;
                     this.updateButtonPairs();
+                    this.buttonsOuter[2].setAttribute("aria-pressed", "true");
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 }, () => { // keyup
                     bpState.aBtn.pressed = false;
                     bpState.bBtn.pressed = false;
                     bpState.abBtn.pressed = false;
                     this.updateButtonPairs();
+                    this.buttonsOuter[2].setAttribute("aria-pressed", "false");
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_UP);
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_CLICK);
             }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -690,20 +690,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            if (state.thermometerState.temperature === tmin) {
-                                return
-                            }
-                            state.thermometerState.temperature--;
-                            this.updateTemperature();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            if (state.thermometerState.temperature === tmax) {
-                                return
-                            }
-                            state.thermometerState.temperature++;
+                        const value = commonKeyHandler(ev, state.thermometerState.temperature, tmin, tmax);
+                        if (value !== undefined) {
+                            state.thermometerState.temperature = value;
                             this.updateTemperature();
                         }
                     })
@@ -755,22 +744,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            const level = state.microphoneState.getLevel()
-                            if (level === tmin) {
-                                return
-                            }
-                            state.microphoneState.setLevel(level - 1);
-                            this.updateMicrophone();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            const level = state.microphoneState.getLevel()
-                            if (level === tmax) {
-                                return
-                            }
-                            state.microphoneState.setLevel(level + 1)
+                        const value = commonKeyHandler(ev, state.microphoneState.getLevel(), tmin, tmax);
+                        if (value !== undefined) {
+                            state.microphoneState.setLevel(value);
                             this.updateMicrophone();
                         }
                     })
@@ -815,18 +791,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            state.compassState.heading--;
-                            if (state.compassState.heading < 0) state.compassState.heading += 360;
-                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
-                            this.updateHeading();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            state.compassState.heading++;
-                            if (state.compassState.heading < 0) state.compassState.heading += 360;
-                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
+                        const value = commonKeyHandler(ev, state.compassState.heading, 0, 360);
+                        if (value !== undefined) {
+                            state.compassState.heading = value;
                             this.updateHeading();
                         }
                     }
@@ -864,6 +831,7 @@ path.sim-board {
                 this.antenna.style.visibility = "visible";
                 this.antennaInitialized = true;
                 const antennaWidth = ANTENNA_WAVE_PERIOD_X * ANTENNA_WAVE_COUNT;
+                const defaultValue = -75;
                 const valueMin = -128;
                 const valueMax = -42;
                 const setValue = (val: number) => {
@@ -878,15 +846,11 @@ path.sim-board {
                     const pos = svg.cursorPoint(pt, this.element, ev);
                     setValue((-138 + (pos.x - ANTENNA_X) / antennaWidth * 100) | 0);
                 };
+
                 const keyboardEventHandler = (ev: KeyboardEvent) => {
-                    const charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode;
-                    const rs = this.board.radioState.datagram.rssi ?? -75;
-                    if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                        ev.preventDefault();
-                        setValue(rs - 1);
-                    } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                        ev.preventDefault();
-                        setValue(rs + 1);
+                    const value = commonKeyHandler(ev, this.board.radioState.datagram.rssi ?? defaultValue, valueMin, valueMax);
+                    if (value !== undefined) {
+                        setValue(value);
                     }
                 };
 
@@ -899,7 +863,7 @@ path.sim-board {
                 this.antenna.setAttribute("aria-valuemin", `${valueMin}`);
                 this.antenna.setAttribute("aria-valuemax", `${valueMax}`);
                 this.antenna.setAttribute("aria-orientation", "horizontal");
-                this.antenna.setAttribute("aria-valuenow", (this.board.radioState.datagram.rssi ?? -75).toString());
+                this.antenna.setAttribute("aria-valuenow", (this.board.radioState.datagram.rssi ?? defaultValue).toString());
             }
             let now = Date.now();
             if (now - this.lastAntennaFlash > 200) {
@@ -966,20 +930,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            if (state.lightSensorState.lightLevel === min) {
-                                return
-                            }
-                            state.lightSensorState.lightLevel--;
-                            this.updateLightLevel();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            if (state.lightSensorState.lightLevel === max) {
-                                return;
-                            }
-                            state.lightSensorState.lightLevel++;
+                        const value = commonKeyHandler(ev, state.lightSensorState.lightLevel, min, max);
+                        if (value !== undefined) {
+                            state.lightSensorState.lightLevel = value;
                             this.updateLightLevel();
                         }
                     });
@@ -1509,44 +1462,11 @@ path.sim-board {
                     },
                     // keydown
                     (ev: KeyboardEvent) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        let state = this.board;
-                        let pin = state.edgeConnectorState.pins[index];
-
-                        if ([37, 38, 39, 40].includes(charCode)) {
-                            if (!(pin.mode & PinFlags.Input)) {
-                                ev.preventDefault();
-                                accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
-                                return;
-                            }
-                            if (pin.mode & PinFlags.Touch) {
-                                // The pin is in touch mode and has button markup, not a slider.
-                                ev.preventDefault();
-                                return;
-                            }
-                        };
-
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            if (pin.mode & PinFlags.Analog) {
-                                pin.value -= 10;
-                                if (pin.value < 0) {
-                                    pin.value = 0;
-                                }
-                            } else {
-                                pin.value = 0;
-                            }
-                            this.updatePin(pin, index);
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            if (pin.mode & PinFlags.Analog) {
-                                pin.value += 10;
-                                if (pin.value > 1023) {
-                                    pin.value = 1023;
-                                }
-                            } else {
-                                pin.value = 1;
-                            }
+                        const state = this.board;
+                        const pin = state.edgeConnectorState.pins[index];
+                        const value = pinKeyHandler(ev, pin.value, 0, pin.mode & PinFlags.Analog ? 1023 : 1, pin.mode);
+                        if (value !== undefined) {
+                            pin.value = value;
                             this.updatePin(pin, index);
                         }
                     });
@@ -1705,5 +1625,66 @@ path.sim-board {
         private attachKeyboardEvents() {
             accessibility.postKeyboardEvent();
         }
+    }
+
+    const isHandledKey = (key: string) => {
+        return ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "PageUp", "PageDown", "Home", "End"].includes(key);
+    }
+
+    const getSliderStepValue = (min: number, max: number) => {
+        const range = max - min;
+        // Assumes slider values are always integers.
+        return Math.max(1, Math.floor(range / 10));
+    }
+
+    const commonKeyHandler = (e: KeyboardEvent, currentValue: number, min: number, max: number): number | undefined => {
+        const key = e.key;
+        if (isHandledKey(key)) {
+            e.preventDefault();
+        }
+        switch(key) {
+            case "ArrowDown":
+            case "ArrowLeft": {
+                return Math.max(min, currentValue - 1)
+            }
+            case "ArrowUp":
+            case "ArrowRight": {
+                return Math.min(max, currentValue + 1)
+            }
+            case "Home": {
+                return min;
+            }
+            case "End": {
+                return max;
+            }
+            case "PageDown": {
+                const step = getSliderStepValue(min, max);
+                const value = currentValue - step;
+                return Math.max(min, value)
+            }
+            case "PageUp": {
+                const step = getSliderStepValue(min, max);
+                const value = currentValue + step;
+                return Math.min(max, value)
+            }
+        }
+        return undefined;
+    }
+
+    const pinKeyHandler = (e: KeyboardEvent, currentValue: number, min: number, max: number, pinMode: PinFlags): number | undefined => {
+        const key = e.key;
+        if (isHandledKey(key)) {
+            if (!(pinMode & PinFlags.Input)) {
+                e.preventDefault();
+                accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
+                return undefined;
+            }
+            if (pinMode & PinFlags.Touch) {
+                // The pin is in touch mode and has button markup, not a slider.
+                e.preventDefault();
+                return undefined;
+            }
+        }
+        return commonKeyHandler(e, currentValue, min, max);
     }
 }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1048,7 +1048,9 @@ path.sim-board {
                 "y": "0px",
                 "width": MB_WIDTH + "px",
                 "height": MB_HEIGHT + "px",
-                "fill": "rgba(0,0,0,0)"
+                "fill": "rgba(0,0,0,0)",
+                // Allows screen reader users to interact with board properly.
+                "role": "application"
             });
             this.style = <SVGStyleElement>svg.child(this.element, "style", {});
             this.style.textContent = MB_STYLE + (this.props.theme.highContrast ? MB_HIGHCONTRAST : "");

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -237,13 +237,13 @@ path.sim-board {
         { title: "P14, SPI - MISO", ariaLabel: pxsim.localization.lf("Pin 14")},
         { title: "P15, SPI - MOSI", ariaLabel: pxsim.localization.lf("Pin 15")},
         { title: "P16, SPI - Chip Select", ariaLabel: pxsim.localization.lf("Pin 16")},
-        { title: "P17, +3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
-        { title: "P18, +3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
+        { title: "P17, +3v3", ariaLabel: pxsim.localization.lf("Pin 3V")},
+        { title: "P18, +3v3", ariaLabel: pxsim.localization.lf("Pin 3V")},
         { title: "P19, I2C - SCL", ariaLabel: pxsim.localization.lf("Pin 19")},
         { title: "P20, I2C - SDA", ariaLabel: pxsim.localization.lf("Pin 20")},
         { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
         { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
-        { title: "+3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
+        { title: "+3v3", ariaLabel: pxsim.localization.lf("Pin 3V")},
         { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
     ];
     const MB_WIDTH = 500;

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -648,7 +648,7 @@ path.sim-board {
                     this.pins[index].setAttribute("aria-orientation", "vertical");
                     this.pins[index].setAttribute("aria-valuenow", v.toString());
                     if (text?.textContent) {
-                        this.pins[index].setAttribute("aria-valuetext", text?.textContent ?? null);
+                        this.pins[index].setAttribute("aria-valuetext", text.textContent);
                     } else {
                         this.pins[index].removeAttribute("aria-valuetext");
                     }
@@ -1479,7 +1479,7 @@ path.sim-board {
                         let state = this.board;
                         let pin = state.edgeConnectorState.pins[index];
                         let svgpin = this.pins[index];
-                        if (pin.mode & PinFlags.Input) {
+                        if (pin.mode & PinFlags.Input && !(pin.mode & PinFlags.Touch)) {
                             let cursor = svg.cursorPoint(pt, this.element, ev);
                             let v = (400 - cursor.y) / 40 * 1023
                             pin.value = Math.max(0, Math.min(1023, Math.floor(v)));
@@ -1492,7 +1492,7 @@ path.sim-board {
                         let pin = state.edgeConnectorState.pins[index];
                         let svgpin = this.pins[index];
                         U.addClass(svgpin, "touched");
-                        if (pin.mode & PinFlags.Input) {
+                        if (pin.mode & PinFlags.Input && !(pin.mode & PinFlags.Touch)) {
                             let cursor = svg.cursorPoint(pt, this.element, ev);
                             let v = (400 - cursor.y) / 40 * 1023
                             pin.value = Math.max(0, Math.min(1023, Math.floor(v)));
@@ -1514,10 +1514,17 @@ path.sim-board {
                         let state = this.board;
                         let pin = state.edgeConnectorState.pins[index];
 
-                        if ([37, 38, 39, 40].includes(charCode) && !(pin.mode & PinFlags.Input)) {
-                            ev.preventDefault();
-                            accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
-                            return;
+                        if ([37, 38, 39, 40].includes(charCode)) {
+                            if (!(pin.mode & PinFlags.Input)) {
+                                ev.preventDefault();
+                                accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
+                                return;
+                            }
+                            if (pin.mode & PinFlags.Touch) {
+                                // The pin is in touch mode and has button markup, not a slider.
+                                ev.preventDefault();
+                                return;
+                            }
                         };
 
                         if (charCode === 40 || charCode === 37) { // Down/Left arrow

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -34,13 +34,14 @@ namespace pxsim.visuals {
         .sim-button-nut:hover {
             stroke:1px solid #704A4A;
         }
-        .sim-pin:hover {
+        .sim-pin[focusable=true]:hover {
             stroke:#D4AF37;
             stroke-width:2px;
         }
 
-        .sim-pin-touch.touched {
+        .sim-pin-touch[focusable=true].touched {
             stroke:darkorange !important;
+            stroke-width:5px;
         }
 
         .sim-led-back:hover {
@@ -143,25 +144,25 @@ namespace pxsim.visuals {
         *:focus {
             outline: none;
         }
-        *:focus .sim-button-outer,
-        .sim-shake:focus,
-        .sim-thermometer:focus {
+        *:focus-visible .sim-button-outer,
+        .sim-shake:focus-visible,
+        .sim-thermometer:focus-visible {
             outline: 5px solid white;
             stroke: black;
             stroke-width: 10px;
             paint-order: stroke;
         }
-        .sim-button-outer.sim-button-group:focus > .sim-button {
+        .sim-button-outer.sim-button-group:focus-visible > .sim-button {
             outline: 5px solid white;
             stroke: black;
             stroke-width: 5px;
             paint-order: stroke;
         }
-        .sim-light-level-button:focus,
-        .sim-antenna-outer:focus > .sim-antenna {
+        .sim-light-level-button:focus-visible,
+        .sim-antenna-outer:focus-visible > .sim-antenna {
             outline: 5px solid white;
         }
-        .sim-pin:focus { 
+        .sim-pin:focus-visible { 
             stroke: white;
             stroke-width: 5px !important;
         }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -214,29 +214,37 @@ path.sim-board {
         "P12", "P2", "P13", "P14", "P15", "P16", "P17", "P18", "P19", "P20",
         "GND0", "GND", "+3v3", "GND1"
     ];
-    const pinTitles = [
-        "P0, ANALOG IN",
-        "P1, ANALOG IN",
-        "P2, ANALOG IN",
-        "P3, ANALOG IN, LED Col 1",
-        "P4, ANALOG IN, LED Col 2",
-        "P5, BUTTON A",
-        "P6, LED Col 9",
-        "P7, LED Col 8",
-        "P8",
-        "P9, LED Col 7",
-        "P10, ANALOG IN, LED Col 3",
-        "P11, BUTTON B",
-        "P12, RESERVED ACCESSIBILITY",
-        "P13, SPI - SCK",
-        "P14, SPI - MISO",
-        "P15, SPI - MOSI",
-        "P16, SPI - Chip Select",
-        "P17, +3v3",
-        "P18, +3v3",
-        "P19, I2C - SCL",
-        "P20, I2C - SDA",
-        "GND", "GND", "+3v3", "GND"
+    interface PinTitle {
+        title: string,
+        ariaLabel: string
+    }
+    // title is currently unused.
+    const pinTitles: PinTitle[] = [
+        { title: "P0, ANALOG IN", ariaLabel: pxsim.localization.lf("Pin 0")},
+        { title: "P1, ANALOG IN", ariaLabel: pxsim.localization.lf("Pin 1")},
+        { title: "P2, ANALOG IN", ariaLabel: pxsim.localization.lf("Pin 2")},
+        { title: "P3, ANALOG IN, LED Col 1", ariaLabel: pxsim.localization.lf("Pin 3")},
+        { title: "P4, ANALOG IN, LED Col 2", ariaLabel: pxsim.localization.lf("Pin 4")},
+        { title: "P5, BUTTON A", ariaLabel: pxsim.localization.lf("Pin 5")},
+        { title: "P6, LED Col 9", ariaLabel: pxsim.localization.lf("Pin 6")},
+        { title: "P7, LED Col 8", ariaLabel: pxsim.localization.lf("Pin 7")},
+        { title: "P8", ariaLabel: pxsim.localization.lf("Pin 8")},
+        { title: "P9, LED Col 7", ariaLabel: pxsim.localization.lf("Pin 9")},
+        { title: "P10, ANALOG IN, LED Col 3", ariaLabel: pxsim.localization.lf("Pin 10")},
+        { title: "P11, BUTTON B", ariaLabel: pxsim.localization.lf("Pin 11")},
+        { title: "P12, RESERVED ACCESSIBILITY", ariaLabel: pxsim.localization.lf("Pin 12")},
+        { title: "P13, SPI - SCK", ariaLabel: pxsim.localization.lf("Pin 13")},
+        { title: "P14, SPI - MISO", ariaLabel: pxsim.localization.lf("Pin 14")},
+        { title: "P15, SPI - MOSI", ariaLabel: pxsim.localization.lf("Pin 15")},
+        { title: "P16, SPI - Chip Select", ariaLabel: pxsim.localization.lf("Pin 16")},
+        { title: "P17, +3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
+        { title: "P18, +3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
+        { title: "P19, I2C - SCL", ariaLabel: pxsim.localization.lf("Pin 19")},
+        { title: "P20, I2C - SDA", ariaLabel: pxsim.localization.lf("Pin 20")},
+        { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
+        { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
+        { title: "+3v3", ariaLabel: pxsim.localization.lf("Pin 3v")},
+        { title: "GND", ariaLabel: pxsim.localization.lf("Pin GND")},
     ];
     const MB_WIDTH = 500;
     const MB_HEIGHT = 408;
@@ -1233,7 +1241,7 @@ path.sim-board {
             this.pins = pinDrawOrder.reduce((pins, pinName) => {
                 const simPinIndex = pinNames.indexOf(pinName);
                 const newPin = drawList[simPinIndex]();
-                svg.hydrate(newPin, { title: pinTitles[simPinIndex] });
+                svg.hydrate(newPin, { title: pinTitles[simPinIndex].ariaLabel });
                 pins[simPinIndex] = newPin;
                 return pins;
             }, new Array(pinDrawOrder.length));
@@ -1278,7 +1286,6 @@ path.sim-board {
                 let btng = svg.child(this.g, "g", { class: "sim-button-group" });
                 accessibility.makeFocusable(btng);
                 accessibility.setAria(btng, "button", label);
-                btng.setAttribute("aria-pressed", "false");
                 this.buttonsOuter.push(btng);
                 svg.child(btng, "rect", { class: "sim-button-outer", x: left, y: top, rx: btnr, ry: btnr, width: btnw, height: btnw });
                 svg.child(btng, "circle", { class: "sim-button-nut", cx: left + btnnm, cy: top + btnnm, r: btnn });
@@ -1345,7 +1352,6 @@ path.sim-board {
             accessibility.makeFocusable(this.headParts);
             accessibility.setAria(this.headParts, "button", headTitle);
             this.headParts.setAttribute("class", "sim-button-outer sim-button-group")
-            this.headParts.setAttribute("aria-pressed", "false");
             this.attachButtonEvents(this.board.logoTouch, this.headParts, this.headParts);
             document.body.addEventListener(pointerEvents.down[0], this.moveHeadingOnClick);
 
@@ -1601,20 +1607,17 @@ path.sim-board {
             pointerEvents.down.forEach(evid => buttonOuter.addEventListener(evid, ev => {
                 stateButton.pressed = true;
                 this.updateButtonPairs();
-                buttonOuter.setAttribute("aria-pressed", "true");
                 this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 pressedTime = runtime.runningTime();
             }));
             buttonOuter.addEventListener(pointerEvents.leave, ev => {
                 stateButton.pressed = false;
                 this.updateButtonPairs();
-                buttonOuter.setAttribute("aria-pressed", "false");
                 svg.fill(elButton, this.props.theme.buttonUp);
             })
             buttonOuter.addEventListener(pointerEvents.up, ev => {
                 stateButton.pressed = false;
                 this.updateButtonPairs();
-                buttonOuter.setAttribute("aria-pressed", "false");
                 this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_UP);
                 const currentTime = runtime.runningTime()
                 if (currentTime - pressedTime > DAL.DEVICE_BUTTON_LONG_CLICK_TIME)
@@ -1626,13 +1629,11 @@ path.sim-board {
             accessibility.enableKeyboardInteraction(buttonOuter,
                 () => { // keydown
                     stateButton.pressed = true;
-                    buttonOuter.setAttribute("aria-pressed", "true");
                     this.updateButtonPairs();
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 }, () => { // keyup
                     stateButton.pressed = false;
                     this.updateButtonPairs();
-                    buttonOuter.setAttribute("aria-pressed", "false");
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_UP);
                     this.board.bus.queue(stateButton.id, DAL.MICROBIT_BUTTON_EVT_CLICK);
             });
@@ -1648,7 +1649,6 @@ path.sim-board {
                 bpState.bBtn.pressed = true;
                 bpState.abBtn.pressed = true;
                 this.updateButtonPairs();
-                this.buttonsOuter[2].setAttribute("aria-pressed", "true");
                 this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 pressedTime = runtime.runningTime()
             }));
@@ -1657,14 +1657,12 @@ path.sim-board {
                 bpState.bBtn.pressed = false;
                 bpState.abBtn.pressed = false;
                 this.updateButtonPairs();
-                this.buttonsOuter[2].setAttribute("aria-pressed", "false");
             })
             this.buttonsOuter[2].addEventListener(pointerEvents.up, ev => {
                 bpState.aBtn.pressed = false;
                 bpState.bBtn.pressed = false;
                 bpState.abBtn.pressed = false;
                 this.updateButtonPairs();
-                this.buttonsOuter[2].setAttribute("aria-pressed", "false");
 
                 this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_UP);
                 const currentTime = runtime.runningTime()
@@ -1681,14 +1679,12 @@ path.sim-board {
                     bpState.bBtn.pressed = true;
                     bpState.abBtn.pressed = true;
                     this.updateButtonPairs();
-                    this.buttonsOuter[2].setAttribute("aria-pressed", "true");
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_DOWN);
                 }, () => { // keyup
                     bpState.aBtn.pressed = false;
                     bpState.bBtn.pressed = false;
                     bpState.abBtn.pressed = false;
                     this.updateButtonPairs();
-                    this.buttonsOuter[2].setAttribute("aria-pressed", "false");
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_UP);
                     this.board.bus.queue(bpState.abBtn.id, DAL.MICROBIT_BUTTON_EVT_CLICK);
             }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -603,7 +603,7 @@ path.sim-board {
             }
             else if (pin.mode & PinFlags.Digital) {
                 gradientValue = pin.value > 0 ? "0%" : "100%";
-                v = pin.value;
+                v = pin.value > 0 ? 1 : 0;
                 if (text) text.textContent = v.toString();
             }
             else if (pin.mode & PinFlags.Touch) {
@@ -616,24 +616,35 @@ path.sim-board {
                 if (text) text.textContent = "";
             }
             if (gradientValue) svg.setGradientValue(this.pinGradients[index], gradientValue);
-
             if (pin.mode !== PinFlags.Unused) {
                 accessibility.makeFocusable(this.pins[index]);
-                accessibility.setAria(this.pins[index], "slider", this.pins[index].firstChild.textContent);
-                this.pins[index].setAttribute("aria-valuemin", "0");
-                this.pins[index].setAttribute("aria-valuemax", pin.mode & PinFlags.Analog ? "1023" : "1");
-                this.pins[index].setAttribute("aria-orientation", "vertical");
-                this.pins[index].setAttribute("aria-valuenow", v.toString());
-                if (text?.textContent) {
-                    this.pins[index].setAttribute("aria-valuetext", text?.textContent ?? null);
-                } else {
+                if (pin.mode & PinFlags.Touch) {
+                    this.pins[index].setAttribute("role", "button");
+                    this.pins[index].ariaLabel = this.pins[index].firstChild.textContent
+                    this.pins[index].removeAttribute("aria-valuemin");
+                    this.pins[index].removeAttribute("aria-valuemax");
+                    this.pins[index].removeAttribute("aria-orientation");
+                    this.pins[index].removeAttribute("aria-valuenow");
                     this.pins[index].removeAttribute("aria-valuetext");
-                }
-                if (pin.mode & PinFlags.Input) {
                     this.pins[index].removeAttribute("aria-readonly");
                 } else {
-                    this.pins[index].setAttribute("aria-readonly", "true");
-                }
+                    this.pins[index].setAttribute("role", "slider");
+                    this.pins[index].ariaLabel = this.pins[index].firstChild.textContent
+                    this.pins[index].setAttribute("aria-valuemin", "0");
+                    this.pins[index].setAttribute("aria-valuemax", pin.mode & PinFlags.Analog ? "1023" : "1");
+                    this.pins[index].setAttribute("aria-orientation", "vertical");
+                    this.pins[index].setAttribute("aria-valuenow", v.toString());
+                    if (text?.textContent) {
+                        this.pins[index].setAttribute("aria-valuetext", text?.textContent ?? null);
+                    } else {
+                        this.pins[index].removeAttribute("aria-valuetext");
+                    }
+                    if (pin.mode & PinFlags.Input) {
+                        this.pins[index].removeAttribute("aria-readonly");
+                    } else {
+                        this.pins[index].setAttribute("aria-readonly", "true");
+                    }
+                } 
             }
         }
 

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1335,7 +1335,7 @@ path.sim-board {
             const title = pxsim.localization.lf("micro:bit v2 needed")
             this.v2Circle = <SVGCircleElement>svg.child(this.g, "circle", { r: 21, title: title });
             svg.fill(this.v2Circle, "white");
-            this.v2Text = <SVGTextElement>svg.child(this.g, "text", { class: "sim-text", title: title });
+            this.v2Text = <SVGTextElement>svg.child(this.g, "text", { class: "sim-text", title: title, "aria-hidden": "true" });
             this.v2Text.textContent = "V2";
             svg.fill(this.v2Text, "black");
             this.v2Text.style.fontWeight = "700";
@@ -1366,8 +1366,7 @@ path.sim-board {
             this.microphoneLed = svg.path(microg, "sim-led sim-mic", "M 352.852 71 C 351.315 71 350.07 72.248 350.07 73.784 V 79.056 C 350.07 80.594 351.316 81.838 352.852 81.838 C 354.387 81.838 355.634 80.593 355.634 79.056 V 73.784 C 355.634 72.248 354.387 71 352.852 71 Z M 346.743 79.981 C 346.743 82.84 348.853 85.062 351.501 85.658 V 87.095 H 348.448 V 89.329 H 357.366 V 87.095 H 354.306 V 85.658 C 356.954 85.064 359.071 82.842 359.071 79.981 H 357.057 C 357.057 82.174 355.168 83.81 352.905 83.81 C 350.64 83.81 348.757 82.173 348.757 79.981 Z");
             svg.fills([this.microphoneLed], this.props.theme.ledOff);
             // ring
-            const microhole = svg.child(this.g, "circle", { cx: 336, cy: 86, r: 3, stroke: "gold", strokeWidth: "1px" })
-            svg.title(microhole, pxsim.localization.lf("microphone (micro:bit v2 needed)"))
+            svg.child(this.g, "circle", { cx: 336, cy: 86, r: 3, stroke: "gold", strokeWidth: "1px" })
 
             this.updateMicrophone();
             this.updateTheme();

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -555,7 +555,7 @@ path.sim-board {
                         this.board.accelerometerState.shake();
                     }
                 );
-                accessibility.setAria(this.shakeButton, "button", "Shake the board");
+                accessibility.setAria(this.shakeButton, "button", pxsim.localization.lf("Shake"));
                 this.shakeText = svg.child(this.g, "text", { x: 420, y: 122, class: "sim-text-small", "aria-hidden": "true" }) as SVGTextElement;
                 this.shakeText.textContent = "SHAKE";
             }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -489,6 +489,8 @@ path.sim-board {
                 U.removeClass(this.element, "grayscale");
 
             if (!initialCall && !this.liveRegionInitialized) {
+                // The iframe document's innerHTML is cleared after mkBoardView is called.
+                // Ensure that the live region is created after this.
                 accessibility.setLiveContent("");
                 this.liveRegionInitialized = true;
             }

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -135,6 +135,7 @@ namespace pxsim.visuals {
         }
         .sim-label, .sim-button-label {
             fill: #000;
+            pointer-events: none;
         }
         .sim-wireframe .sim-board {
             stroke-width: 2px;
@@ -172,6 +173,9 @@ namespace pxsim.visuals {
             -webkit-user-drag: none;
             -webkit-user-select: none;
             -ms-user-select: none;
+        }
+        [focusable=true] {
+            cursor: pointer;
         }
     `;
     const MB_HIGHCONTRAST = `

--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1678,7 +1678,7 @@ path.sim-board {
         if (isHandledKey(key)) {
             if (!(pinMode & PinFlags.Input)) {
                 e.preventDefault();
-                accessibility.setLiveContent(pxsim.localization.lf("This input is read only"));
+                accessibility.setLiveContent(pxsim.localization.lf("This pin is read-only"));
                 return undefined;
             }
             if (pinMode & PinFlags.Touch) {


### PR DESCRIPTION
This PR introduces changes to improve the screen reader and keyboard controls behaviour of the simulator as well as some refactoring and de-duplication of keyboard handling code.

- CSS tweaks to ensure that focus outlines are only visible for keyboard users (focus-visible) and not mouse users
- Pin values have been decoupled from gradient values and their real values (0..1 or 0..1023) are used in the markup
- Pins can be in the following modes for both keyboard and mouse controls (keyboard and mouse behaviour has been aligned):
    - touch with role="button" (no slider role or slider keyboard controls are active in this mode)
    - input (digital or analog) with role="slider" and readonly attributes - pressing arrow keys etc at this point will provide feedback via the live region that the pin is readonly
    - output (digital or analogue) with role="slider" and active slider controls (value can be changed)
- Simplify the pin and shake aria-labels
    - shake the board -> shake
    - P0, ANALOG IN -> Pin 0 (etc)
- Initialise the live region as soon as possible
    -  The live region needs to exist before text content is added / changed, otherwise screen readers may not output anything
- Remove uses of setLiveContent for sensor value changes and hide sensor value text from screen readers to avoid values being output multiple times
    - Screen readers already provide feedback for slider values and value changes
- Slider values no longer loop/wrap (including the compass) when using keyboard controls
- Sliders implement arrow key keyboard controls as well as Home (min value) / End (max value) and Page Up / Down (increment in steps of range / 10)

The compass control is currently not accessible as it is trying to be both a button and slider which cannot be supported simultaneously. See https://github.com/microsoft/pxt-microbit/issues/6784

This PR is expected to work with https://github.com/microsoft/pxt/pull/11275