### PR TITLE
Add block name "LED" for led namespace

### DIFF
--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -1,7 +1,7 @@
 /**
  * Control of the LED screen.
  */
-//% color=#5C2D91 weight=101 icon="\uf205"
+//% color=#5C2D91 weight=101 icon="\uf205" block="LED"
 namespace led {
     /**
      * Get the on/off state of the specified LED using x, y coordinates. (0,0) is upper left.


### PR DESCRIPTION
This ensures that screen readers output LED correctly. Will impact existing translations.