### PR TITLE
Reference pages for 'math.convert' and 'blocks.pauseUntil'

### DIFF
--- a/docs/blocks/pause-until.md
+++ b/docs/blocks/pause-until.md
@@ -1,0 +1,40 @@
+# pause Until
+
+Pause the current part of the program until a condition becomes true.
+
+```sig
+pauseUntil(() => true)
+```
+
+Sometimes you need to wait in one part of a program for something to happen somewhere else in the program. This is done by pausing until some condition elsewhere becomes ``true``. Such a condition could be a value you set in an event block or a function that returns a [boolean](/types/boolean).
+
+## Parameters
+
+* **condition**: a [boolean](/types/boolean) condition that restarts the program when it becomes ``true``.
+* **timeOut**: an optional paramenter which is a [number](/types/number) of milliseconds to wait for the **condition** to become ``true``. The pause ends when the timeout has elapsed even if **condition** is still ``false``.
+
+### ~hint
+
+#### Other code will run too
+
+The code you have in **events** blocks will continue to execute while the current part of your program is paused.
+
+### ~
+
+## Example
+
+Wait on a five second timer function.
+
+```blocks
+function waitFiveSeconds() : boolean {
+    for (let i = 0; i < 5000; i++) {
+        control.waitMicros(1000)
+    }
+    return true
+}
+pauseUntil(() => waitFiveSeconds())
+```
+
+## See also
+
+[pause](/reference/basic/pause)

--- a/docs/reference/math/convert.md
+++ b/docs/reference/math/convert.md
@@ -1,0 +1,39 @@
+# convert
+
+Converts a value from one unit to another.
+
+```sig
+Math.convert(0, UnitConversion.DegreesToRadians)
+```
+
+## Parameters
+
+* **value**: a [number](/types/number) that is the value to convert to the new units.
+* **type**: the unit type to convert to. The units available are:
+
+>* `degrees to radians` - change from angle units of degrees to angle units of radians
+>* `radians to degrees` - change from angle units of radians to angle units of degrees
+>* `celsius to fahrenheit` - change from temperature units of degrees celsius to degrees fahrenheit
+>* `fahrenheit to celsius` - change from temperature units of degrees fahrenheit to degrees celsius
+
+## Returns
+
+* a [number](/types/number) that is the **value** converted to a new value with the selected units.
+
+## Example
+
+Show what the measured temperature is every 30 seconds. Use degrees fahrenheit for the display.
+
+```blocks
+let tempc = 0
+let tempf = 0
+loops.everyInterval(500, function () {
+    tempc = input.temperature()
+    tempf = Math.convert(tempc, UnitConversion.CelsiusToFahrenheit)
+    basic.showNumber(tempf)
+})
+```
+
+## See Also
+
+[random int](/reference/math/randint)

--- a/libs/bluetooth/shims.d.ts
+++ b/libs/bluetooth/shims.d.ts
@@ -80,7 +80,8 @@ declare namespace bluetooth {
      * @param delimiters the characters to match received characters against.
      */
     //% help=bluetooth/on-uart-data-received
-    //% weight=18 blockId=bluetooth_on_data_received block="bluetooth|on data received %delimiters=serial_delimiter_conv" shim=bluetooth::onUartDataReceived
+    //% weight=18 blockId=bluetooth_on_data_received block="bluetooth|on data received %delimiters=serial_delimiter_conv"
+    //% delimiters.label="delimiter" shim=bluetooth::onUartDataReceived
     function onUartDataReceived(delimiters: string, body: () => void): void;
 
     /**
@@ -108,6 +109,7 @@ declare namespace bluetooth {
      * @param connectable true to keep bluetooth connectable for other services, false otherwise.
      */
     //% blockId=eddystone_advertise_url block="bluetooth advertise url %url|with power %power|connectable %connectable"
+    //% url.label="url" power.label="power" connectable.label="connectable"
     //% parts=bluetooth weight=11 blockGap=8
     //% help=bluetooth/advertise-url blockExternalInputs=1
     //% hidden=1 deprecated=1 shim=bluetooth::advertiseUrl
@@ -127,7 +129,8 @@ declare namespace bluetooth {
      * @param power power level between 0 (minimal) and 7 (maximum), eg: 7.
      */
     //% parts=bluetooth weight=5 help=bluetooth/set-transmit-power advanced=true
-    //% blockId=bluetooth_settransmitpower block="bluetooth set transmit power %power" shim=bluetooth::setTransmitPower
+    //% blockId=bluetooth_settransmitpower block="bluetooth set transmit power %power"
+    //% power.label="value" shim=bluetooth::setTransmitPower
     function setTransmitPower(power: int32): void;
 
     /**

--- a/libs/bluetooth/shims.d.ts
+++ b/libs/bluetooth/shims.d.ts
@@ -80,8 +80,7 @@ declare namespace bluetooth {
      * @param delimiters the characters to match received characters against.
      */
     //% help=bluetooth/on-uart-data-received
-    //% weight=18 blockId=bluetooth_on_data_received block="bluetooth|on data received %delimiters=serial_delimiter_conv"
-    //% delimiters.label="delimiter" shim=bluetooth::onUartDataReceived
+    //% weight=18 blockId=bluetooth_on_data_received block="bluetooth|on data received %delimiters=serial_delimiter_conv" shim=bluetooth::onUartDataReceived
     function onUartDataReceived(delimiters: string, body: () => void): void;
 
     /**
@@ -109,7 +108,6 @@ declare namespace bluetooth {
      * @param connectable true to keep bluetooth connectable for other services, false otherwise.
      */
     //% blockId=eddystone_advertise_url block="bluetooth advertise url %url|with power %power|connectable %connectable"
-    //% url.label="url" power.label="power" connectable.label="connectable"
     //% parts=bluetooth weight=11 blockGap=8
     //% help=bluetooth/advertise-url blockExternalInputs=1
     //% hidden=1 deprecated=1 shim=bluetooth::advertiseUrl
@@ -129,8 +127,7 @@ declare namespace bluetooth {
      * @param power power level between 0 (minimal) and 7 (maximum), eg: 7.
      */
     //% parts=bluetooth weight=5 help=bluetooth/set-transmit-power advanced=true
-    //% blockId=bluetooth_settransmitpower block="bluetooth set transmit power %power"
-    //% power.label="value" shim=bluetooth::setTransmitPower
+    //% blockId=bluetooth_settransmitpower block="bluetooth set transmit power %power" shim=bluetooth::setTransmitPower
     function setTransmitPower(power: int32): void;
 
     /**

--- a/libs/core/helpers.ts
+++ b/libs/core/helpers.ts
@@ -27,7 +27,7 @@ namespace Math {
     //% blockId=math_convert_unit
     //% block="convert $value|from $type"
     //% value.label="value"
-    //% help=math/convert-unit
+    //% help=math/convert
     //% weight=0
     export function convert(value: number, type: UnitConversion): number {
         switch (type) {


### PR DESCRIPTION
The 'convert' page was missing and the 'pause-until' page was sitting in `../base/docs/blocks`. Moved it into target `./docs/blocks` with a few edits.

Suggested example/s that are more practical are welcome.

Closes #6994