### PR TITLE
Hide sensor text and values from screen readers

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -305,6 +305,7 @@ path.sim-board {
 
     export class MicrobitBoardSvg implements BoardView {
         public element: SVGSVGElement;
+        private liveRegionInitialized = false;
         private style: SVGStyleElement;
         private defs: SVGDefsElement;
         private g: SVGGElement;
@@ -381,7 +382,7 @@ path.sim-board {
             if (props && props.runtime) {
                 this.board = this.props.runtime.board as pxsim.DalBoard;
                 this.board.updateSubscribers.push(() => this.updateState());
-                this.updateState();
+                this.updateState(true);
                 this.attachEvents();
             }
         }
@@ -451,7 +452,7 @@ path.sim-board {
             this.positionV2Elements();
         }
 
-        public updateState() {
+        public updateState(initialCall: boolean = false) {
             const state = this.board;
             if (!state) return;
 
@@ -473,6 +474,13 @@ path.sim-board {
                 U.addClass(this.element, "grayscale");
             else
                 U.removeClass(this.element, "grayscale");
+
+            if (!initialCall && !this.liveRegionInitialized) {
+                // The iframe document's innerHTML is cleared after mkBoardView is called.
+                // Ensure that the live region is created after this.
+                accessibility.setLiveContent("");
+                this.liveRegionInitialized = true;
+            }
         }
 
         private updateButtonPairs() {
@@ -542,7 +550,7 @@ path.sim-board {
                     }
                 );
                 accessibility.setAria(this.shakeButton, "button", "Shake the board");
-                this.shakeText = svg.child(this.g, "text", { x: 420, y: 122, class: "sim-text-small" }) as SVGTextElement;
+                this.shakeText = svg.child(this.g, "text", { x: 420, y: 122, class: "sim-text-small", "aria-hidden": true }) as SVGTextElement;
                 this.shakeText.textContent = "SHAKE";
             }
         }
@@ -613,7 +621,6 @@ path.sim-board {
                 this.pins[index].setAttribute("aria-valuemax", pin.mode & PinFlags.Analog ? "1023" : "100");
                 this.pins[index].setAttribute("aria-orientation", "vertical");
                 this.pins[index].setAttribute("aria-valuenow", text ? text.textContent : v);
-                accessibility.setLiveContent(text ? text.textContent : v);
             }
         }
 
@@ -626,7 +633,7 @@ path.sim-board {
             if (!this.thermometerInitialized) {
                 this.thermometerInitialized = true;
                 this.thermometer.style.visibility = "visible";
-                this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130 }) as SVGTextElement;
+                this.thermometerText = svg.child(this.g, "text", { class: 'sim-text', x: 58, y: 130, "aria-hidden": true }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("temperature")] = state.thermometerState.temperature;
                 this.updateTheme();
@@ -679,7 +686,6 @@ path.sim-board {
             this.thermometerText.textContent = t + "°C";
             this.thermometer.setAttribute("aria-valuenow", t.toString());
             this.thermometer.setAttribute("aria-valuetext", t + "°C");
-            accessibility.setLiveContent(t + "°C");
         }
 
         private updateSoundLevel() {
@@ -692,7 +698,7 @@ path.sim-board {
                 this.soundLevelInitialized = true;
                 this.soundLevel.style.visibility = "visible";
                 const level = state.microphoneState.getLevel();
-                this.soundLevelText = svg.child(this.g, "text", { class: 'sim-text', x: 370, y: 90 }) as SVGTextElement;
+                this.soundLevelText = svg.child(this.g, "text", { class: 'sim-text', x: 370, y: 90, "aria-hidden": true }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("sound level")] = state.microphoneState.getLevel();
                 this.updateTheme();
@@ -739,7 +745,6 @@ path.sim-board {
             this.soundLevelText.textContent = t + "";
             this.soundLevel.setAttribute("aria-valuenow", t.toString());
             this.soundLevel.setAttribute("aria-valuetext", t + "");
-            accessibility.setLiveContent(t + "");
         }
 
         private updateHeading() {
@@ -852,7 +857,6 @@ path.sim-board {
                 this.antenna.setAttribute("aria-valuemax", `${valueMax}`);
                 this.antenna.setAttribute("aria-orientation", "horizontal");
                 this.antenna.setAttribute("aria-valuenow", "");
-                accessibility.setLiveContent("");
             }
             let now = Date.now();
             if (now - this.lastAntennaFlash > 200) {
@@ -873,7 +877,7 @@ path.sim-board {
                 let ayb = 40;
                 for (let i = 0; i < 4; ++i)
                     svg.child(this.g, "rect", { x: ANTENNA_X - 90 + i * 6, y: ayt + 28 - i * 4, width: 4, height: 2 + i * 4, fill: "#fff" })
-                this.rssi = svg.child(this.g, "text", { x: ANTENNA_X - 64, y: ayb, class: "sim-text" }) as SVGTextElement;
+                this.rssi = svg.child(this.g, "text", { x: ANTENNA_X - 64, y: ayb, class: "sim-text", "aria-hidden": true }) as SVGTextElement;
                 this.rssi.textContent = "";
             }
 
@@ -881,7 +885,6 @@ path.sim-board {
             if (vt !== this.rssi.textContent) {
                 this.rssi.textContent = v.toString();
                 this.antenna.setAttribute("aria-valuenow", this.rssi.textContent);
-                accessibility.setLiveContent(this.rssi.textContent);
             }
         }
 
@@ -934,7 +937,7 @@ path.sim-board {
                             this.applyLightLevel();
                         }
                     });
-                this.lightLevelText = svg.child(this.g, "text", { x: 85, y: LIGHT_LEVEL_BUTTON_POSITION_Y + LIGHT_LEVEL_BUTTON_RADIUS - 5, text: '', class: 'sim-text' }) as SVGTextElement;
+                this.lightLevelText = svg.child(this.g, "text", { x: 85, y: LIGHT_LEVEL_BUTTON_POSITION_Y + LIGHT_LEVEL_BUTTON_RADIUS - 5, text: '', class: 'sim-text', 'aria-hidden': true }) as SVGTextElement;
                 if (this.props.runtime)
                     this.props.runtime.environmentGlobals[pxsim.localization.lf("lightLevel")] = state.lightSensorState.lightLevel;
                 this.updateTheme();
@@ -956,7 +959,6 @@ path.sim-board {
             svg.setGradientValue(this.lightLevelGradient, Math.min(100, Math.max(0, Math.floor(lv * 100 / 255))) + '%')
             this.lightLevelText.textContent = lv.toString();
             this.lightLevelButton.setAttribute("aria-valuenow", lv.toString());
-            accessibility.setLiveContent(lv.toString());
         }
 
         findParentElement() {
@@ -996,21 +998,21 @@ path.sim-board {
                 // update text
                 if (acc.flags & AccelerometerFlag.X) {
                     if (!this.accTextX) {
-                        this.accTextX = svg.child(this.g, "text", { x: 365, y: 260, class: "sim-text" }) as SVGTextElement;
+                        this.accTextX = svg.child(this.g, "text", { x: 365, y: 260, class: "sim-text", "aria-hidden": true }) as SVGTextElement;
                         this.accTextX.textContent = "";
                     }
                     this.accTextX.textContent = `ax:${x}`;
                 }
                 if (acc.flags & AccelerometerFlag.Y) {
                     if (!this.accTextY) {
-                        this.accTextY = svg.child(this.g, "text", { x: 365, y: 285, class: "sim-text" }) as SVGTextElement;
+                        this.accTextY = svg.child(this.g, "text", { x: 365, y: 285, class: "sim-text", "aria-hidden": true }) as SVGTextElement;
                         this.accTextY.textContent = "";
                     }
                     this.accTextY.textContent = `ay:${-y}`;
                 }
                 if (acc.flags & AccelerometerFlag.Z) {
                     if (!this.accTextZ) {
-                        this.accTextZ = svg.child(this.g, "text", { x: 365, y: 310, class: "sim-text" }) as SVGTextElement;
+                        this.accTextZ = svg.child(this.g, "text", { x: 365, y: 310, class: "sim-text", "aria-hidden": true }) as SVGTextElement;
                         this.accTextZ.textContent = "";
                     }
                     this.accTextZ.textContent = `az:${z}`;
@@ -1171,7 +1173,7 @@ path.sim-board {
             this.heads.push(svg.path(this.headParts, "sim-theme", "M269.9,50.2L269.9,50.2l-39.5,0v0c-14.1,0.1-24.6,10.7-24.6,24.8c0,13.9,10.4,24.4,24.3,24.7v0h39.6c14.2,0,24.8-10.6,24.8-24.7C294.5,61,284,50.3,269.9,50.2 M269.7,89.2L269.7,89.2l-39.3,0c-7.7-0.1-14-6.4-14-14.2c0-7.8,6.4-14.2,14.2-14.2h39.1c7.8,0,14.2,6.4,14.2,14.2C283.9,82.9,277.5,89.2,269.7,89.2"));
             this.heads.push(svg.path(this.headParts, "sim-theme", "M230.6,69.7c-2.9,0-5.3,2.4-5.3,5.3c0,2.9,2.4,5.3,5.3,5.3c2.9,0,5.3-2.4,5.3-5.3C235.9,72.1,233.5,69.7,230.6,69.7"));
             this.heads.push(svg.path(this.headParts, "sim-theme", "M269.7,80.3c2.9,0,5.3-2.4,5.3-5.3c0-2.9-2.4-5.3-5.3-5.3c-2.9,0-5.3,2.4-5.3,5.3C264.4,77.9,266.8,80.3,269.7,80.3"));
-            this.headText = <SVGTextElement>svg.child(this.g, "text", { x: 160, y: 60, class: "sim-text" })
+            this.headText = <SVGTextElement>svg.child(this.g, "text", { x: 160, y: 60, class: "sim-text", "aria-hidden": true })
         }
 
         private buildPinElements() {
@@ -1213,7 +1215,7 @@ path.sim-board {
                 return lg;
             });
 
-            this.pinTexts = [67, 165, 275].map(x => <SVGTextElement>svg.child(this.g, "text", { class: "sim-text-pin", x: x, y: 345 }));
+            this.pinTexts = [67, 165, 275].map(x => <SVGTextElement>svg.child(this.g, "text", { class: "sim-text-pin", x: x, y: 345, "aria-hidden": true }));
 
             svg.path(this.g, "sim-label", "M35.7,376.4c0-2.8,2.1-5.1,5.5-5.1c3.3,0,5.5,2.4,5.5,5.1v4.7c0,2.8-2.2,5.1-5.5,5.1c-3.3,0-5.5-2.4-5.5-5.1V376.4zM43.3,376.4c0-1.3-0.8-2.3-2.2-2.3c-1.3,0-2.1,1.1-2.1,2.3v4.7c0,1.2,0.8,2.3,2.1,2.3c1.3,0,2.2-1.1,2.2-2.3V376.4z");
             svg.path(this.g, "sim-label", "M136.2,374.1c2.8,0,3.4-0.8,3.4-2.5h2.9v14.3h-3.4v-9.5h-3V374.1z");
@@ -1290,7 +1292,7 @@ path.sim-board {
             const title = pxsim.localization.lf("micro:bit v2 needed")
             this.v2Circle = <SVGCircleElement>svg.child(this.g, "circle", { r: 21, title: title });
             svg.fill(this.v2Circle, "white");
-            this.v2Text = <SVGTextElement>svg.child(this.g, "text", { class: "sim-text", title: title });
+            this.v2Text = <SVGTextElement>svg.child(this.g, "text", { class: "sim-text", title: title, "aria-hidden": true });
             this.v2Text.textContent = "V2";
             svg.fill(this.v2Text, "black");
             this.v2Text.style.fontWeight = "700";


### PR DESCRIPTION
When changing a simulator slider value, such as the temperature, with a screen reader enabled, the new value is output three times. Once as a result of the interaction with the slider control, once more  via the text updating on the simulator, and a third time via the live region. 

This PR removes uses of setLiveContent for sensor value changes and hides sensor value text from screen readers to avoid values being output multiple times as screen readers already provide feedback for sliders as a result of interaction.

This PR also initialises the live region as soon as possible. The live region needs to exist before text content is added / changed, otherwise screen readers may not output anything. A follow up PR will utilise this live region.

