### PR TITLE
Update Blockly dependency overrides to 13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     },
     "overrides": {
         "@blockly/field-grid-dropdown": {
-            "blockly": "13.0.0"
+            "blockly": "13.1.0"
         },
         "@blockly/plugin-workspace-search": {
-            "blockly": "13.0.0"
+            "blockly": "13.1.0"
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/11441