### PR TITLE
restore old focus outline behavior for pin dropdown

### DIFF
--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -33,3 +33,11 @@ text.blocklyText {
     stroke: white;
     stroke-width: 1px;
 }
+
+.blocklyWidgetDiv .blocklyGridPickerScroller.keyboardNavigable:has(:focus-visible) {
+    outline: none;
+
+    .blocklyGridPickerMenu:focus .blocklyGridPickerRow .gridpicker-menuitem.gridpicker-option-focused {
+        outline: 4px solid white;
+    }
+}


### PR DESCRIPTION
other part of the fix for https://github.com/microsoft/pxt-microbit/issues/6695

along with https://github.com/microsoft/pxt/pull/11312

restores the old white outline color for the gridpicker in microbit because it contrasts better than the blue one we use for minecraft