### PR TITLE
Extension: add Peanut King Controller

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -593,6 +593,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Peanut King Controller",
+  "url":"/pkg/peanut-king-solution/pxt-pks-controller",
+  "cardType": "package"
+}, {
   "name": "Kitronik Design & Automate Accessory Kit",
   "url":"/pkg/KitronikLtd/pxt-design-and-automate-accessory-kit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -449,6 +449,7 @@
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "pasalt/pxt-neopixel-matrix-extension": { "tags": [ "Lights and Display" ] },
+            "peanut-king-solution/pxt-pks-controller": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/100703 (private)
@jasoni4399
@abchatra 

Extension: https://github.com/peanut-king-solution/pxt-pks-controller
Version: v1.0.3
Product: https://play.google.com/store/apps/details?id=com.peanut.king.solution&hl=en_GB
All blocks: https://makecode.microbit.org/_JYq5Aa8umPyX

<img width="1040" height="798" alt="image" src="https://github.com/user-attachments/assets/c194f291-c8b5-4dea-b0d6-0c38131362a2" />

