### PR TITLE
pxtarget.json: githubCorePackage bumped from v0.2.13 to v0.3.0

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -205,7 +205,7 @@
                 },
                 "codalBinary": "MICROBIT",
                 "githubCorePackage": "lancaster-university/microbit-v2-samples",
-                "gittag": "v0.2.13",
+                "gittag": "v0.3.0",
                 "serviceId": "mbcodal2",
                 "dockerImage": "pext/yotta:latest",
                 "yottaConfigCompatibility": true


### PR DESCRIPTION
Hi @abchatra @thomasjball,

This is the aforementioned compilation issue:
[CMake 4.0.0+ removed compatibility with versions older than 3.5](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features). This is a problem because the current githubCorePackage is on v0.2.13 which means that the [microbit-v2-samples/utils/cmake/JSONParser.cmake](https://github.com/lancaster-university/microbit-v2-samples/blob/490a890626674aa859a2f9f19d96dc8e2367f137/utils/cmake/JSONParser.cmake#L23) has a cmake_minimum_required of 3.1, thus pxt-microbit cannot be compiled when using the latest versions of CMake.

Fortunately, [the latest microbit-v2-samples ](https://github.com/lancaster-university/microbit-v2-samples/blob/04b7089d82af24534f3dcd460a9c343850b60b5d/utils/cmake/JSONParser.cmake#L23) bumps the cmake_minimum_required to 3.6, so we need only update the githubCorePackage to it.

I tested the change by building [microcode-v2](https://github.com/microbit-apps/Microcode-v2/) and its dependencies with this change and the latest CMake version 4.3.0.

There are a few changes between v0.3.0 and v0.2.13, as visible in this [comparison for v0.3.0 and v0.2.13](https://github.com/lancaster-university/microbit-v2-samples/compare/v0.2.13...master).

Thanks,
Kier