### PR TITLE
Extension: add FWD Voice AI Kit

### DIFF
--- a/docs/extensions/extension-gallery.md
+++ b/docs/extensions/extension-gallery.md
@@ -556,6 +556,10 @@ Many extensions are available to work with interface kits, add-on hardware, or o
 
 ```codecard
 [{
+  "name": "FWD Voice AI Kit",
+  "url":"/pkg/Forward-Education/pxt-ai-voice",
+  "cardType": "package"
+}, {
   "name": "enorasisCore",
   "url":"/pkg/skinformatics/enorasisCore-makecode",
   "cardType": "package"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -449,6 +449,7 @@
             "bsiever/pxt-sen66": { "tags": [ "Science" ] },
             "skinformatics/enorasiscore-makecode": { "tags": [ "Science" ] },
             "pasalt/pxt-neopixel-matrix-extension": { "tags": [ "Lights and Display" ] },
+            "forward-education/pxt-ai-voice": { "tags": [ "Science" ] },
             "microsoft/pxt-simx-sample": {
                 "simx": {
                     "sha": "7301f5900879b85127482d79bab48f03c25690a8",


### PR DESCRIPTION
Arising from support ticket https://support.microbit.org/helpdesk/tickets/100985 (private)
@ssande-fwd 
@abchatra 

Extension: https://github.com/Forward-Education/pxt-ai-voice
Version: v1.0.1
Dependencies:
https://github.com/Forward-Education/pxt-fwd-modules/tree/main/fwd-ai-voice
https://github.com/Forward-Education/pxt-fwd-base
https://github.com/Forward-Education/pxt-fwd-base/tree/main/fwd-i2c
Product: https://forwardedu.com/products/voice-ai-kit-exploration
All blocks: https://makecode.microbit.org/_MkX0mLhTAPDc

<img width="595" height="643" alt="image" src="https://github.com/user-attachments/assets/f1132d34-900f-4ae7-87b4-31d3fb9006c3" />
