### PR TITLE
Extension: add Peanut King micro:bit Shield V2

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -593,6 +593,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "Peanut King micro:bit Shield V2",
+  "url":"/pkg/peanut-king-solution/pxt-pks-shield-v2",
+  "cardType": "package"
+}, {
   "name": "Kitronik Design & Automate Accessory Kit",
   "url":"/pkg/KitronikLtd/pxt-design-and-automate-accessory-kit",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -449,6 +449,7 @@
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "pasalt/pxt-neopixel-matrix-extension": { "tags": [ "Lights and Display" ] },
+            "peanut-king-solution/pxt-pks-shield-v2": { "tags": [ "Robotics" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/97704 (private)
@jasoni4399
@abchatra 

Extension: https://github.com/peanut-king-solution/pxt-pks-shield-v2
Version: v1.0.4
Product: [Peanut KING micro:bit Shield V2 Extension Shield](https://www.peanutkingsolution.com/en/product-page/peanut-king-micro-bit-shield-v2-%E6%93%B4%E5%B1%95%E6%9D%BF) [​](https://www.peanutkingsolution.com/en/product-page/peanut-king-micro-bit-shield-v2-%E6%93%B4%E5%B1%95%E6%9D%BF)
All blocks: https://makecode.microbit.org/_V2taKb8stTEx

<img width="743" height="330" alt="image" src="https://github.com/user-attachments/assets/7a5ddf22-0ca7-4375-916c-4e5e8646453a" />
<img width="754" height="755" alt="image" src="https://github.com/user-attachments/assets/4c8b01fc-f798-4453-b13f-f61276db8ce4" />
<img width="663" height="658" alt="image" src="https://github.com/user-attachments/assets/e9f9e763-efcd-4211-9165-138489e08114" />
<img width="673" height="844" alt="image" src="https://github.com/user-attachments/assets/5869f2ad-36e5-4088-91e2-812eb4e2740b" />
<img width="909" height="405" alt="image" src="https://github.com/user-attachments/assets/0117234a-d9d4-4ffe-93e9-061601b2cdec" />
