### PR TITLE
Update Blockly dependency overrides to beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     },
     "overrides": {
         "@blockly/field-grid-dropdown": {
-            "blockly": "13.0.0-beta.8"
+            "blockly": "13.0.0-beta.9"
         },
         "@blockly/plugin-workspace-search": {
-            "blockly": "13.0.0-beta.8"
+            "blockly": "13.0.0-beta.9"
         }
     }
 }


### PR DESCRIPTION
This change will need to be paired with the pxt upgrade that contains the same change. I do not suggest merging it as-is, see my notes on https://github.com/microsoft/pxt/pull/11398