### PR TITLE
Extension: add SEN66

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -192,6 +192,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "SEN66 Air Quality Sensor",
+  "url":"/pkg/bsiever/pxt-sen66",
+  "cardType": "package"
+}, {
   "name": "KY-040 Rotary Encoder Plus",
   "url":"/pkg/steveturbek/pxt-rotary-encoder-KY-040-plus",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -444,6 +444,7 @@
             "kitronikltd/pxt-design-and-automate-accessory-kit": { "tags": [ "Robotics" ] },
             "aorczyk/my-controller": { "tags": [ "Software" ] },
             "forward-education/pxt-ceibal-ubit": {},
+            "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/98911 (private)
@bsiever
@abchatra

Extension: https://github.com/bsiever/pxt-sen66
Version: v0.2.1
Product: https://sensirion.com/products/catalog/SEN66
All blocks: https://makecode.microbit.org/_Ai7Ck3W1uJir

<img width="759" height="388" alt="image" src="https://github.com/user-attachments/assets/0abadb54-96bd-41ef-a3ac-d8445b6a14ca" />
