### PR TITLE
suppress microphone and radio so they don't always pop up

### DIFF
--- a/libs/microphone/pxt.json
+++ b/libs/microphone/pxt.json
@@ -2,5 +2,6 @@
     "additionalFilePath": "../../node_modules/pxt-common-packages/libs/microphone",
     "dependencies": {
         "core": "file:../core"
-    }
+    },
+    "searchOnly": true
 }

--- a/libs/radio/pxt.json
+++ b/libs/radio/pxt.json
@@ -8,5 +8,6 @@
                 }
             }
         }
-    }
+    },
+    "searchOnly": true
 }


### PR DESCRIPTION
with https://github.com/microsoft/pxt/pull/11437 these would always pop up; make them search only so they don't take up space when useless, but still accessible if really need them (e.g. if add a bluetooth extension and really need to revert and add radio back i suppose)