### PR TITLE
Add Kitronik Design & Automate Accessory Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -577,6 +577,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Kitronik Design & Automate Accessory Kit",
+  "url":"/pkg/KitronikLtd/pxt-design-and-automate-accessory-kit",
+  "cardType": "package"
+}, {
   "name": "PyoBot",
   "url":"/pkg/pyocodingcompany-crypto/pyobot-makecode",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -441,6 +441,7 @@
             "steveturbek/pxt-rotary-encoder-ky-040-plus": { "tags": [ "Science" ] },
             "jim-no-surname-provided/pxt-tobbieii": { "tags": [ "Robotics" ] },
             "pyocodingcompany-crypto/pyobot-makecode": { "tags": [ "Robotics" ] },
+            "kitronikltd/pxt-design-and-automate-accessory-kit": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from https://support.microbit.org/helpdesk/tickets/99198 (private)
@JakeAtKitronik
@abchatra 

Extension: https://github.com/KitronikLtd/pxt-design-and-automate-accessory-kit
Version: v1.0.3
All blocks: https://makecode.microbit.org/_JMg0FCP9fKkE
<img width="312" height="258" alt="image" src="https://github.com/user-attachments/assets/08e8c638-033e-4417-ab52-bad91790d1ba" />
