### PR TITLE
Update pxt-core dependency to version 12.3.21 to pick up offline app related fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.7",
-        "pxt-core": "12.3.20"
+        "pxt-core": "12.3.21"
     },
     "overrides": {
         "@blockly/field-grid-dropdown": {


### PR DESCRIPTION
Primarily bumping to pick up https://github.com/microsoft/pxt/pull/11342 for test offline app build, since the bugs listed there are most noticeable / annoying in offline app scenario and ideally addressed now