### PR TITLE
use npm v11 in workflow

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |
@@ -79,7 +79,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |


### PR DESCRIPTION
pinning 11 because 12 doesn't like our node version