### PR TITLE
Extension: add Elecfreaks PU Robot

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -593,6 +593,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Elecfreaks PU Robot",
+  "url":"/pkg/elecfreaks/pxt-PU-Robot",
+  "cardType": "package"
+}, {
   "name": "Kitronik Design & Automate Accessory Kit",
   "url":"/pkg/KitronikLtd/pxt-design-and-automate-accessory-kit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -449,6 +449,7 @@
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "pasalt/pxt-neopixel-matrix-extension": { "tags": [ "Lights and Display" ] },
+            "elecfreaks/pxt-pu-robot": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/99514 (private)
@DeXin64
@abchatra 

Extension: https://github.com/elecfreaks/pxt-PU-Robot
Version: v0.9.0
Product: https://shop.elecfreaks.com/products/elecfreaks-micro-bit-pu-robot-kit
All blocks: https://makecode.microbit.org/_FyugmKej2XYV

<img width="896" height="813" alt="image" src="https://github.com/user-attachments/assets/fe472f5d-04e8-4633-9ec6-aa7ff3be1700" />
