### PR TITLE
Extension: add Ceibal UBit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -939,6 +939,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+    "name": "Ceibal Ubit",
+    "url": "/pkg/Forward-Education/pxt-ceibal-ubit",
+    "cardType": "package"
+}, {
     "name": "BestModules BMduino",
     "url": "/pkg/BestModules-Libraries/pxt-bmduino",
     "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -443,6 +443,7 @@
             "pyocodingcompany-crypto/pyobot-makecode": { "tags": [ "Robotics" ] },
             "kitronikltd/pxt-design-and-automate-accessory-kit": { "tags": [ "Robotics" ] },
             "aorczyk/my-controller": { "tags": [ "Software" ] },
+            "forward-education/pxt-ceibal-ubit": {},
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/99943 (private)
@ssande-fwd 
@abchatra

Extension: https://github.com/Forward-Education/pxt-ceibal-ubit
Version: v1.0.2
Product: https://forwardedu.com/products/ubit-accessory-for-micro-bit
All blocks: https://makecode.microbit.org/_4xh3yFFawg3T

<img width="859" height="343" alt="image" src="https://github.com/user-attachments/assets/cc5a9cf6-71cc-4656-b2c8-6b30849478f2" />
