### PR TITLE
Implement additional keyboard controls for sim sliders

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -646,20 +646,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            state.thermometerState.temperature--;
-                            if (state.thermometerState.temperature < -5) {
-                                state.thermometerState.temperature = 50;
-                            }
-                            this.updateTemperature();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            state.thermometerState.temperature++;
-                            if (state.thermometerState.temperature > 50) {
-                                state.thermometerState.temperature = -5;
-                            }
+                        const value = commonKeyHandler(ev, state.thermometerState.temperature, tmin, tmax);
+                        if (value !== undefined) {
+                            state.thermometerState.temperature = value;
                             this.updateTemperature();
                         }
                     })
@@ -712,14 +701,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            state.microphoneState.setLevel(state.microphoneState.getLevel() - 1);
-                            this.updateMicrophone();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            state.microphoneState.setLevel(state.microphoneState.getLevel() + 1)
+                        const value = commonKeyHandler(ev, state.microphoneState.getLevel(), tmin, tmax);
+                        if (value !== undefined) {
+                            state.microphoneState.setLevel(value);
                             this.updateMicrophone();
                         }
                     })
@@ -767,18 +751,9 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            state.compassState.heading--;
-                            if (state.compassState.heading < 0) state.compassState.heading += 360;
-                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
-                            this.updateHeading();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            state.compassState.heading++;
-                            if (state.compassState.heading < 0) state.compassState.heading += 360;
-                            if (state.compassState.heading >= 360) state.compassState.heading %= 360;
+                        const value = commonKeyHandler(ev, state.compassState.heading, 0, 359);
+                        if (value !== undefined) {
+                            state.compassState.heading = value;
                             this.updateHeading();
                         }
                     }
@@ -831,14 +806,9 @@ path.sim-board {
                     setValue((-138 + (pos.x - ANTENNA_X) / antennaWidth * 100) | 0);
                 };
                 const keyboardEventHandler = (ev: KeyboardEvent) => {
-                    const charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode;
-                    const rs = this.board.radioState.datagram.rssi ?? -75;
-                    if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                        ev.preventDefault();
-                        setValue(rs - 1);
-                    } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                        ev.preventDefault();
-                        setValue(rs + 1);
+                    const value = commonKeyHandler(ev, this.board.radioState.datagram.rssi ?? -75, valueMin, valueMax);
+                    if (value !== undefined) {
+                        setValue(value);
                     }
                 };
 
@@ -917,21 +887,10 @@ path.sim-board {
                     ev => { },
                     // keydown
                     (ev) => {
-                        let charCode = (typeof ev.which == "number") ? ev.which : ev.keyCode
-                        if (charCode === 40 || charCode === 37) { // Down/Left arrow
-                            ev.preventDefault();
-                            this.board.lightSensorState.lightLevel--;
-                            if (this.board.lightSensorState.lightLevel < 0) {
-                                this.board.lightSensorState.lightLevel = 255;
-                            }
-                            this.applyLightLevel();
-                        } else if (charCode === 38 || charCode === 39) { // Up/Right arrow
-                            ev.preventDefault();
-                            this.board.lightSensorState.lightLevel++;
-                            if (this.board.lightSensorState.lightLevel > 255) {
-                                this.board.lightSensorState.lightLevel = 0;
-                            }
-                            this.applyLightLevel();
+                        const value = commonKeyHandler(ev, state.lightSensorState.lightLevel, 0, 255);
+                        if (value !== undefined) {
+                            state.lightSensorState.lightLevel = value;
+                            this.updateLightLevel();
                         }
                     });
                 this.lightLevelText = svg.child(this.g, "text", { x: 85, y: LIGHT_LEVEL_BUTTON_POSITION_Y + LIGHT_LEVEL_BUTTON_RADIUS - 5, text: '', class: 'sim-text' }) as SVGTextElement;
@@ -1640,5 +1599,49 @@ path.sim-board {
         private attachKeyboardEvents() {
             accessibility.postKeyboardEvent();
         }
+    }
+
+    const isHandledKey = (key: string) => {
+        return ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "PageUp", "PageDown", "Home", "End"].includes(key);
+    }
+
+    const getSliderStepValue = (min: number, max: number) => {
+        const range = max - min;
+        // Assumes slider values are always integers.
+        return Math.max(1, Math.floor(range / 10));
+    }
+
+    const commonKeyHandler = (e: KeyboardEvent, currentValue: number, min: number, max: number): number | undefined => {
+        const key = e.key;
+        if (isHandledKey(key)) {
+            e.preventDefault();
+        }
+        switch(key) {
+            case "ArrowDown":
+            case "ArrowLeft": {
+                return Math.max(min, currentValue - 1)
+            }
+            case "ArrowUp":
+            case "ArrowRight": {
+                return Math.min(max, currentValue + 1)
+            }
+            case "Home": {
+                return min;
+            }
+            case "End": {
+                return max;
+            }
+            case "PageDown": {
+                const step = getSliderStepValue(min, max);
+                const value = currentValue - step;
+                return Math.max(min, value)
+            }
+            case "PageUp": {
+                const step = getSliderStepValue(min, max);
+                const value = currentValue + step;
+                return Math.min(max, value)
+            }
+        }
+        return undefined;
     }
 }


### PR DESCRIPTION
This PR prevents slider values from looping and implements controls for the Page Up and Page Down keys (increment value in steps of range / 10) and the Home and End keys (set slider to min and max values).

Duplicated code has been pulled out into a common key handler function.

The pins will addressed in a follow up PR due to additional complexity in the pin values (digital vs analog) and their dual roles as both sliders and buttons.