### PR TITLE
Extension: add enorasisCore

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -552,6 +552,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "enorasisCore",
+  "url":"/pkg/skinformatics/enorasisCore-makecode",
+  "cardType": "package"
+}, {
   "name": "Kocoafab COCOCAM",
   "url":"/pkg/ekkai/aicococam",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -447,6 +447,7 @@
             "forward-education/pxt-openscied": { "tags": [ "Science" ] },
             "forward-education/pxt-ceibal-ubit": {},
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
+            "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/100118 (private)
@skinformatics
@abchatra 

Extension: https://github.com/skinformatics/enorasisCore-makecode
Version: v0.1.5
Product: https://enorasiscore.eu/
All blocks: https://makecode.microbit.org/_HR20g53wj6iK
<img width="513" height="399" alt="image" src="https://github.com/user-attachments/assets/5175d7df-0e12-42eb-a965-ef14d5ee95ed" />
