### PR TITLE
Add pauseUntil block to runtime configuration

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -215,6 +215,10 @@
     "runtime": {
         "mathBlocks": true,
         "loopsBlocks": true,
+        "pauseUntilBlock": {
+            "category": "loops",
+            "weight": 25
+        },
         "logicBlocks": true,
         "variablesBlocks": true,
         "textBlocks": true,


### PR DESCRIPTION
close https://github.com/microsoft/pxt-microbit/issues/5919

adds it to the bottom of loops, like arcade
<img width="701" height="1352" alt="image" src="https://github.com/user-attachments/assets/f247ee6c-647a-4141-b474-c4b56fe69676" />
the fiddley bit is that the normal pause block is in basic in microbit, so doesn't have the same association of pause = loops category arcade does. pause until *definitely* does not belong in basic though