### PR TITLE
override the color of the focus indicator in the file list

### DIFF
--- a/theme/color-themes/overrides/microbit-dark-overrides.css
+++ b/theme/color-themes/overrides/microbit-dark-overrides.css
@@ -1,4 +1,9 @@
 
+
+#simulator .editor-sidebar .filemenu {
+    --pxt-focus-border: yellow;
+}
+
 #langmodal #availablelocales .langoption .header {
     /* Better contrast than default, which is purple */
     color: var(--pxt-neutral-foreground1);
@@ -52,7 +57,7 @@
     background: var(--pxt-target-background2);
 }
 
-/* 
+/*
  * Inverted image colors
  */
 .barcharticon,

--- a/theme/color-themes/overrides/microbit-light-overrides.css
+++ b/theme/color-themes/overrides/microbit-light-overrides.css
@@ -1,3 +1,7 @@
+#simulator .editor-sidebar .filemenu {
+    --pxt-focus-border: yellow;
+}
+
 /* Lots of specificity to override another !important rule */
 #simulator #editorSidebar .simtoolbar .ui.icon.tiny.buttons .ui.button.play-button.play .icon.play {
     color: var(--pxt-colors-green-background) !important;


### PR DESCRIPTION
companion PR to https://github.com/microsoft/pxt/pull/11423

changing the color of the focus indicator from blue to yellow in the file list, since the micro:bit file list is already blue.