### PR TITLE
[pxt-cli] bump version to v8.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.5",
-        "pxt-core": "12.3.12"
+        "pxt-core": "12.3.13"
     },
     "overrides": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-microbit",
-    "version": "8.1.17",
+    "version": "8.1.18",
     "description": "micro:bit target for Microsoft MakeCode (PXT)",
     "keywords": [
         "JavaScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.