### PR TITLE
Give sim application role to fix screen reader user interaction

### DIFF
--- a/sim/visuals/microbit.ts
+++ b/sim/visuals/microbit.ts
@@ -1029,7 +1029,9 @@ path.sim-board {
                 "y": "0px",
                 "width": MB_WIDTH + "px",
                 "height": MB_HEIGHT + "px",
-                "fill": "rgba(0,0,0,0)"
+                "fill": "rgba(0,0,0,0)",
+                // Allows screen reader users to interact with board properly.
+                "role": "application"
             });
             this.style = <SVGStyleElement>svg.child(this.element, "style", {});
             this.style.textContent = MB_STYLE + (this.props.theme.highContrast ? MB_HIGHCONTRAST : "");


### PR DESCRIPTION
Screen readers don't always respect the role attribute on SVG elements. While running NVDA on Windows and using the current live version of MakeCode, keyboard interaction with the sliders work, but you are unable to trigger a button press on Button A or Button B for example using Space or Enter, even though these elements have role="button" and tabindex="0" on them. There may be a more nuanced way to address this (such as adding non-SVG buttons inside foreignObjects which is more disruptive), but role="application" is one fix. This only impacts the micro:bit simulator and I'm not sure there is much in the way of screen reader semantics that will be lost here. Thoughts welcome.