### PR TITLE
Add parameter labels for input names

### DIFF
--- a/libs/audio-recording/recording.ts
+++ b/libs/audio-recording/recording.ts
@@ -186,6 +186,7 @@ namespace record {
      * @param hz The sample frequency, in Hz
      */
     //% block="set sample rate to $hz || for $scope"
+    //% hz.label="sample rate"
     //% blockId="record_setSampleRate"
     //% hz.min=1000 hz.max=22000 hz.defl=11000
     //% expandableArgumentMode="enabled"

--- a/libs/bluetooth/bluetooth.cpp
+++ b/libs/bluetooth/bluetooth.cpp
@@ -145,6 +145,7 @@ namespace bluetooth {
     */
     //% help=bluetooth/on-uart-data-received
     //% weight=18 blockId=bluetooth_on_data_received block="bluetooth|on data received %delimiters=serial_delimiter_conv"
+    //% delimiters.label="delimiter"
     void onUartDataReceived(String delimiters, Action body) {
       startUartService();
       uart->eventOn(MSTR(delimiters));
@@ -181,6 +182,7 @@ namespace bluetooth {
     * @param connectable true to keep bluetooth connectable for other services, false otherwise.
     */
     //% blockId=eddystone_advertise_url block="bluetooth advertise url %url|with power %power|connectable %connectable"
+    //% url.label="url" power.label="power" connectable.label="connectable"
     //% parts=bluetooth weight=11 blockGap=8
     //% help=bluetooth/advertise-url blockExternalInputs=1
     //% hidden=1 deprecated=1
@@ -217,6 +219,7 @@ namespace bluetooth {
     */
     //% parts=bluetooth weight=5 help=bluetooth/set-transmit-power advanced=true
     //% blockId=bluetooth_settransmitpower block="bluetooth set transmit power %power"
+    //% power.label="value"
     void setTransmitPower(int power) {
         uBit.bleManager.setTransmitPower(min(MICROBIT_BLE_POWER_LEVELS-1, max(0, power)));
     }

--- a/libs/bluetooth/bluetooth.ts
+++ b/libs/bluetooth/bluetooth.ts
@@ -20,6 +20,7 @@ namespace bluetooth {
     */
     //% help=bluetooth/uart-write-string weight=80
     //% blockId=bluetooth_uart_write block="bluetooth uart|write string %data" blockGap=8
+    //% data.label="value"
     //% parts="bluetooth" shim=bluetooth::uartWriteString advanced=true
     export function uartWriteString(data: string): void {
         console.log(data)
@@ -30,6 +31,7 @@ namespace bluetooth {
     */
     //% help=bluetooth/uart-write-line weight=79
     //% blockId=bluetooth_uart_line block="bluetooth uart|write line %data" blockGap=8
+    //% data.label="value"
     //% parts="bluetooth" advanced=true
     export function uartWriteLine(data: string): void {
         uartWriteString(data + serial.NEW_LINE);
@@ -41,6 +43,7 @@ namespace bluetooth {
     //% help=bluetooth/uart-write-number weight=79
     //% weight=89 blockGap=8 advanced=true
     //% blockId=bluetooth_uart_writenumber block="bluetooth uart|write number %value"
+    //% value.label="value"
     export function uartWriteNumber(value: number): void {
         uartWriteString(value.toString());
     }
@@ -53,6 +56,7 @@ namespace bluetooth {
     //% weight=88 weight=78
     //% help=bluetooth/uart-write-value advanced=true
     //% blockId=bluetooth_uart_writevalue block="bluetooth uart|write value %name|= %value"
+    //% name.label="name" value.label="value"
     export function uartWriteValue(name: string, value: number): void {
         uartWriteString((name ? name + ":" : "") + value + NEW_LINE);
     }
@@ -62,6 +66,7 @@ namespace bluetooth {
      */
     //% help=bluetooth/uart-read-until weight=75
     //% blockId=bluetooth_uart_read block="bluetooth uart|read until %del=serial_delimiter_conv"
+    //% del.label="delimiter"
     //% parts="bluetooth" shim=bluetooth::uartReadUntil advanced=true
     export function uartReadUntil(del: string): string {
         // dummy implementation for simulator
@@ -76,6 +81,7 @@ namespace bluetooth {
     * @param connectable true to keep bluetooth connectable for other services, false otherwise.
     */
     //% blockId=eddystone_advertise_uid block="bluetooth advertise UID|namespace (bytes 6-9)%ns|instance (bytes 2-6)%instance|with power %power|connectable %connectable"
+    //% ns.label="namespace" instance.label="instance" power.label="power" connectable.label="connectable"
     //% parts=bluetooth weight=12 blockGap=8
     //% help=bluetooth/advertise-uid blockExternalInputs=1
     //% hidden=1 deprecated=1

--- a/libs/core/basic.cpp
+++ b/libs/core/basic.cpp
@@ -29,6 +29,7 @@ namespace basic {
     //% help=basic/show-string
     //% weight=87 blockGap=16
     //% block="show|string %text"
+    //% text.label="value"
     //% async
     //% blockId=device_print_message
     //% parts="ledmatrix"
@@ -95,6 +96,7 @@ namespace basic {
      */
     //% help=basic/pause weight=54
     //% async block="pause (ms) %pause" blockGap=16
+    //% ms.label="value"
     //% blockId=device_pause icon="\uf110"
     //% pause.shadow=timePicker
     void pause(int ms) {

--- a/libs/core/basic.ts
+++ b/libs/core/basic.ts
@@ -7,6 +7,7 @@ namespace basic {
     //% help=basic/show-number
     //% weight=96
     //% blockId=device_show_number block="show|number %number" blockGap=8
+    //% value.label="value"
     //% async
     //% parts="ledmatrix" interval.defl=150
     export function showNumber(value: number, interval?: number) {

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -258,6 +258,7 @@ namespace control {
     */
     //% help=control/wait-for-event async
     //% blockId=control_wait_for_event block="wait for event|from %src|with value %value"
+    //% src.label="source" value.label="value"
     void waitForEvent(int src, int value) {
         pxt::waitForEvent(src, value);
     }
@@ -283,6 +284,7 @@ namespace control {
     */
     //% help=control/wait-micros weight=29 async
     //% blockId="control_wait_us" block="wait (µs)%micros"
+    //% micros.label="microseconds"
     //% micros.min=0 micros.max=6000
     void waitMicros(int micros) {
         sleep_us(micros);
@@ -295,6 +297,7 @@ namespace control {
      * @param mode optional definition of how the event should be processed after construction (default is CREATE_AND_FIRE).
      */
     //% weight=21 blockGap=12 blockId="control_raise_event" block="raise event|from source %src=control_event_source_id|with value %value=control_event_value_id" blockExternalInputs=1
+    //% src.label="source" value.label="value"
     //% help=control/raise-event
     //% mode.defl=CREATE_AND_FIRE
     void raiseEvent(int src, int value, EventCreationMode mode) {
@@ -305,6 +308,7 @@ namespace control {
      * Registers an event handler.
      */
     //% weight=20 blockGap=8 blockId="control_on_event" block="on event|from %src=control_event_source_id|with value %value=control_event_value_id"
+    //% src.label="source" value.label="value"
     //% help=control/on-event
     //% blockExternalInputs=1
     void onEvent(int src, int value, Action handler, int flags = 0) {

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -201,6 +201,7 @@ namespace control {
  */
 //% help=text/convert-to-text weight=1
 //% block="convert $value=math_number to text"
+//% value.label="value"
 //% blockId=variable_to_text blockNamespace="text"
 function convertToText(value: any): string {
     return "" + value;

--- a/libs/core/game.ts
+++ b/libs/core/game.ts
@@ -44,6 +44,7 @@ namespace game {
      */
     //% weight=60 blockGap=8 help=game/create-sprite
     //% blockId=game_create_sprite block="create sprite at|x: %x|y: %y"
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     export function createSprite(x: number, y: number): LedSprite {
         init();
@@ -66,6 +67,7 @@ namespace game {
      */
     //% weight=10 help=game/add-score
     //% blockId=game_add_score block="change score by|%points" blockGap=8
+    //% points.label="value"
     //% parts="ledmatrix"
     export function addScore(points: number): void {
         setScore(_score + points);
@@ -89,6 +91,7 @@ namespace game {
      */
     //% weight=9 help=game/start-countdown
     //% blockId=game_start_countdown block="start countdown|(ms) %duration" blockGap=8
+    //% ms.label="value"
     //% parts="ledmatrix"
     export function startCountdown(ms: number): void {
         if (checkStart()) {
@@ -153,6 +156,7 @@ namespace game {
      * @param value new score value.
      */
     //% blockId=game_set_score block="set score %points" blockGap=8
+    //% value.label="value"
     //% weight=10 help=game/set-score
     export function setScore(value: number): void {
         _score = Math.max(0, value);
@@ -172,6 +176,7 @@ namespace game {
      */
     //% weight=10 help=game/set-life
     //% blockId=game_set_life block="set life %value" blockGap=8
+    //% value.label="value"
     export function setLife(value: number): void {
         _life = Math.max(0, value);
         if (_life <= 0) {
@@ -185,6 +190,7 @@ namespace game {
      */
     //% weight=10 help=game/add-life
     //% blockId=game_add_life block="add life %lives" blockGap=8
+    //% lives.label="value"
     export function addLife(lives: number): void {
         setLife(_life + lives);
     }
@@ -208,6 +214,7 @@ namespace game {
     //% weight=10 help=game/remove-life
     //% parts="ledmatrix"
     //% blockId=game_remove_life block="remove life %life" blockGap=8
+    //% life.label="value"
     export function removeLife(life: number): void {
         setLife(_life - life);
         if (!_paused && !_backgroundAnimation) {
@@ -360,6 +367,7 @@ namespace game {
          */
         //% weight=50 help=game/move
         //% blockId=game_move_sprite block="%sprite|move by %leds" blockGap=8
+        //% sprite.label="sprite" leds.label="LEDs"
         //% parts="ledmatrix"
         public move(leds: number): void {
             if (this._dir == 0) {
@@ -409,6 +417,7 @@ namespace game {
          */
         //% weight=18 help=game/if-on-edge-bounce
         //% blockId=game_sprite_bounce block="%sprite|if on edge, bounce"
+        //% sprite.label="sprite"
         //% parts="ledmatrix"
         public ifOnEdgeBounce(): void {
             if (this._dir == 0 && this._y == 0) {
@@ -463,6 +472,7 @@ namespace game {
          */
         //% weight=49 help=game/turn
         //% blockId=game_turn_sprite block="%sprite|turn %direction|by (°) %degrees"
+        //% sprite.label="sprite" degrees.label="degrees"
         public turn(direction: Direction, degrees: number) {
             if (direction == Direction.Right)
                 this.setDirection(this._dir + degrees);
@@ -495,6 +505,7 @@ namespace game {
          */
         //% weight=29 help=game/set
         //% blockId=game_sprite_set_property block="%sprite|set %property|to %value" blockGap=8
+        //% sprite.label="sprite" value.label="value"
         public set(property: LedSpriteProperty, value: number) {
             switch (property) {
                 case LedSpriteProperty.X: this.setX(value); break;
@@ -512,6 +523,7 @@ namespace game {
          */
         //% weight=30 help=game/change
         //% blockId=game_sprite_change_xy block="%sprite|change %property|by %value" blockGap=8
+        //% sprite.label="sprite" value.label="value"
         public change(property: LedSpriteProperty, value: number) {
             switch (property) {
                 case LedSpriteProperty.X: this.changeXBy(value); break;
@@ -528,6 +540,7 @@ namespace game {
          */
         //% weight=28 help=game/get
         //% blockId=game_sprite_property block="%sprite|%property"
+        //% sprite.label="sprite"
         public get(property: LedSpriteProperty) {
             switch (property) {
                 case LedSpriteProperty.X: return this.x();
@@ -622,6 +635,7 @@ namespace game {
          */
         //% weight=20 help=game/is-touching
         //% blockId=game_sprite_touching_sprite block="is %sprite|touching %other" blockGap=8
+        //% sprite.label="sprite" other.label="other sprite"
         public isTouching(other: LedSprite): boolean {
             return this._enabled && other._enabled && this._x == other._x && this._y == other._y;
         }
@@ -632,6 +646,7 @@ namespace game {
          */
         //% weight=19 help=game/is-touching-edge
         //% blockId=game_sprite_touching_edge block="is %sprite|touching edge" blockGap=8
+        //% sprite.label="sprite"
         public isTouchingEdge(): boolean {
             return this._enabled && (this._x == 0 || this._x == 4 || this._y == 0 || this._y == 4);
         }
@@ -697,6 +712,7 @@ namespace game {
          */
         //% weight=59 blockGap=8 help=game/delete
         //% blockId="game_delete_sprite" block="delete %this(sprite)"
+        //% this.label="sprite"
         public delete(): void {
             this._enabled = false;
             if (_sprites.removeElement(this))
@@ -708,6 +724,7 @@ namespace game {
          */
         //% weight=58 help=game/is-deleted
         //% blockId="game_sprite_is_deleted" block="is %sprite|deleted"
+        //% sprite.label="sprite"
         public isDeleted(): boolean {
             return !this._enabled;
         }

--- a/libs/core/helpers.ts
+++ b/libs/core/helpers.ts
@@ -26,6 +26,7 @@ namespace Math {
      */
     //% blockId=math_convert_unit
     //% block="convert $value|from $type"
+    //% value.label="value"
     //% help=math/convert-unit
     //% weight=0
     export function convert(value: number, type: UnitConversion): number {

--- a/libs/core/icons.ts
+++ b/libs/core/icons.ts
@@ -200,6 +200,7 @@ namespace basic {
     //% weight=50 blockGap=8
     //% blockId=basic_show_arrow
     //% block="show arrow %i=device_arrow"
+    //% direction.label="direction"
     //% parts="ledmatrix"
     //% help=basic/show-arrow
     export function showArrow(direction: number, interval = 600) {

--- a/libs/core/images.cpp
+++ b/libs/core/images.cpp
@@ -87,6 +87,7 @@ void plotImage(Image i, int xOffset = 0) {
  */
 //% help=images/show-image weight=80 blockNamespace=images
 //% blockId=device_show_image_offset block="show image %sprite(myImage)|at offset %offset ||and interval (ms) %interval"
+//% sprite.label="image" xOffset.label="offset" interval.label="interval"
 //% interval.defl=400
 //% blockGap=8 parts="ledmatrix" async
 void showImage(Image sprite, int xOffset, int interval = 400) {
@@ -112,6 +113,7 @@ void plotFrame(Image i, int xOffset) {
 //% help=images/scroll-image weight=79 async blockNamespace=images
 //% blockId=device_scroll_image
 //% block="scroll image %sprite(myImage)|with offset %frameoffset|and interval (ms) %delay"
+//% id.label="image" frameOffset.label="offset" interval.label="interval"
 //% blockGap=8 parts="ledmatrix"
 void scrollImage(Image id, int frameOffset, int interval) {
     MicroBitImage i(id->img);

--- a/libs/core/led.cpp
+++ b/libs/core/led.cpp
@@ -20,6 +20,7 @@ namespace led {
      */
     //% help=led/plot weight=78
     //% blockId=device_plot block="plot|x %x|y %y" blockGap=8
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
@@ -35,6 +36,7 @@ namespace led {
      */
     //% help=led/plot-brightness weight=78
     //% blockId=device_plot_brightness block="plot|x %x|y %y|brightness %brightness" blockGap=8
+    //% x.label="x" y.label="y" brightness.label="brightness"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4 brightness.min=0 brightness.max=255
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
@@ -54,6 +56,7 @@ namespace led {
      */
     //% help=led/unplot weight=77
     //% blockId=device_unplot block="unplot|x %x|y %y" blockGap=8
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
@@ -68,6 +71,7 @@ namespace led {
      */
     //% help=led/point-brightness weight=76
     //% blockId=device_point_brightness block="point|x %x|y %y brightness"
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
@@ -93,6 +97,7 @@ namespace led {
      */
     //% help=led/set-brightness weight=59
     //% blockId=device_set_brightness block="set brightness %value"
+    //% value.label="value"
     //% parts="ledmatrix"
     //% advanced=true
     //% value.min=0 value.max=255
@@ -134,6 +139,7 @@ namespace led {
     * Turns on or off the display
     */
     //% help=led/enable blockId=device_led_enable block="led enable %on"
+    //% on.label="value"
     //% advanced=true parts="ledmatrix"
     void enable(bool on) {
         if (on) uBit.display.enable();

--- a/libs/core/led.ts
+++ b/libs/core/led.ts
@@ -10,6 +10,7 @@ namespace led {
      */
     //% help=led/point weight=76
     //% blockId=device_point block="point|x %x|y %y"
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1
@@ -36,6 +37,7 @@ namespace led {
      */
     //% help=led/plot-bar-graph weight=20
     //% blockId=device_plot_bar_graph block="plot bar graph of $value up to $high|| serial write $valueToConsole" icon="\uf080" blockExternalInputs=true
+    //% value.label="value" high.label="maximum" valueToConsole.label="serial write"
     //% parts="ledmatrix"
     //% valueToConsole.shadow=toggleOnOff
     //% valueToConsole.defl=true
@@ -89,6 +91,7 @@ namespace led {
      */
     //% help=led/toggle weight=77
     //% blockId=device_led_toggle block="toggle|x %x|y %y" icon="\uf204" blockGap=8
+    //% x.label="x" y.label="y"
     //% parts="ledmatrix"
     //% x.min=0 x.max=4 y.min=0 y.max=4
     //% x.fieldOptions.precision=1 y.fieldOptions.precision=1

--- a/libs/core/loops.ts
+++ b/libs/core/loops.ts
@@ -10,6 +10,7 @@ namespace loops {
     //% interval.shadow=longTimePicker
     //% afterOnStart=true help=loops/every-interval
     //% blockId=every_interval block="every $interval ms"
+    //% interval.label="value"
     export function everyInterval(interval: number, a: () => void): void {
         control.runInParallel(() => {
             let start = 0;

--- a/libs/core/music.cpp
+++ b/libs/core/music.cpp
@@ -11,6 +11,7 @@ namespace music {
  * @param volume the volume 0...255
  */
 //% blockId=synth_set_volume block="set volume %volume"
+//% volume.label="value"
 //% volume.min=0 volume.max=255
 //% volume.defl=127
 //% help=music/set-volume
@@ -47,6 +48,7 @@ int volume() {
 * @param enabled whether the built-in speaker is enabled in addition to the sound pin
 */
 //% blockId=music_set_built_in_speaker_enable block="set built-in speaker $enabled"
+//% enabled.label="value"
 //% group="micro:bit (V2)"
 //% parts=builtinspeaker
 //% help=music/set-built-in-speaker-enabled

--- a/libs/core/music.ts
+++ b/libs/core/music.ts
@@ -196,6 +196,7 @@ namespace music {
      */
     //% help=music/play-tone weight=90
     //% blockId=device_play_note block="play|tone %note=device_note|for %duration=device_beat" blockGap=8
+    //% frequency.label="note" ms.label="duration"
     //% parts="headphone"
     //% useEnumVal=1
     //% group="Tone"
@@ -212,6 +213,7 @@ namespace music {
      */
     //% help=music/ring-tone weight=80
     //% blockId=device_ring block="ring tone (Hz)|%note=device_note" blockGap=8
+    //% frequency.label="note"
     //% parts="headphone"
     //% useEnumVal=1
     //% group="Tone"
@@ -225,6 +227,7 @@ namespace music {
      */
     //% help=music/rest weight=79
     //% blockId=device_rest block="rest for |%duration=device_beat"
+    //% ms.label="value"
     //% parts="headphone"
     //% group="Tone"
     export function rest(ms: number): void {
@@ -291,6 +294,7 @@ namespace music {
      */
     //% help=music/change-tempo-by weight=39
     //% blockId=device_change_tempo block="change tempo by (bpm)|%value" blockGap=8
+    //% bpm.label="value"
     //% group="Tempo"
     //% weight=100
     export function changeTempoBy(bpm: number): void {
@@ -305,6 +309,7 @@ namespace music {
      */
     //% help=music/set-tempo weight=38
     //% blockId=device_set_tempo block="set tempo to (bpm)|%value"
+    //% bpm.label="value"
     //% bpm.min=40 bpm.max=500
     //% group="Tempo"
     //% weight=99
@@ -374,6 +379,7 @@ namespace music {
      */
     //% help=music/begin-melody weight=60 blockGap=16
     //% blockId=device_start_melody block="start melody %melody=device_builtin_melody| repeating %options"
+    //% melodyArray.label="melody"
     //% parts="headphone"
     //% group="Melody Advanced"
     //% deprecated=1
@@ -387,6 +393,7 @@ namespace music {
      * @param tempo number in beats per minute (bpm), dictating how long each note will play for
      */
     //% block="play melody $melody at tempo $tempo|(bpm)" blockId=playMelody
+    //% melody.label="melody" tempo.label="tempo"
     //% weight=85 blockGap=8 help=music/play-melody
     //% melody.shadow="melody_editor"
     //% tempo.min=40 tempo.max=500

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -179,6 +179,7 @@ namespace pins {
      */
     //% help=pins/digital-read-pin weight=30
     //% blockId=device_get_digital_pin block="digital read|pin %name" blockGap=8
+    //% name.label="value"
     //% name.shadow=digital_pin_shadow
     int digitalReadPin(int name) {
         PINREAD(getDigitalValue());
@@ -191,6 +192,7 @@ namespace pins {
       */
     //% help=pins/digital-write-pin weight=29
     //% blockId=device_set_digital_pin block="digital write|pin %name|to %value"
+    //% name.label="pin" value.label="value"
     //% value.min=0 value.max=1
     //% name.shadow=digital_pin_shadow
     void digitalWritePin(int name, int value) {
@@ -203,6 +205,7 @@ namespace pins {
      */
     //% help=pins/analog-read-pin weight=25
     //% blockId=device_get_analog_pin block="analog read|pin %name" blockGap="8"
+    //% name.label="value"
     //% name.shadow=analog_read_write_pin_shadow
     int analogReadPin(int name) {
         PINREAD(getAnalogValue());
@@ -215,6 +218,7 @@ namespace pins {
      */
     //% help=pins/analog-write-pin weight=24
     //% blockId=device_set_analog_pin block="analog write|pin %name|to %value" blockGap=8
+    //% name.label="pin" value.label="value"
     //% value.min=0 value.max=1023
     //% name.shadow=analog_pin_shadow
     void analogWritePin(int name, int value) {
@@ -229,6 +233,7 @@ namespace pins {
      */
     //% help=pins/analog-set-period weight=23 blockGap=8
     //% blockId=device_set_analog_period block="analog set period|pin %pin|to (µs)%micros"
+    //% name.label="pin" micros.label="microseconds"
     //% pin.shadow=analog_pin_shadow
     void analogSetPeriod(int name, int micros) {
         PINOP(setAnalogPeriodUs(micros));
@@ -273,6 +278,7 @@ namespace pins {
     * @param maximum duration in microseconds
     */
     //% blockId="pins_pulse_in" block="pulse in (µs)|pin %name|pulsed %value"
+    //% name.label="pin"
     //% advanced=true
     //% help=pins/pulse-in
     //% name.shadow=digital_pin_shadow
@@ -319,6 +325,7 @@ namespace pins {
      */
     //% help=pins/servo-write-pin weight=20
     //% blockId=device_set_servo_pin block="servo write|pin %name|to %value" blockGap=8
+    //% name.label="pin" value.label="angle"
     //% parts=microservo trackArgs=0
     //% value.min=0 value.max=180
     //% name.shadow=analog_pin_shadow
@@ -342,6 +349,7 @@ namespace pins {
      */
     //% help=pins/servo-set-pulse weight=19
     //% blockId=device_set_servo_pulse block="servo set pulse|pin %value|to (µs) %micros"
+    //% name.label="pin" micros.label="microseconds"
     //% value.shadow=analog_pin_shadow
     //% group="Servo"
     void servoSetPulse(int name, int micros) {
@@ -359,6 +367,7 @@ namespace pins {
      * @param name pin to modulate pitch from
      */
     //% blockId=device_analog_set_pitch_pin block="analog set pitch pin %name"
+    //% name.label="value"
     //% help=pins/analog-set-pitch-pin advanced=true
     //% name.shadow=analog_pin_shadow
     //% group="Pins"
@@ -383,6 +392,7 @@ namespace pins {
     * @param volume the intensity of the sound from 0..255
     */
     //% blockId=device_analog_set_pitch_volume block="analog set pitch volume $volume"
+    //% volume.label="value"
     //% help=pins/analog-set-pitch-volume weight=3 advanced=true
     //% volume.min=0 volume.max=255
     //% deprecated
@@ -412,6 +422,7 @@ namespace pins {
      * @param ms duration of the pitch in milliseconds.
      */
     //% blockId=device_analog_pitch block="analog pitch %frequency|for (ms) %ms"
+    //% frequency.label="frequency" ms.label="duration"
     //% help=pins/analog-pitch async advanced=true
     //% group="Pins"
     //% weight=14
@@ -463,6 +474,7 @@ namespace pins {
     */
     //% help=pins/set-pull advanced=true
     //% blockId=device_set_pull block="set pull|pin %pin|to %pull"
+    //% name.label="pin"
     //% pin.shadow=digital_pin_shadow
     //% group="Pins"
     //% weight=15
@@ -491,6 +503,7 @@ namespace pins {
     */
     //% help=pins/set-events advanced=true
     //% blockId=device_set_pin_events block="set pin %pin|to emit %type|events"
+    //% name.label="pin"
     //% pin.shadow=digital_pin_shadow
     //% group="Pins"
     //% weight=13
@@ -518,6 +531,7 @@ namespace pins {
      */
     //% help=pins/neopixel-matrix-width advanced=true
     //% blockId=pin_neopixel_matrix_width block="neopixel matrix width|pin %pin %width"
+    //% pin.label="pin" width.label="width"
     //% pin.shadow=digital_pin_shadow
     //% width.defl=5 width.min=2
     //% group="Pins"
@@ -564,6 +578,7 @@ namespace pins {
     */
     //% help=pins/spi-write advanced=true
     //% blockId=spi_write block="spi write %value"
+    //% value.label="value"
     //% group="SPI"
     //% blockGap=8
     //% weight=53
@@ -602,6 +617,7 @@ namespace pins {
     */
     //% help=pins/spi-frequency advanced=true
     //% blockId=spi_frequency block="spi frequency %frequency"
+    //% frequency.label="value"
     //% group="SPI"
     //% blockGap=8
     //% weight=55
@@ -617,6 +633,7 @@ namespace pins {
     */
     //% help=pins/spi-format advanced=true
     //% blockId=spi_format block="spi format|bits %bits|mode %mode"
+    //% bits.label="bits" mode.label="mode"
     //% group="SPI"
     //% blockGap=8
     //% weight=54
@@ -637,6 +654,7 @@ namespace pins {
     */
     //% help=pins/spi-pins advanced=true
     //% blockId=spi_pins block="spi set pins|MOSI %mosi|MISO %miso|SCK %sck"
+    //% mosi.label="MOSI pin" miso.label="MISO pin" sck.label="SCK pin"
     //% mosi.shadow=digital_pin_shadow
     //% miso.shadow=digital_pin_shadow
     //% sck.shadow=digital_pin_shadow
@@ -664,6 +682,7 @@ namespace pins {
     * @param name pin to modulate pitch from
     */
     //% blockId=pin_set_audio_pin block="set audio pin $name"
+    //% name.label="value"
     //% help=pins/set-audio-pin
     //% name.shadow=digital_pin_shadow
     //% weight=1
@@ -684,6 +703,7 @@ namespace pins {
     */
     //% blockId=pin_set_audio_pin_enabled
     //% block="set audio pin enabled $enabled"
+    //% enabled.label="value"
     //% weight=0 help=pins/set-audio-pin-enabled
     void setAudioPinEnabled(bool enabled) {
         edgeConnectorSoundDisabled = !enabled;

--- a/libs/core/pins.ts
+++ b/libs/core/pins.ts
@@ -98,6 +98,7 @@ namespace pins {
      */
     //% help=pins/map weight=23
     //% blockId=pin_map block="map %value|from low %fromLow|from high %fromHigh|to low %toLow|to high %toHigh"
+    //% value.label="value" fromLow.label="from low" fromHigh.label="from high" toLow.label="to low" toHigh.label="to high"
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
     }
@@ -107,6 +108,7 @@ namespace pins {
      */
     //% help=pins/i2c-read-number blockGap=8 advanced=true
     //% blockId=pins_i2c_readnumber block="i2c read number|at address %address|of format %format|repeated %repeat" weight=7
+    //% address.label="address" repeated.label="repeated"
     //% group="I2C"
     //% weight=45
     export function i2cReadNumber(address: number, format: NumberFormat, repeated?: boolean): number {
@@ -119,6 +121,7 @@ namespace pins {
      */
     //% help=pins/i2c-write-number blockGap=8 advanced=true
     //% blockId=i2c_writenumber block="i2c write number|at address %address|with value %value|of format %format|repeated %repeat" weight=6
+    //% address.label="address" value.label="value" repeated.label="repeated"
     //% group="I2C"
     //% weight=44
     export function i2cWriteNumber(address: number, value: number, format: NumberFormat, repeated?: boolean): void {

--- a/libs/core/playable.ts
+++ b/libs/core/playable.ts
@@ -95,6 +95,7 @@ namespace music {
      */
     //% blockId="music_playable_play"
     //% block="play $toPlay $playbackMode"
+    //% toPlay.label="sound"
     //% toPlay.shadow=music_string_playable
     //% group="Melody"
     //% help="music/play"
@@ -105,6 +106,7 @@ namespace music {
 
     //% blockId="music_playable_play_default_bkg"
     //% block="play $toPlay $playbackMode"
+    //% toPlay.label="sound"
     //% toPlay.shadow=music_string_playable
     //% playbackMode.defl=music.PlaybackMode.InBackground
     //% group="Melody"
@@ -121,6 +123,7 @@ namespace music {
      */
     //% blockId="music_string_playable"
     //% block="melody $melody at tempo $bpm|(bpm)"
+    //% melody.label="melody" bpm.label="tempo"
     //% weight=85 blockGap=8
     //% help=music/string-playable
     //% group="Melody"
@@ -141,6 +144,7 @@ namespace music {
      */
     //% blockId="music_tone_playable"
     //% block="tone $note for $duration"
+    //% note.label="note" duration.label="duration"
     //% toolboxParent=music_playable_play
     //% toolboxParentArgument=toPlay
     //% group="Tone"

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -58,6 +58,7 @@ namespace serial {
      */
     //% help=serial/read-until
     //% blockId=serial_read_until block="serial|read until %delimiter=serial_delimiter_conv"
+    //% delimiter.label="delimiter"
     //% weight=19
     String readUntil(String delimiter) {
       return PSTR(uBit.serial.readUntil(MSTR(delimiter)));
@@ -81,6 +82,7 @@ namespace serial {
     */
     //% help=serial/on-data-received
     //% weight=18 blockId=serial_on_data_received block="serial|on data received %delimiters=serial_delimiter_conv"
+    //% delimiters.label="delimiter"
     void onDataReceived(String delimiters, Action body) {
       uBit.serial.eventOn(MSTR(delimiters));
       registerWithDal(MICROBIT_ID_SERIAL, MICROBIT_SERIAL_EVT_DELIM_MATCH, body);
@@ -94,6 +96,7 @@ namespace serial {
     //% help=serial/write-string
     //% weight=87 blockGap=8
     //% blockId=serial_writestring block="serial|write string %text"
+    //% text.label="value"
     //% text.shadowOptions.toString=true
     void writeString(String text) {
       if (!text) return;
@@ -105,6 +108,7 @@ namespace serial {
     * Send a buffer through serial connection
     */
     //% blockId=serial_writebuffer block="serial|write buffer %buffer=serial_readbuffer"
+    //% buffer.label="value"
     //% help=serial/write-buffer advanced=true weight=6
     void writeBuffer(Buffer buffer) {
       if (!buffer) return;
@@ -118,6 +122,7 @@ namespace serial {
     * @param length default buffer length
     */
     //% blockId=serial_readbuffer block="serial|read buffer %length"
+    //% length.label="value"
     //% help=serial/read-buffer advanced=true weight=5
     Buffer readBuffer(int length) {
       auto mode = SYNC_SLEEP;
@@ -240,6 +245,7 @@ namespace serial {
     */
     //% help=serial/set-rx-buffer-size
     //% blockId=serialSetRxBufferSize block="serial set rx buffer size to $size"
+    //% size.label="value"
     //% advanced=true
     void setRxBufferSize(uint8_t size) {
       uBit.serial.setRxBufferSize(size);
@@ -251,6 +257,7 @@ namespace serial {
     */
     //% help=serial/set-tx-buffer-size
     //% blockId=serialSetTxBufferSize block="serial set tx buffer size to $size"
+    //% size.label="value"
     //% advanced=true
     void setTxBufferSize(uint8_t size) {
       uBit.serial.setTxBufferSize(size);

--- a/libs/core/serial.ts
+++ b/libs/core/serial.ts
@@ -43,6 +43,7 @@ namespace serial {
     //% weight=90
     //% help=serial/write-line blockGap=8
     //% blockId=serial_writeline block="serial|write line %text"
+    //% text.label="value"
     //% text.shadowOptions.toString=true
     export function writeLine(text: string): void {
         if (!text) text = "";
@@ -65,6 +66,7 @@ namespace serial {
     //% weight=1
     //% help=serial/set-write-line-padding
     //% blockId=serialWriteNewLinePadding block="serial set write line padding to $length"
+    //% length.label="value"
     //% advanced=true
     //% length.min=0 length.max=128
     export function setWriteLinePadding(length: number) {
@@ -77,6 +79,7 @@ namespace serial {
     //% help=serial/write-number
     //% weight=89 blockGap=8
     //% blockId=serial_writenumber block="serial|write number %value"
+    //% value.label="value"
     export function writeNumber(value: number): void {
         writeString(value.toString());
     }
@@ -87,6 +90,7 @@ namespace serial {
     //% help=serial/write-numbers
     //% weight=86
     //% blockId=serial_writenumbers block="serial|write numbers %values"
+    //% values.label="value"
     export function writeNumbers(values: number[]): void {
         if (!values) return;
         for (let i = 0; i < values.length; ++i) {
@@ -104,6 +108,7 @@ namespace serial {
     //% weight=88 blockGap=8
     //% help=serial/write-value
     //% blockId=serial_writevalue block="serial|write value %name|= %value"
+    //% name.label="name" value.label="value"
     export function writeValue(name: string, value: number): void {
         writeLine((name ? name + ":" : "") + value);
     }

--- a/libs/core/soundexpressions.ts
+++ b/libs/core/soundexpressions.ts
@@ -23,6 +23,7 @@ class SoundExpression extends music.Playable {
      * Starts to play a sound expression.
      */
     //% block="play sound $this"
+    //% this.label="sound"
     //% weight=80
     //% blockGap=8
     //% help=music/play
@@ -37,6 +38,7 @@ class SoundExpression extends music.Playable {
      * Plays a sound expression until finished
      */
     //% block="play sound $this until done"
+    //% this.label="sound"
     //% weight=81
     //% blockGap=8
     //% help=music/play-until-done
@@ -327,6 +329,7 @@ namespace music {
      */
     //% blockId=soundExpression_playSoundEffect
     //% block="play sound $sound $mode"
+    //% sound.label="sound"
     //% sound.shadow=soundExpression_createSoundEffect
     //% weight=100 help=music/play-sound-effect
     //% blockGap=8
@@ -355,6 +358,7 @@ namespace music {
     //% blockId=soundExpression_createSoundEffect
     //% help=music/create-sound-effect
     //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
+    //% startFrequency.label="start frequency" endFrequency.label="end frequency" duration.label="duration" startVolume.label="start volume" endVolume.label="end volume"
     //% waveShape.defl=WaveShape.Sine
     //% waveShape.fieldEditor=soundeffect
     //% startFrequency.defl=5000
@@ -438,6 +442,7 @@ namespace music {
     //% blockId=soundExpression_createSoundExpression
     //% help=music/create-sound-expression
     //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
+    //% startFrequency.label="start frequency" endFrequency.label="end frequency" duration.label="duration" startVolume.label="start volume" endVolume.label="end volume"
     //% waveShape.defl=WaveShape.Sine
     //% waveShape.fieldEditor=soundeffect
     //% startFrequency.defl=5000

--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -61,6 +61,7 @@ namespace datalogger {
      * @returns A new value that can be stored in flash storage using log data
      */
     //% block="column $column value $value"
+    //% column.label="column" value.label="value"
     //% value.shadow=math_number
     //% column.shadow=datalogger_columnfield
     //% blockId=dataloggercreatecolumnvalue
@@ -85,6 +86,7 @@ namespace datalogger {
      * @param data Array of data to be logged to flash storage
      */
     //% block="log data array $data"
+    //% data.label="value"
     //% blockId=dataloggerlogdata
     //% data.shadow=lists_create_with
     //% data.defl=dataloggercreatecolumnvalue
@@ -120,6 +122,7 @@ namespace datalogger {
      * @param data10 [optional] tenth column and value to be logged
      */
     //% block="log data $data1||$data2 $data3 $data4 $data5 $data6 $data7 $data8 $data9 $data10"
+    //% data1.label="data 1" data2.label="data 2" data3.label="data 3" data4.label="data 4" data5.label="data 5" data6.label="data 6" data7.label="data 7" data8.label="data 8" data9.label="data 9" data10.label="data 10"
     //% blockId=dataloggerlog
     //% data1.shadow=dataloggercreatecolumnvalue
     //% data2.shadow=dataloggercreatecolumnvalue
@@ -168,6 +171,7 @@ namespace datalogger {
      * @param cols Array of the columns that will be logged.
      */
     //% block="set columns $cols"
+    //% cols.label="value"
     //% blockId=dataloggersetcolumns
     //% data.shadow=list_create_with
     //% data.defl=datalogger_columnfield
@@ -195,6 +199,7 @@ namespace datalogger {
      * @param col10 Title for tenth column to be added
      */
     //% block="set columns $col1||$col2 $col3 $col4 $col5 $col6 $col7 $col8 $col9 $col10"
+    //% col1.label="column 1" col2.label="column 2" col3.label="column 3" col4.label="column 4" col5.label="column 5" col6.label="column 6" col7.label="column 7" col8.label="column 8" col9.label="column 9" col10.label="column 10"
     //% blockId=dataloggersetcolumntitles
     //% inlineInputMode="variable"
     //% inlineInputModeLimit=1
@@ -276,6 +281,7 @@ namespace datalogger {
      * @param on if true, data that is logged will be mirrored to serial
      */
     //% block="mirror data to serial $on"
+    //% on.label="value"
     //% blockId=dataloggertogglemirrortoserial
     //% on.shadow=toggleOnOff
     //% on.defl=false

--- a/libs/microphone/microphone.cpp
+++ b/libs/microphone/microphone.cpp
@@ -75,6 +75,7 @@ int soundLevel() {
 */
 //% help=input/set-sound-threshold
 //% blockId=input_set_sound_threshold block="set %sound sound threshold to %value"
+//% threshold.label="threshold"
 //% parts="microphone"
 //% threshold.min=0 threshold.max=255 threshold.defl=128
 //% weight=14 blockGap=8


### PR DESCRIPTION
This PR uses the mechanism added in https://github.com/microsoft/pxt/pull/11334 to create sensible input names for block inputs for screen reader users. The impact of these changes is currently limited to move mode where the block has more than one input. However, in the next Blockly release, these names will be surfaced when screen reader users focus an input via keyboard navigation. As such, I've opened this PR as a draft to provide visibility of these changes ahead of time for review and feedback.

Example of how this will work:
<img width="419" height="294" alt="Screenshot 2026-06-24 at 15 57 45" src="https://github.com/user-attachments/assets/9f138ef1-6e9d-414e-8333-ad647fa15b30" />


Current output on beta:
<img width="430" height="286" alt="Screenshot 2026-06-24 at 15 57 32" src="https://github.com/user-attachments/assets/ad211162-dda3-4822-8dbe-5cefaf95c752" />

The parameter label creation was AI-assisted and manually reviewed.

Note: I have not included the automatically generated files in this PR.