### PR TITLE
Remove 'showProjectDescription' from pxtarget.json

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -618,7 +618,6 @@
         "timeMachine": true,
         "timeMachineDiffInterval": 600000,
         "timeMachineSnapshotInterval": 1800000,
-        "showProjectDescription": true,
         "shareHomepageContent": true,
         "songEditor": true,
         "blocklyKeyboardControlsByDefault": true


### PR DESCRIPTION
Removed the 'showProjectDescription' property from the configuration as not enabling on share page