### PR TITLE
Extension: add FWD Vision AI Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -556,6 +556,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "FWD Vision AI Kit",
+  "url":"/pkg/Forward-Education/pxt-ai-vision",
+  "cardType": "package"
+}, {
   "name": "enorasisCore",
   "url":"/pkg/skinformatics/enorasisCore-makecode",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -449,6 +449,7 @@
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "pasalt/pxt-neopixel-matrix-extension": { "tags": [ "Lights and Display" ] },
+            "forward-education/pxt-ai-vision": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/100983 (private)
@ssande-fwd
@abchatra 

Extension: https://github.com/Forward-Education/pxt-ai-vision
Version: v1.0.1
Dependencies:
https://github.com/Forward-Education/pxt-fwd-modules/blob/main/fwd-ai-vision
https://github.com/Forward-Education/pxt-fwd-base/tree/main/fwd-i2c
https://github.com/Forward-Education/pxt-fwd-base
Product: https://forwardedu.com/products/vision-ai-kit-exploration
All blocks: https://makecode.microbit.org/_2Lu5MsVmf2Pt

<img width="778" height="560" alt="image" src="https://github.com/user-attachments/assets/ff5560a6-5aaa-40dc-a141-19df7c21376b" />

<img width="787" height="645" alt="image" src="https://github.com/user-attachments/assets/46c8f346-0626-4e33-b9fd-6be0ca9fcb1e" />
